### PR TITLE
Allow to configure `isort` through `pyproject.toml`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Feature: Add support for ``-l``/``--line-length`` and ``-S``/``--skip-string-normalization``
 - Feature: ``--diff`` outputs a diff for each file on standard output
 - Feature: Require ``isort`` >= 5.0.1 and be compatible with it.
+- Feature: Allow to configure ``isort`` through pyproject.toml
 
 
 0.2.0 / 2020-03-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
+known_third_party = ["pytest"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ package_dir =
 packages = find:
 install_requires =
     black
+    typing-extensions ; python_version < "3.8"
 python_requires = >=3.6
 
 [options.packages.find]

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -61,8 +61,10 @@ def format_edited_parts(
 
     # 1. run isort
     if isort:
+        config = black_args.get("config")
+        line_length = black_args.get("line_length")
         edited_srcs = {
-            src: apply_isort(edited_content)
+            src: apply_isort(edited_content, src, config, line_length)
             for src, edited_content in worktree_srcs.items()
         }
     else:

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -4,9 +4,9 @@ import logging
 import sys
 from difflib import unified_diff
 from pathlib import Path
-from typing import Dict, Iterable, List, Union
+from typing import Iterable, List
 
-from darker.black_diff import run_black
+from darker.black_diff import BlackArgs, run_black
 from darker.chooser import choose_lines
 from darker.command_line import ISORT_INSTRUCTION, parse_command_line
 from darker.diff import (
@@ -27,10 +27,7 @@ MAX_CONTEXT_LINES = 1000
 
 
 def format_edited_parts(
-    srcs: Iterable[Path],
-    isort: bool,
-    black_args: Dict[str, Union[bool, int]],
-    print_diff: bool,
+    srcs: Iterable[Path], isort: bool, black_args: BlackArgs, print_diff: bool,
 ) -> None:
     """Black (and optional isort) formatting for chunks with edits since the last commit
 
@@ -176,7 +173,7 @@ def main(argv: List[str] = None) -> None:
         logger.error(f"{ISORT_INSTRUCTION} to use the `--isort` option.")
         exit(1)
 
-    black_args = {}
+    black_args = BlackArgs()
     if args.config:
         black_args["config"] = args.config
     if args.line_length:

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -27,15 +27,15 @@ class IsortArgs(TypedDict, total=False):
 
 def apply_isort(
     content: str,
-    src: Optional[Path] = None,
+    src: Path,
     config: Optional[str] = None,
     line_length: Optional[int] = None,
 ) -> str:
     isort_args = IsortArgs()
-    if src and not config:
-        isort_args["settings_path"] = str(find_project_root((str(src),)))
     if config:
         isort_args["settings_file"] = config
+    else:
+        isort_args["settings_path"] = str(find_project_root((str(src),)))
     if line_length:
         isort_args["line_length"] = line_length
 

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from darker.black_diff import read_black_config, run_black
+from darker.black_diff import BlackArgs, read_black_config, run_black
 
 
 @pytest.mark.parametrize(
@@ -39,6 +39,6 @@ def test_black_config(tmpdir, config_path, config_lines, expect):
 def test_run_black(tmpdir):
     src_contents = "print ( '42' )\n"
 
-    result = run_black(Path(tmpdir / "src.py"), src_contents, {})
+    result = run_black(Path(tmpdir / "src.py"), src_contents, BlackArgs())
 
     assert result == ['print("42")']

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -11,7 +11,7 @@ ISORTED_SOURCE = "import os\nimport sys\n"
 
 
 def test_apply_isort():
-    result = apply_isort(ORIGINAL_SOURCE)
+    result = apply_isort(ORIGINAL_SOURCE, Path("test1.py"))
 
     assert result == ISORTED_SOURCE
 
@@ -58,8 +58,7 @@ def test_isort_config(monkeypatch, tmpdir, line_length, settings_file, expect):
     )
 
     content = "from module import ab, cd, ef, gh, ij, kl, mn, op, qr, st, uv, wx, yz"
-    src = Path(tmpdir / "test1.py") if not settings_file else None
     config = str(tmpdir / settings_file) if settings_file else None
 
-    actual = apply_isort(content, src, config)
+    actual = apply_isort(content, Path("test1.py"), config)
     assert actual == expect

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
 from darker.import_sorting import apply_isort
 
 ORIGINAL_SOURCE = "import sys\nimport os\n"
@@ -8,3 +13,28 @@ def test_apply_isort():
     result = apply_isort(ORIGINAL_SOURCE)
 
     assert result == ISORTED_SOURCE
+
+
+@pytest.mark.parametrize("settings_file", [None, "pyproject.toml"])
+@pytest.mark.parametrize("line_length", [20, 60])
+def test_isort_config(monkeypatch, tmpdir, line_length, settings_file):
+    from black import find_project_root
+
+    find_project_root.cache_clear()
+    monkeypatch.chdir(tmpdir)
+    (tmpdir / 'pyproject.toml').write(
+        dedent(
+            f"""\
+            [tool.isort]
+            line_length = {line_length}
+            """
+        )
+    )
+
+    content = "from module import ab, cd, ef, gh, ij, kl, mn, op, qr, st, uv, wx, yz"
+    src = Path(tmpdir / "test1.py") if not settings_file else None
+    config = str(tmpdir / settings_file) if settings_file else None
+
+    actual = apply_isort(content, src, config)
+    expected = apply_isort(content, line_length=line_length)
+    assert actual == expected

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+from black import find_project_root
 
 from darker.import_sorting import apply_isort
 
@@ -15,11 +16,36 @@ def test_apply_isort():
     assert result == ISORTED_SOURCE
 
 
-@pytest.mark.parametrize("settings_file", [None, "pyproject.toml"])
-@pytest.mark.parametrize("line_length", [20, 60])
-def test_isort_config(monkeypatch, tmpdir, line_length, settings_file):
-    from black import find_project_root
-
+@pytest.mark.parametrize(
+    "line_length, settings_file, expect",
+    [
+        (
+            50,
+            None,
+            "from module import (ab, cd, ef, gh, ij, kl, mn,\n"
+            "                    op, qr, st, uv, wx, yz)\n",
+        ),
+        (
+            50,
+            "pyproject.toml",
+            "from module import (ab, cd, ef, gh, ij, kl, mn,\n"
+            "                    op, qr, st, uv, wx, yz)\n",
+        ),
+        (
+            60,
+            None,
+            "from module import (ab, cd, ef, gh, ij, kl, mn, op, qr, st,\n"
+            "                    uv, wx, yz)\n",
+        ),
+        (
+            60,
+            "pyproject.toml",
+            "from module import (ab, cd, ef, gh, ij, kl, mn, op, qr, st,\n"
+            "                    uv, wx, yz)\n",
+        ),
+    ],
+)
+def test_isort_config(monkeypatch, tmpdir, line_length, settings_file, expect):
     find_project_root.cache_clear()
     monkeypatch.chdir(tmpdir)
     (tmpdir / 'pyproject.toml').write(
@@ -36,5 +62,4 @@ def test_isort_config(monkeypatch, tmpdir, line_length, settings_file):
     config = str(tmpdir / settings_file) if settings_file else None
 
     actual = apply_isort(content, src, config)
-    expected = apply_isort(content, line_length=line_length)
-    assert actual == expected
+    assert actual == expect

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from black import find_project_root
 
 import darker.__main__
 import darker.import_sorting
@@ -23,8 +24,6 @@ def test_isort_option_without_isort(tmpdir, without_isort, caplog):
 
 @pytest.fixture
 def run_isort(git_repo, monkeypatch, caplog, request):
-    from black import find_project_root
-
     find_project_root.cache_clear()
 
     monkeypatch.chdir(git_repo.root)

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -45,7 +45,7 @@ def test_isort_option_with_isort(run_isort):
 
 
 @pytest.mark.parametrize(
-    "run_isort,isort_args",
+    "run_isort, isort_args",
     [((), {}), (("--line-length", "120"), {"line_length": 120})],
     indirect=["run_isort"],
 )

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -22,14 +22,19 @@ def test_isort_option_without_isort(tmpdir, without_isort, caplog):
 
 
 @pytest.fixture
-def run_isort(git_repo, monkeypatch, caplog):
+def run_isort(git_repo, monkeypatch, caplog, request):
+    from black import find_project_root
+
+    find_project_root.cache_clear()
+
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'test1.py': 'original'}, commit='Initial commit')
     paths['test1.py'].write('changed')
+    args = getattr(request, "param", ())
     with patch.multiple(
         darker.__main__, run_black=Mock(return_value=[]), verify_ast_unchanged=Mock(),
     ), patch("darker.import_sorting.isort.code"):
-        darker.__main__.main(["--isort", "./test1.py"])
+        darker.__main__.main(["--isort", "./test1.py", *args])
         return SimpleNamespace(
             isort_code=darker.import_sorting.isort.code, caplog=caplog
         )
@@ -39,15 +44,14 @@ def test_isort_option_with_isort(run_isort):
     assert "Please run" not in run_isort.caplog.text
 
 
-def test_isort_option_with_isort_calls_sortimports(run_isort):
+@pytest.mark.parametrize(
+    "run_isort,isort_args",
+    [((), {}), (("--line-length", "120"), {"line_length": 120})],
+    indirect=["run_isort"],
+)
+def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args):
     run_isort.isort_code.assert_called_once_with(
-        code="changed",
-        force_grid_wrap=0,
-        include_trailing_comma=True,
-        line_length=88,
-        multi_line_output=3,
-        use_parentheses=True,
-        quiet=True,
+        code="changed", settings_path=str(tmpdir), **isort_args
     )
 
 


### PR DESCRIPTION
Attempt # 2. Decided to rewrite #13 from scratch after #16 due to a lot of conflicts and redundant code

@akaihola your comments from #13 were taken to account:

- TypedDict for BlackArgs / IsortArgs
- debug message is readable enough