### PR TITLE
Add support for black config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,12 @@
+0.3.0.dev / 2020-06-22
+----------------------
+
+- Feature: Add support for black config
+
+
 0.2.0 / 2020-03-11
 ------------------
 
 - Feature: Retry with a larger ``git diff -U<context_lines>`` option after producing a
   re-formatted Python file which fails to result in an identical AST.
 - Bugfix: Run `isort` first, and only then do the detailed ``git diff`` for Black.
-
-
-0.3.0 / 2020-06-22
-------------------
-
-- Feature: Add support for black config

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,3 +4,9 @@
 - Feature: Retry with a larger ``git diff -U<context_lines>`` option after producing a
   re-formatted Python file which fails to result in an identical AST.
 - Bugfix: Run `isort` first, and only then do the detailed ``git diff`` for Black.
+
+
+0.3.0 / 2020-06-22
+------------------
+
+- Feature: Add support for black config

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,4 +4,5 @@
 
 (in alphabetic order and with GitHub handles)
 
+- Alexander Tishin (@Mystic-Mirage)
 - Antti Kaihola (@akaihola)

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Iterable, List, Set
+from typing import Iterable, List, Optional, Set
 
 from darker.black_diff import diff_and_get_opcodes, opcodes_to_chunks, run_black
 from darker.chooser import choose_lines
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 MAX_CONTEXT_LINES = 1000
 
 
-def format_edited_parts(srcs: Iterable[Path], isort: bool) -> None:
+def format_edited_parts(
+    srcs: Iterable[Path], isort: bool, config: Optional[str]
+) -> None:
     """Black (and optional isort) formatting for chunks with edits since the last commit
 
     1. run isort on each edited file
@@ -40,6 +42,7 @@ def format_edited_parts(srcs: Iterable[Path], isort: bool) -> None:
 
     :param srcs: Directories and files to re-format
     :param isort: ``True`` to also run ``isort`` first on each changed file
+    :param config: Path to the black configuration file (optional)
 
     """
     remaining_srcs: Set[Path] = set(srcs)
@@ -65,7 +68,7 @@ def format_edited_parts(srcs: Iterable[Path], isort: bool) -> None:
                 continue
 
             # 4. run black
-            edited, formatted = run_black(src)
+            edited, formatted = run_black(src, config)
             logger.debug("Read %s lines from edited file %s", len(edited), src)
             logger.debug("Black reformat resulted in %s lines", len(formatted))
 
@@ -134,7 +137,7 @@ def main(argv: List[str] = None) -> None:
         exit(1)
 
     paths = {Path(p) for p in args.src}
-    format_edited_parts(paths, args.isort)
+    format_edited_parts(paths, args.isort, args.config)
 
 
 if __name__ == "__main__":

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -74,22 +74,42 @@ a mixed result with only selected regions reformatted can be reconstructed.
 
 import logging
 from difflib import SequenceMatcher
+from functools import lru_cache
 from pathlib import Path
-from typing import Generator, List, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
-from black import FileMode, format_str
+from black import FileMode, format_str, read_pyproject_toml
+from click import Command, Context, Option
 
 logger = logging.getLogger(__name__)
 
 
-def run_black(src: Path) -> Tuple[List[str], List[str]]:
+@lru_cache(maxsize=1)
+def read_black_config(src: Path, value: Optional[str]) -> Dict[str, Any]:
+    """Read the black configuration from pyproject.toml"""
+    command = Command("main")
+
+    context = Context(command)
+    context.params["src"] = (str(src),)
+
+    parameter = Option(("--config",))
+
+    read_pyproject_toml(context, parameter, value)
+
+    return context.default_map or {}
+
+
+def run_black(src: Path, config: Optional[str]) -> Tuple[List[str], List[str]]:
     """Run the black formatter for the contents of the given Python file
 
     Return lines of the original file as well as the formatted content.
 
     """
+    defaults = read_black_config(src, config)
+    mode = FileMode(**defaults)
+
     src_contents = src.read_text()
-    dst_contents = format_str(src_contents, mode=FileMode())
+    dst_contents = format_str(src_contents, mode=mode)
     return src_contents.splitlines(), dst_contents.splitlines()
 
 

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -31,7 +31,10 @@ def parse_command_line(argv: List[str]) -> Namespace:
         "-i", "--isort", action="store_true", help="".join(isort_help),
     )
     parser.add_argument(
-        "-c", "--config", metavar="PATH", help="Read configuration from PATH."
+        "-c",
+        "--config",
+        metavar="PATH",
+        help="Ask `black` to read configuration from PATH.",
     )
     parser.add_argument(
         "-v",

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -31,6 +31,9 @@ def parse_command_line(argv: List[str]) -> Namespace:
         "-i", "--isort", action="store_true", help="".join(isort_help),
     )
     parser.add_argument(
+        "-c", "--config", metavar="PATH", help="Read configuration from PATH."
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         dest="log_level",

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from textwrap import dedent
 
+import pytest
 from black import FileMode, format_str
 
-from darker.black_diff import diff_and_get_opcodes, opcodes_to_chunks
+from darker.black_diff import diff_and_get_opcodes, opcodes_to_chunks, read_black_config
 
 FUNCTIONS2_PY = dedent(
     '''\
@@ -147,3 +149,15 @@ def test_mixed():
             ['    print("Inner defs should breathe a little.")'],
         ),
     ]
+
+
+@pytest.mark.parametrize("config,line_length", ((None, 79), ("custom.toml", 99)))
+def test_black_config(tmpdir, config, line_length):
+    tmpdir = Path(tmpdir)
+    src = tmpdir / "src.py"
+    toml = tmpdir / (config or "pyproject.toml")
+
+    toml.write_text("[tool.black]\nline-length = {}\n".format(line_length))
+
+    config = read_black_config(src, config and str(toml))
+    assert config == {"line_length": line_length}


### PR DESCRIPTION
Hi!

Now darker can use the black config.

It's ugly because it uses a dirty hack with click module. This was done for reusing purposes of the black code.