### PR TITLE
Changelog to link to commit logs, not diffs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,8 +49,8 @@ Added
 -----
 - Initial implementation
 
-.. _Unreleased: https://github.com/akaihola/darker/compare/1.0.0..HEAD
-.. _1.0.0: https://github.com/akaihola/darker/compare/0.2.0..1.0.0
-.. _0.2.0: https://github.com/akaihola/darker/compare/0.1.1..0.2.0
-.. _0.1.1: https://github.com/akaihola/darker/compare/0.1.0..0.1.1
+.. _Unreleased: https://github.com/akaihola/darker/compare/1.0.0...HEAD
+.. _1.0.0: https://github.com/akaihola/darker/compare/0.2.0...1.0.0
+.. _0.2.0: https://github.com/akaihola/darker/compare/0.1.1...0.2.0
+.. _0.1.1: https://github.com/akaihola/darker/compare/0.1.0...0.1.1
 .. _0.1.0: https://github.com/akaihola/darker/releases/tag/0.1.0


### PR DESCRIPTION
The version number headers in `CHANGES.rst` now link to the GitHub URL with the list of commits since the previous release. These links have three periods between version numbers (e.g. `0.2.0...1.0.0`) instead of just two periods (e.g. `0.2.0..1.0.0`) which link to a diff between versions instead. The commit log is certainly more useful.