### PR TITLE
Add ability to use as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: darker
+  name: darker
+  description: "Black reformatting to Python files in only regions changed since last commit"
+  entry: darker
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [python]


### PR DESCRIPTION
This should allow using `darker` as a pre-commit hook in `pre-commit`. 