### PR TITLE
Allow to configure `isort` through pyproject.toml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Feature: Add support for black config
 - Feature: Add support for ``-l``/``--line-length`` and ``-S``/``--skip-string-normalization``
 - Feature: ``--diff`` outputs a diff for each file on standard output
-- Feature: Allow to configure `isort` through pyproject.toml
+- Feature: Allow to configure ``isort`` through pyproject.toml
 
 
 0.2.0 / 2020-03-11

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Feature: Add support for black config
 - Feature: Add support for ``-l``/``--line-length`` and ``-S``/``--skip-string-normalization``
 - Feature: ``--diff`` outputs a diff for each file on standard output
+- Feature: Allow to configure `isort` through pyproject.toml
 
 
 0.2.0 / 2020-03-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
+known_third_party = ["py", "pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,3 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
-known_third_party = ["py", "pytest"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ console_scripts =
 
 [options.extras_require]
 isort =
-    isort
+    isort<5
 test =
     pytest
     pytest-black

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from difflib import unified_diff
 from pathlib import Path
-from typing import Dict, Iterable, List, Union
+from typing import Dict, Iterable, List, Optional, Union, cast
 
 from darker.black_diff import run_black
 from darker.chooser import choose_lines
@@ -29,7 +29,7 @@ MAX_CONTEXT_LINES = 1000
 def format_edited_parts(
     srcs: Iterable[Path],
     isort: bool,
-    black_args: Dict[str, Union[bool, int]],
+    black_args: Dict[str, Union[bool, int, str]],
     print_diff: bool,
 ) -> None:
     """Black (and optional isort) formatting for chunks with edits since the last commit
@@ -64,8 +64,10 @@ def format_edited_parts(
 
     # 1. run isort
     if isort:
+        config = cast(Optional[str], black_args.get("config"))
+        line_length = cast(Optional[int], black_args.get("line_length"))
         edited_srcs = {
-            src: apply_isort(edited_content)
+            src: apply_isort(edited_content, src, config, line_length)
             for src, edited_content in worktree_srcs.items()
         }
     else:

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -35,7 +35,7 @@ for how this result is further processed with:
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 from black import FileMode, format_str, read_pyproject_toml
 from click import Command, Context, Option
@@ -63,7 +63,7 @@ def read_black_config(src: Path, value: Optional[str]) -> Dict[str, Union[bool, 
 
 
 def run_black(
-    src: Path, src_contents: str, black_args: Dict[str, Union[bool, int]]
+    src: Path, src_contents: str, black_args: Dict[str, Union[bool, int, str]]
 ) -> List[str]:
     """Run the black formatter for the Python source code given as a string
 
@@ -76,7 +76,8 @@ def run_black(
     """
     config = black_args.pop("config", None)
     defaults = read_black_config(src, config)
-    combined_args = {**defaults, **black_args}
+    args = cast(Dict[str, Union[bool, int]], black_args)
+    combined_args = {**defaults, **args}
 
     effective_args = {}
     if "line_length" in combined_args:

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -6,16 +6,10 @@ from black import find_project_root
 
 try:
     from isort import SortImports
-    from isort.settings import (
-        _update_with_config_file,
-        default,
-        from_path,
-    )
+    import isort.settings as isort_settings
 except ImportError:
     SortImports = None
-    _update_with_config_file = None
-    default = None
-    from_path = None
+    isort_settings = None
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +19,14 @@ IsortSettings = Dict[str, Union[bool, int, List[str], str, Tuple[str], None]]
 def get_isort_settings(src: Optional[Path], config: Optional[str]) -> IsortSettings:
     if src and config is None:
         project_root = find_project_root((str(src),))
-        settings: IsortSettings = from_path(str(project_root))
+        settings: IsortSettings = isort_settings.from_path(str(project_root))
         return settings
 
-    computed_settings: IsortSettings = default.copy()
+    computed_settings: IsortSettings = isort_settings.default.copy()
     if config:
-        _update_with_config_file(config, ('tool.isort',), computed_settings)
+        isort_settings._update_with_config_file(
+            config, ('tool.isort',), computed_settings
+        )
     return computed_settings
 
 

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from subprocess import check_call
+from textwrap import dedent
 from typing import Dict
 from unittest.mock import patch
 
@@ -43,3 +44,21 @@ class GitRepoFixture:
 def git_repo(tmpdir):
     check_call(["git", "init"], cwd=tmpdir)
     return GitRepoFixture(tmpdir)
+
+
+@pytest.fixture
+def isort_config(tmpdir):
+    from darker.import_sorting import find_project_root
+
+    find_project_root.cache_clear()
+
+    config = tmpdir / 'pyproject.toml'
+    config.write(
+        dedent(
+            """\
+            [tool.isort]
+            line_length = 120
+            """
+        )
+    )
+    return config

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -1,4 +1,8 @@
-from darker.import_sorting import apply_isort
+from pathlib import Path
+
+import pytest
+
+from darker.import_sorting import apply_isort, get_isort_settings
 
 ORIGINAL_SOURCE = "import sys\nimport os\n"
 ISORTED_SOURCE = "import os\nimport sys\n"
@@ -8,3 +12,12 @@ def test_apply_isort():
     result = apply_isort(ORIGINAL_SOURCE)
 
     assert result == ISORTED_SOURCE
+
+
+@pytest.mark.parametrize("config", (None, "pyproject.toml"))
+def test_get_isort_settings(config, tmpdir, isort_config):
+    src = Path(tmpdir / "test1.py")
+    config = str(tmpdir / config) if config else None
+
+    isort_settings = get_isort_settings(src, config)
+    assert isort_settings["line_length"] == 120

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -41,12 +41,14 @@ def test_isort_option_with_isort(run_isort):
 
 def test_isort_option_with_isort_calls_sortimports(run_isort):
     run_isort.SortImports.assert_called_once_with(
-        file_contents="changed", check=True, **darker.import_sorting.default
+        file_contents="changed",
+        check=True,
+        **darker.import_sorting.isort_settings.default
     )
 
 
 def test_isort_option_with_config(isort_config, run_isort):
-    isort_args = darker.import_sorting.default.copy()
+    isort_args = darker.import_sorting.isort_settings.default.copy()
     isort_args["line_length"] = 120
     run_isort.SortImports.assert_called_once_with(
         file_contents="changed", check=True, **isort_args

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -41,14 +41,15 @@ def test_isort_option_with_isort(run_isort):
 
 def test_isort_option_with_isort_calls_sortimports(run_isort):
     run_isort.SortImports.assert_called_once_with(
-        file_contents="changed",
-        check=True,
-        force_grid_wrap=0,
-        include_trailing_comma=True,
-        line_length=88,
-        multi_line_output=3,
-        use_parentheses=True,
-        quiet=True,
+        file_contents="changed", check=True, **darker.import_sorting.default
+    )
+
+
+def test_isort_option_with_config(isort_config, run_isort):
+    isort_args = darker.import_sorting.default.copy()
+    isort_args["line_length"] = 120
+    run_isort.SortImports.assert_called_once_with(
+        file_contents="changed", check=True, **isort_args
     )
 
 


### PR DESCRIPTION
Now it's possible to customize `isort` parameters using the same pyproject.toml that contains `black` configuration.