### PR TITLE
Bump `pytest-isort` version to `1.1.0`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,6 @@ doctest_optionflags = NORMALIZE_WHITESPACE
 show_capture = no
 addopts =
   --black
-  ## Disable pytest-isort until it is fixed to work with isort 5.x
-  #  --isort
+  --isort
   --mypy
   --doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,5 @@ isort =
 test =
     pytest
     pytest-black
-    ## Disable pytest-isort until it is fixed to work with isort 5.x
-    #pytest-isort
+    pytest-isort>=1.1.0
     pytest-mypy


### PR DESCRIPTION
Reenable `--isort` testing