### PR TITLE
Don't show traceback if there are no SRCs specified

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -18,7 +18,6 @@ from darker.git import git_diff_name_only, git_get_unmodified_content
 from darker.import_sorting import apply_isort, isort
 from darker.utils import get_common_root, joinlines
 from darker.verification import NotEquivalentError, verify_ast_unchanged
-from darker.version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -167,9 +166,6 @@ def main(argv: List[str] = None) -> None:
 
     # Make sure we don't get excessive debug log output from Black
     logging.getLogger("blib2to3.pgen2.driver").setLevel(logging.WARNING)
-
-    if args.version:
-        print(__version__)
 
     if args.isort and not isort:
         logger.error(f"{ISORT_INSTRUCTION} to use the `--isort` option.")

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -24,7 +24,12 @@ def parse_command_line(argv: List[str]) -> Namespace:
     parser = ArgumentParser(
         description="\n".join(description), formatter_class=NewlinePreservingFormatter,
     )
-    parser.add_argument("src", nargs="+")
+    parser.add_argument(
+        "src",
+        nargs="+",
+        help="Path(s) to the Python source file(s) to reformat",
+        metavar="PATH",
+    )
     isort_help = ["Also sort imports using the `isort` package"]
     if not isort:
         isort_help.append(f". {ISORT_INSTRUCTION} to enable usage of this option.")

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -23,7 +23,7 @@ def parse_command_line(argv: List[str]) -> Namespace:
     parser = ArgumentParser(
         description="\n".join(description), formatter_class=NewlinePreservingFormatter,
     )
-    parser.add_argument("src", nargs="*")
+    parser.add_argument("src", nargs="+")
     isort_help = ["Also sort imports using the `isort` package"]
     if not isort:
         isort_help.append(f". {ISORT_INSTRUCTION} to enable usage of this option.")

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser, Namespace
 from typing import List
 
 from darker.argparse_helpers import NewlinePreservingFormatter
+from darker.version import __version__
 
 ISORT_INSTRUCTION = "Please run `pip install 'darker[isort]'`"
 
@@ -58,7 +59,10 @@ def parse_command_line(argv: List[str]) -> Namespace:
         help="Reduce amount of output",
     )
     parser.add_argument(
-        "--version", action="store_true", help="Show the version of `darker`"
+        "--version",
+        action="version",
+        version=__version__,
+        help="Show the version of `darker`",
     )
     parser.add_argument(
         "-S",


### PR DESCRIPTION
This fixes annoying:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/mm/.virtualenvs/black/lib/python3.8/site-packages/darker/__main__.py", line 191, in <module>
    main()
  File "/home/mm/.virtualenvs/black/lib/python3.8/site-packages/darker/__main__.py", line 187, in main
    format_edited_parts(paths, args.isort, black_args, args.diff)
  File "/home/mm/.virtualenvs/black/lib/python3.8/site-packages/darker/__main__.py", line 52, in format_edited_parts
    git_root = get_common_root(srcs)
  File "/home/mm/.virtualenvs/black/lib/python3.8/site-packages/darker/utils.py", line 51, in get_common_root
    raise ValueError(f"Paths have no common parent Git root: {resolved_paths}")
ValueError: Paths have no common parent Git root: []
```