### PR TITLE
Remove `isort.check_code()` call

### DIFF
--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 def apply_isort(content: str) -> str:
-    isort.check_code(code=content)
     isort_config_kwargs = dict(
         multi_line_output=3,
         include_trailing_comma=True,

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -106,13 +106,7 @@ A_PY_DIFF_BLACK_ISORT = [
     'isort, black_args, print_diff, expect_stdout, expect_a_py',
     [
         (False, {}, True, A_PY_DIFF_BLACK, A_PY),
-        (
-            True,
-            {},
-            False,
-            ['ERROR:  Imports are incorrectly sorted and/or formatted.', ''],
-            A_PY_BLACK_ISORT,
-        ),
+        (True, {}, False, [''], A_PY_BLACK_ISORT,),
         (
             False,
             {'skip_string_normalization': True},
@@ -121,14 +115,7 @@ A_PY_DIFF_BLACK_ISORT = [
             A_PY,
         ),
         (False, {}, False, [''], A_PY_BLACK),
-        (
-            True,
-            {},
-            True,
-            ['ERROR:  Imports are incorrectly sorted and/or formatted.']
-            + A_PY_DIFF_BLACK_ISORT,
-            A_PY,
-        ),
+        (True, {}, True, A_PY_DIFF_BLACK_ISORT, A_PY,),
     ],
 )
 def test_format_edited_parts(


### PR DESCRIPTION
This gets rid of unnecessary isort check errors on stdout.