### PR TITLE
Context extension fix

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -81,7 +81,9 @@ def format_edited_parts(
             edited_opcodes = diff_and_get_opcodes(head_lines, edited)
 
             # 3. extract line numbers in each edited to-file for changed lines
-            edited_linenums = list(opcodes_to_edit_linenums(edited_opcodes))
+            edited_linenums = list(
+                opcodes_to_edit_linenums(edited_opcodes, context_lines)
+            )
             if (
                 isort
                 and not edited_linenums

--- a/src/darker/diff.py
+++ b/src/darker/diff.py
@@ -117,12 +117,13 @@ def opcodes_to_edit_linenums(
 
     """
     _validate_opcodes(opcodes)
-    previous_end = 1
+    prev_chunk_end = 1
+    _tag, _i1, _i2, _j1, end = opcodes[-1]
     for tag, _i1, _i2, j1, j2 in opcodes:
         if tag != "equal":
-            end = j2 + 1 + context_lines
-            yield from range(max(j1 + 1 - context_lines, previous_end), end)
-            previous_end = end
+            chunk_end = min(j2 + 1 + context_lines, end + 1)
+            yield from range(max(j1 + 1 - context_lines, prev_chunk_end), chunk_end)
+            prev_chunk_end = chunk_end
 
 
 def opcodes_to_chunks(

--- a/src/darker/diff.py
+++ b/src/darker/diff.py
@@ -107,13 +107,22 @@ def _validate_opcodes(opcodes: List[Tuple[str, int, int, int, int]]) -> None:
 
 
 def opcodes_to_edit_linenums(
-    opcodes: List[Tuple[str, int, int, int, int]]
+    opcodes: List[Tuple[str, int, int, int, int]], context_lines: int
 ) -> Generator[int, None, None]:
-    """Convert diff opcode to line number of edited lines in the destination file"""
+    """Convert diff opcodes to line numbers of edited lines in the destination file
+
+    :param opcodes: The diff opcodes to convert
+    :param context_lines: The number of lines before and after an edited line to mark
+                          edited as well
+
+    """
     _validate_opcodes(opcodes)
+    previous_end = 1
     for tag, _i1, _i2, j1, j2 in opcodes:
         if tag != "equal":
-            yield from range(j1 + 1, j2 + 1)
+            end = j2 + 1 + context_lines
+            yield from range(max(j1 + 1 - context_lines, previous_end), end)
+            previous_end = end
 
 
 def opcodes_to_chunks(

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -1,5 +1,7 @@
+from itertools import chain
 from textwrap import dedent
 
+import pytest
 from black import FileMode, format_str
 
 from darker.diff import (
@@ -141,7 +143,17 @@ def test_opcodes_to_chunks():
     ]
 
 
-def test_opcodes_to_edit_linenums():
-    edit_linenums = list(opcodes_to_edit_linenums(OPCODES))
+@pytest.mark.parametrize(
+    'context_lines, expect',
+    [
+        (0, [1, 4, 5, 13, 14, 17, 20, 22, 23, 27]),
+        (1, [[1, 6], [12, 24], [26, 28]]),
+        (2, [[1, 7], [11, 29]]),
+    ],
+)
+def test_opcodes_to_edit_linenums(context_lines, expect):
+    edit_linenums = list(opcodes_to_edit_linenums(OPCODES, context_lines))
+    expect_ranges = [[n, n] if isinstance(n, int) else n for n in expect]
+    expect_linenums = list(chain(*(range(n[0], n[1] + 1) for n in expect_ranges)))
 
-    assert edit_linenums == [1, 4, 5, 13, 14, 17, 20, 22, 23, 27]
+    assert edit_linenums == expect_linenums

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -148,7 +148,7 @@ def test_opcodes_to_chunks():
     [
         (0, [1, 4, 5, 13, 14, 17, 20, 22, 23, 27]),
         (1, [[1, 6], [12, 24], [26, 28]]),
-        (2, [[1, 7], [11, 29]]),
+        (2, [[1, 7], [11, 28]]),
     ],
 )
 def test_opcodes_to_edit_linenums(context_lines, expect):


### PR DESCRIPTION
When `git diff` was replaced with `difflib.SequenceMatcher` in #11, I failed to also re-implement "context expansion". The equivalent of `git diff -U<number-of-context-lines>` is now properly implemented in `diff_and_get_opcodes()` again. Additionally, the number of extra context lines can no longer grow beyond the number of lines in the processed file.

What context expansion does is:

In case the AST of the original edited file doesn't match with the AST of the partially reformatted one, darker considers one more line before and after every user-edited chunk as part of the chunk. This expansion is repeated one line at a time until the ASTs match.

Context expansion helps is rare cases of two nearby chunks of Black reformatting separated by intact lines. Sometimes applying only one of those nearby chunks causes the AST to change, and context expansion will eventually cause them to be applied together.