### PR TITLE
Compatibility with isort 5.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Feature: Add support for ``-l``/``--line-length`` and ``-S``/``--skip-string-normalization``
 - Feature: ``--diff`` outputs a diff for each file on standard output
 - Feature: Allow to configure ``isort`` through pyproject.toml
+- Feature: Require ``isort`` >= 5.0.1 and be compatible with it.
 
 
 0.2.0 / 2020-03-11

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ doctest_optionflags = NORMALIZE_WHITESPACE
 show_capture = no
 addopts =
   --black
-#  --isort
+  ## Disable pytest-isort until it is fixed to work with isort 5.x
+  #  --isort
   --mypy
   --doctest-modules

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,6 @@ doctest_optionflags = NORMALIZE_WHITESPACE
 show_capture = no
 addopts =
   --black
-  --isort
+#  --isort
   --mypy
   --doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,10 @@ console_scripts =
 
 [options.extras_require]
 isort =
-    isort<5
+    isort>=5.0.1
 test =
     pytest
     pytest-black
-    pytest-isort
+    ## Disable pytest-isort until it is fixed to work with isort 5.x
+    #pytest-isort
     pytest-mypy

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -15,7 +15,7 @@ from darker.diff import (
     opcodes_to_edit_linenums,
 )
 from darker.git import git_diff_name_only, git_get_unmodified_content
-from darker.import_sorting import SortImports, apply_isort
+from darker.import_sorting import sort_code_string, apply_isort
 from darker.utils import get_common_root, joinlines
 from darker.verification import NotEquivalentError, verify_ast_unchanged
 from darker.version import __version__
@@ -174,7 +174,7 @@ def main(argv: List[str] = None) -> None:
     if args.version:
         print(__version__)
 
-    if args.isort and not SortImports:
+    if args.isort and not sort_code_string:
         logger.error(f"{ISORT_INSTRUCTION} to use the `--isort` option.")
         exit(1)
 

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Optional, Tuple, Union
 from black import find_project_root
 
 try:
-    from isort.api import sort_code_string as SortImports
+    from isort.api import sort_code_string
     import isort.settings as isort_settings
 except ImportError:
-    SortImports = None
+    sort_code_string = None
     isort_settings = None
 
 logger = logging.getLogger(__name__)
@@ -42,9 +42,9 @@ def apply_isort(
         isort_settings["line_length"] = line_length
 
     logger.debug(
-        "SortImports(file_contents=..., check=True, {})".format(
+        "sort_code_string(file_contents=..., check=True, {})".format(
             ", ".join(f"{k}={v}" for k, v in isort_settings.items())
         )
     )
-    output: str = SortImports(content, **isort_settings)
+    output: str = sort_code_string(content, **isort_settings)
     return output

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union, cast
@@ -5,7 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union, cast
 from black import find_project_root
 
 try:
-    from isort import SortImports
+    from isort.api import sort_stream as SortImports
     import isort.settings as isort_settings
 except ImportError:
     SortImports = None
@@ -45,5 +46,6 @@ def apply_isort(
             ", ".join(f"{k}={v}" for k, v in isort_settings.items())
         )
     )
-    result = SortImports(file_contents=content, check=True, **isort_settings)
-    return cast(str, result.output)
+    result = io.StringIO()
+    SortImports(io.StringIO(content), result, check=True, **isort_settings)
+    return result.getvalue()

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from subprocess import check_call
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, ANY
 
 import pytest
 
@@ -40,19 +40,14 @@ def test_isort_option_with_isort(run_isort):
 
 
 def test_isort_option_with_isort_calls_sortimports(run_isort):
-    run_isort.SortImports.assert_called_once_with(
-        file_contents="changed",
-        check=True,
-        **darker.import_sorting.isort_settings.default
-    )
+    run_isort.SortImports.assert_called_once()
+    assert run_isort.SortImports.call_args[0] == ("changed",)
 
 
 def test_isort_option_with_config(isort_config, run_isort):
-    isort_args = darker.import_sorting.isort_settings.default.copy()
-    isort_args["line_length"] = 120
-    run_isort.SortImports.assert_called_once_with(
-        file_contents="changed", check=True, **isort_args
-    )
+    run_isort.SortImports.assert_called_once()
+    assert run_isort.SortImports.call_args[0] == ("changed",)
+    assert run_isort.SortImports.call_args[1]["line_length"] == 120
 
 
 def test_format_edited_parts_empty():
@@ -110,13 +105,7 @@ A_PY_DIFF_BLACK_ISORT = [
     'isort, black_args, print_diff, expect_stdout, expect_a_py',
     [
         (False, {}, True, A_PY_DIFF_BLACK, A_PY),
-        (
-            True,
-            {},
-            False,
-            ['ERROR:  Imports are incorrectly sorted.', ''],
-            A_PY_BLACK_ISORT,
-        ),
+        (True, {}, False, [''], A_PY_BLACK_ISORT,),
         (
             False,
             {'skip_string_normalization': True},
@@ -125,13 +114,7 @@ A_PY_DIFF_BLACK_ISORT = [
             A_PY,
         ),
         (False, {}, False, [''], A_PY_BLACK),
-        (
-            True,
-            {},
-            True,
-            ['ERROR:  Imports are incorrectly sorted.'] + A_PY_DIFF_BLACK_ISORT,
-            A_PY,
-        ),
+        (True, {}, True, A_PY_DIFF_BLACK_ISORT, A_PY,),
     ],
 )
 def test_format_edited_parts(

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from subprocess import check_call
 from types import SimpleNamespace
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -11,7 +11,9 @@ import darker.import_sorting
 
 def test_isort_option_without_isort(tmpdir, without_isort, caplog):
     check_call(["git", "init"], cwd=tmpdir)
-    with patch.object(darker.__main__, "SortImports", None), pytest.raises(SystemExit):
+    with patch.object(darker.__main__, "sort_code_string", None), pytest.raises(
+        SystemExit
+    ):
 
         darker.__main__.main(["--isort", str(tmpdir)])
 
@@ -28,10 +30,10 @@ def run_isort(git_repo, monkeypatch, caplog):
     paths['test1.py'].write('changed')
     with patch.multiple(
         darker.__main__, run_black=Mock(return_value=[]), verify_ast_unchanged=Mock(),
-    ), patch("darker.import_sorting.SortImports"):
+    ), patch("darker.import_sorting.sort_code_string"):
         darker.__main__.main(["--isort", "./test1.py"])
         return SimpleNamespace(
-            SortImports=darker.import_sorting.SortImports, caplog=caplog
+            sort_code_string=darker.import_sorting.sort_code_string, caplog=caplog
         )
 
 
@@ -40,14 +42,14 @@ def test_isort_option_with_isort(run_isort):
 
 
 def test_isort_option_with_isort_calls_sortimports(run_isort):
-    run_isort.SortImports.assert_called_once()
-    assert run_isort.SortImports.call_args[0] == ("changed",)
+    run_isort.sort_code_string.assert_called_once()
+    assert run_isort.sort_code_string.call_args[0] == ("changed",)
 
 
 def test_isort_option_with_config(isort_config, run_isort):
-    run_isort.SortImports.assert_called_once()
-    assert run_isort.SortImports.call_args[0] == ("changed",)
-    assert run_isort.SortImports.call_args[1]["line_length"] == 120
+    run_isort.sort_code_string.assert_called_once()
+    assert run_isort.sort_code_string.call_args[0] == ("changed",)
+    assert run_isort.sort_code_string.call_args[1]["line_length"] == 120
 
 
 def test_format_edited_parts_empty():


### PR DESCRIPTION
- [ ] ~~wait for #13 to be merged, this one is based on that~~
- [ ] ~~wait for [pytest-isort](https://github.com/moccu/pytest-isort/) to [fix compatibility with isort 5.x](https://github.com/moccu/pytest-isort/issues/23)~~
- [ ] ~~re-enable `pytest-isort` in `setup.cfg` and `pytest.ini`~~

Let's use #16 instead and discard this PR. But I'll keep this open for now so we can easily see the diff in case there's something useful there.