### PR TITLE
Add support for linters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ These features will be included in the next release:
 
 Added
 -----
+- ``-L``/``--lint`` option for running a linter for modified lines.
 
 - ``--check`` returns 1 from the process but leaves files untouched if any file would
   require reformatting

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-===========================================================================
- Darker – Apply Black formatting only in regions changed since last commit
-===========================================================================
+=================================================
+ Darker – reformat and lint modified Python code
+=================================================
 
 |travis-badge|_ |license-badge|_ |pypi-badge|_ |downloads-badge|_ |black-badge|_ |changelog-badge|_
 
@@ -20,18 +20,34 @@
 What?
 =====
 
-This is a small utility built on top of the black_ and isort_ Python code formatters
-to enable formatting of only regions which have changed in the Git working tree
-since the last commit.
+This utility reformats and checks Python source code files in a Git repository.
+However, it only applies reformatting and reports errors
+in regions which have changed in the Git working tree since the last commit.
+
+The reformatters and linters supported are:
+
+- Black_ for code reformatting
+- isort_ for sorting imports
+- Mypy_ for static type checking
+- Pylint_ for generic static checking of code
+- Flake8_ for style guide enforcement
+
+*New in version 1.1.0:* Support for Mypy_, Pylint_ and other linters.
 
 .. _black: https://github.com/python/black
 .. _isort: https://github.com/timothycrosley/isort
+.. _Mypy: https://pypi.org/project/mypy
+.. _Pylint: https://pypi.org/project/pylint
+.. _Flake8: https://pypi.org/project/flake8
 
 Why?
 ====
 
 You want to start unifying code style in your project using black_.
-But instead of formatting the whole code base in one giant commit,
+Maybe you also like to standardize on how to order your imports,
+or do static type checking or other static analysis for your code.
+
+However, instead of formatting the whole code base in one giant commit,
 you'd like to only change formatting when you're touching the code for other reasons.
 
 This can also be useful
@@ -53,7 +69,7 @@ This tool is for those who want to do partial formatting anyway.
 
 Note that this tool is meant for special situations
 when dealing with existing code bases.
-You should just use black_ as is when starting a project from scratch.
+You should just use Black_ and isort_ as is when starting a project from scratch.
 
 How?
 ====
@@ -71,6 +87,18 @@ and writes back over the original file.
 Alternatively, you can invoke the module directly through the ``python`` executable,
 which may be preferable depending on your setup.
 Use ``python -m darker`` instead of ``darker`` in that case.
+
+By default, ``darker`` just runs Black_ to reformat the code.
+You can enable additional features with command line options:
+
+- ``-i`` / ``--isort``: Reorder imports using isort_
+- ``-L <linter>`` / ``--lint <linter>``: Run a supported linter:
+
+  - ``-L mypy``: do static type checking using Mypy_
+  - ``-L pylint``: analyze code using Pylint_
+  - ``-L flake8``: enforce the Python style guide using Flake8_
+
+*New in version 1.1.0:* The ``-L`` / ``--lint`` option.
 
 Example:
 
@@ -127,6 +155,9 @@ The following `command line arguments`_ can also be used to modify the defaults:
 
      -i, --isort           Also sort imports using the `isort` package
 
+     -L CMD, --lint CMD    Also run a linter on changed files. CMD can be a name
+                           of path of the linter binary, or a full quoted command
+                           line
      -c PATH, --config PATH
                            Ask `black` and `isort` to read configuration from PATH.
      -S, --skip-string-normalization
@@ -149,6 +180,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
 *New in version 1.1.0:* The ``--check`` command line option.
 
 *New in version 1.1.0:* The ``--no-skip-string-normalization`` command line option.
+
+*New in version 1.1.0:* The ``-L`` / ``--lint`` command line option.
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/
@@ -269,6 +302,8 @@ are applied to the edited file.
 
 Also, in case the ``--isort`` option was specified,
 isort_ is run on each edited file before applying black_.
+Similarly, each linter requested using the `--lint <command>` option is run,
+and only linting errors/warnings on modified lines are displayed.
 
 
 License

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -28,8 +28,9 @@ def format_edited_parts(
 ) -> Generator[Tuple[Path, str, str, List[str]], None, None]:
     """Black (and optional isort) formatting for chunks with edits since the last commit
 
-    1. run isort on each edited file
-    2. diff HEAD and worktree for all file & dir paths on the command line
+    1. run isort on each edited file (optional)
+    2. diff HEAD and worktree (optionally with isort modifications) for all file & dir
+       paths on the command line
     3. extract line numbers in each edited to-file for changed lines
     4. run black on the contents of each edited to-file
     5. get a diff between the edited to-file and the reformatted content
@@ -42,6 +43,11 @@ def format_edited_parts(
     9. verify that the resulting reformatted source code parses to an identical AST as
        the original edited to-file
     10. write the reformatted source back to the original file
+    11. run linter subprocesses for all edited files (11.-14. optional)
+    12. diff HEAD and worktree (after isort and Black reformatting) for each file
+        reported by a linter
+    13. extract line numbers in each file reported by a linter for changed lines
+    14. print only linter error lines which fall on changed lines
 
     :param srcs: Directories and files to re-format
     :param revision: The Git revision against which to compare the working tree
@@ -75,7 +81,7 @@ def format_edited_parts(
         max_context_lines = len(edited_lines)
         for context_lines in range(max_context_lines + 1):
             # 2. diff HEAD and worktree for the file
-            # 3. extract line numbers in each edited to-file for changed lines
+            # 3. extract line numbers in the edited to-file for changed lines
             edited_linenums = edited_linenums_differ.revision_vs_lines(
                 path_in_repo, edited_lines, context_lines
             )
@@ -92,7 +98,7 @@ def format_edited_parts(
             logger.debug("Read %s lines from edited file %s", len(edited_lines), src)
             logger.debug("Black reformat resulted in %s lines", len(formatted))
 
-            # 5. get the diff between each edited and reformatted file
+            # 5. get the diff between the edited and reformatted file
             opcodes = diff_and_get_opcodes(edited_lines, formatted)
 
             # 6. convert the diff into chunks
@@ -138,11 +144,11 @@ def format_edited_parts(
                     # Pass them both on to avoid back-and-forth conversion.
                     yield src, worktree_content, result_str, chosen_lines
                 break
-    # 11. start a Mypy process on all edited files
+    # 11. run linter subprocesses for all edited files (11.-14. optional)
     # 12. diff HEAD and worktree (after isort and Black reformatting) for each file
-    #     reported by Mypy
-    # 13. extract line numbers in each file reported by Mypy for changed lines
-    # 14. print only Mypy error lines which fall on changed lines
+    #     reported by a linter
+    # 13. extract line numbers in each file reported by a linter for changed lines
+    # 14. print only linter error lines which fall on changed lines
     for linter_cmdline in linter_cmdlines:
         run_linter(linter_cmdline, git_root, changed_files)
 

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -29,8 +29,8 @@ def format_edited_parts(
     """Black (and optional isort) formatting for chunks with edits since the last commit
 
     1. run isort on each edited file (optional)
-    2. diff HEAD and worktree (optionally with isort modifications) for all file & dir
-       paths on the command line
+    2. diff the given revision and worktree (optionally with isort modifications) for
+       all file & dir paths on the command line
     3. extract line numbers in each edited to-file for changed lines
     4. run black on the contents of each edited to-file
     5. get a diff between the edited to-file and the reformatted content
@@ -44,8 +44,8 @@ def format_edited_parts(
        the original edited to-file
     10. write the reformatted source back to the original file
     11. run linter subprocesses for all edited files (11.-14. optional)
-    12. diff HEAD and worktree (after isort and Black reformatting) for each file
-        reported by a linter
+    12. diff the given revision and worktree (after isort and Black reformatting) for
+        each file reported by a linter
     13. extract line numbers in each file reported by a linter for changed lines
     14. print only linter error lines which fall on changed lines
 
@@ -80,7 +80,7 @@ def format_edited_parts(
         edited_lines = edited_content.splitlines()
         max_context_lines = len(edited_lines)
         for context_lines in range(max_context_lines + 1):
-            # 2. diff HEAD and worktree for the file
+            # 2. diff the given revision and worktree for the file
             # 3. extract line numbers in the edited to-file for changed lines
             edited_linenums = edited_linenums_differ.revision_vs_lines(
                 path_in_repo, edited_lines, context_lines
@@ -145,8 +145,8 @@ def format_edited_parts(
                     yield src, worktree_content, result_str, chosen_lines
                 break
     # 11. run linter subprocesses for all edited files (11.-14. optional)
-    # 12. diff HEAD and worktree (after isort and Black reformatting) for each file
-    #     reported by a linter
+    # 12. diff the given revision and worktree (after isort and Black reformatting) for
+    #     each file reported by a linter
     # 13. extract line numbers in each file reported by a linter for changed lines
     # 14. print only linter error lines which fall on changed lines
     for linter_cmdline in linter_cmdlines:

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -63,6 +63,18 @@ def parse_command_line(argv: List[str]) -> Namespace:
         "-i", "--isort", action="store_true", help="".join(isort_help),
     )
     parser.add_argument(
+        "-L",
+        "--lint",
+        action="append",
+        metavar="CMD",
+        type=lambda s: s.split(),
+        default=[],
+        help=(
+            "Also run a linter on changed files. CMD can be a name of path of the "
+            "linter binary, or a full quoted command line"
+        ),
+    )
+    parser.add_argument(
         "-c",
         "--config",
         metavar="PATH",

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -102,6 +102,7 @@ class EditedLinenumsDiffer:
 
     @lru_cache(maxsize=1)
     def revision_vs_worktree(self, path_in_repo: Path, context_lines: int) -> List[int]:
+        """Return numbers of lines changed between HEAD and the working tree"""
         lines = (self.git_root / path_in_repo).read_text('utf-8').splitlines()
         return self.revision_vs_lines(path_in_repo, lines, context_lines)
 

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -103,7 +103,7 @@ class EditedLinenumsDiffer:
     @lru_cache(maxsize=1)
     def revision_vs_worktree(self, path_in_repo: Path, context_lines: int) -> List[int]:
         """Return numbers of lines changed between HEAD and the working tree"""
-        lines = (self.git_root / path_in_repo).read_text('utf-8').splitlines()
+        lines = (self.git_root / path_in_repo).read_text("utf-8").splitlines()
         return self.revision_vs_lines(path_in_repo, lines, context_lines)
 
     def revision_vs_lines(

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
 from typing import Iterable, List, Set
@@ -98,6 +99,11 @@ class EditedLinenumsDiffer:
 
     git_root: Path
     revision: str = "HEAD"
+
+    @lru_cache(maxsize=1)
+    def revision_vs_worktree(self, path_in_repo: Path, context_lines: int) -> List[int]:
+        lines = (self.git_root / path_in_repo).read_text('utf-8').splitlines()
+        return self.revision_vs_lines(path_in_repo, lines, context_lines)
 
     def revision_vs_lines(
         self, path_in_repo: Path, lines: List[str], context_lines: int

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -102,7 +102,7 @@ class EditedLinenumsDiffer:
 
     @lru_cache(maxsize=1)
     def revision_vs_worktree(self, path_in_repo: Path, context_lines: int) -> List[int]:
-        """Return numbers of lines changed between HEAD and the working tree"""
+        """Return numbers of lines changed between a given revision and the worktree"""
         lines = (self.git_root / path_in_repo).read_text("utf-8").splitlines()
         return self.revision_vs_lines(path_in_repo, lines, context_lines)
 

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -73,6 +73,8 @@ def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
         stdout=PIPE,
         encoding='utf-8',
     )
+    # assert needed for MyPy (see https://stackoverflow.com/q/57350490/15770)
+    assert linter_process.stdout is not None
     edited_linenums_differ = EditedLinenumsDiffer(git_root)
     for line in linter_process.stdout:
         path_in_repo, linter_error_linenum = _parse_linter_line(line, git_root)

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -38,11 +38,11 @@ def _parse_linter_line(
     #       linenum = 123
     #       description = "error: Foo"
     try:
-        location, _ = line[:-1].split(': ', 1)
-        path_str, linenum_bytes, *rest = location.split(':')
+        location, _ = line[:-1].split(": ", 1)
+        path_str, linenum_bytes, *rest = location.split(":")
         linenum = int(linenum_bytes)
         if len(rest) > 1:
-            raise ValueError('Too many colon-separated tokens')
+            raise ValueError("Too many colon-separated tokens")
         if len(rest) == 1:
             # Make sure it column looks like an int on "<path>:<linenum>:<column>"
             _column = int(rest[0])
@@ -51,7 +51,7 @@ def _parse_linter_line(
         # For example, on Mypy:
         # "Found XX errors in YY files (checked ZZ source files)"
         # "Success: no issues found in 1 source file"
-        logger.debug('Unparseable linter output: %s', line[:-1])
+        logger.debug("Unparseable linter output: %s", line[:-1])
         return None, None
     path_from_cwd = Path(path_str).absolute()
     path_in_repo = path_from_cwd.relative_to(git_root)
@@ -71,7 +71,7 @@ def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
     linter_process = Popen(
         cmdline + [str(git_root / path) for path in sorted(paths)],
         stdout=PIPE,
-        encoding='utf-8',
+        encoding="utf-8",
     )
     # assert needed for MyPy (see https://stackoverflow.com/q/57350490/15770)
     assert linter_process.stdout is not None
@@ -84,4 +84,4 @@ def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
             path_in_repo, context_lines=0
         )
         if linter_error_linenum in edited_linenums:
-            print(line, end='')
+            print(line, end="")

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -1,0 +1,85 @@
+"""Run arbitrary linters on given files in a Git repository
+
+This supports any linter which reports on standard output and has a fairly standard
+correct output format::
+
+    <path>:<linenum>: <description>
+    <path>:<linenum>:<column>: <description>
+
+For example, Mypy outputs::
+
+    module.py:57: error: Function is missing a type annotation for one or more arguments
+
+Pylint, on the other hand::
+
+    module.py:44:8: R1720: Unnecessary "elif" after "raise" (no-else-raise)
+
+All such output from the linter will be printed on the standard output
+provided that the ``<linenum>`` falls on a changed line.
+
+"""
+
+import logging
+from pathlib import Path
+from subprocess import PIPE, Popen
+from typing import List, Set, Tuple, Union
+
+from darker.git import EditedLinenumsDiffer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_linter_line(
+    line: str, git_root: Path
+) -> Union[Tuple[Path, int], Tuple[None, None]]:
+    # Parse an error/note line.
+    # Given: line == "dir/file.py:123: error: Foo\n"
+    # Sets: path = Path("abs/path/to/dir/file.py:123"
+    #       linenum = 123
+    #       description = "error: Foo"
+    try:
+        location, _ = line[:-1].split(': ', 1)
+        path_str, linenum_bytes, *rest = location.split(':')
+        linenum = int(linenum_bytes)
+        if len(rest) > 1:
+            raise ValueError('Too many colon-separated tokens')
+        if len(rest) == 1:
+            # Make sure it column looks like an int on "<path>:<linenum>:<column>"
+            _column = int(rest[0])
+    except ValueError:
+        # Encountered a non-parseable line which doesn't express a linting error.
+        # For example, on Mypy:
+        # "Found XX errors in YY files (checked ZZ source files)"
+        # "Success: no issues found in 1 source file"
+        logger.debug('Unparseable linter output: %s', line[:-1])
+        return None, None
+    path_from_cwd = Path(path_str).absolute()
+    path_in_repo = path_from_cwd.relative_to(git_root)
+    return path_in_repo, linenum
+
+
+def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
+    """Run the given linter and print linting errors falling on changed lines
+
+    :param cmdline: The command line for running the linter
+    :param git_root: The repository root for the changed files
+    :param paths: Paths of files to check, relative to ``git_root``
+
+    """
+    if not paths:
+        return
+    linter_process = Popen(
+        cmdline + [str(git_root / path) for path in sorted(paths)],
+        stdout=PIPE,
+        encoding='utf-8',
+    )
+    edited_linenums_differ = EditedLinenumsDiffer(git_root)
+    for line in linter_process.stdout:
+        path_in_repo, linter_error_linenum = _parse_linter_line(line, git_root)
+        if path_in_repo is None:
+            continue
+        edited_linenums = edited_linenums_differ.revision_vs_worktree(
+            path_in_repo, context_lines=0
+        )
+        if linter_error_linenum in edited_linenums:
+            print(line, end='')

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -132,21 +132,21 @@ def test_black_options_skip_string_normalization(git_repo, config, options, expe
 @pytest.mark.parametrize(
     'options, expect',
     [
-        (["a.py"], ({Path("a.py")}, "HEAD", False, {})),
-        (["--isort", "a.py"], ({Path("a.py")}, "HEAD", True, {})),
+        (["a.py"], ({Path("a.py")}, "HEAD", False, [], {})),
+        (["--isort", "a.py"], ({Path("a.py")}, "HEAD", True, [], {})),
         (
             ["--config", "my.cfg", "a.py"],
-            ({Path("a.py")}, "HEAD", False, {"config": "my.cfg"}),
+            ({Path("a.py")}, "HEAD", False, [], {"config": "my.cfg"}),
         ),
         (
             ["--line-length", "90", "a.py"],
-            ({Path("a.py")}, "HEAD", False, {"line_length": 90}),
+            ({Path("a.py")}, "HEAD", False, [], {"line_length": 90}),
         ),
         (
             ["--skip-string-normalization", "a.py"],
-            ({Path("a.py")}, "HEAD", False, {"skip_string_normalization": True}),
+            ({Path("a.py")}, "HEAD", False, [], {"skip_string_normalization": True}),
         ),
-        (["--diff", "a.py"], ({Path("a.py")}, "HEAD", False, {})),
+        (["--diff", "a.py"], ({Path("a.py")}, "HEAD", False, [], {})),
     ],
 )
 def test_options(options, expect):

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -102,10 +102,13 @@ edited_linenums_differ_cases = pytest.mark.parametrize(
 
 @edited_linenums_differ_cases
 def test_edited_linenums_differ_head_vs_worktree(git_repo, context_lines, expect):
+    """Tests for EditedLinenumsDiffer.head_vs_worktree()"""
     paths = git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
     paths['a.py'].write('1\n2\nthree\n4\n5\n6\nseven\n8\n')
     differ = EditedLinenumsDiffer(git_repo.root)
+
     result = differ.revision_vs_worktree(Path('a.py'), context_lines)
+
     assert result == expect
 
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -101,8 +101,8 @@ edited_linenums_differ_cases = pytest.mark.parametrize(
 
 
 @edited_linenums_differ_cases
-def test_edited_linenums_differ_head_vs_worktree(git_repo, context_lines, expect):
-    """Tests for EditedLinenumsDiffer.head_vs_worktree()"""
+def test_edited_linenums_differ_revision_vs_worktree(git_repo, context_lines, expect):
+    """Tests for EditedLinenumsDiffer.revision_vs_worktree()"""
     paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
     paths["a.py"].write("1\n2\nthree\n4\n5\n6\nseven\n8\n")
     differ = EditedLinenumsDiffer(git_repo.root)
@@ -113,9 +113,12 @@ def test_edited_linenums_differ_head_vs_worktree(git_repo, context_lines, expect
 
 
 @edited_linenums_differ_cases
-def test_edited_linenums_differ_head_vs_lines(git_repo, context_lines, expect):
+def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expect):
+    """Tests for EditedLinenumsDiffer.revision_vs_lines()"""
     git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
     lines = ['1', '2', 'three', '4', '5', '6', 'seven', '8']
     differ = EditedLinenumsDiffer(git_repo.root)
+
     result = differ.revision_vs_lines(Path("a.py"), lines, context_lines)
+
     assert result == expect

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -103,11 +103,11 @@ edited_linenums_differ_cases = pytest.mark.parametrize(
 @edited_linenums_differ_cases
 def test_edited_linenums_differ_head_vs_worktree(git_repo, context_lines, expect):
     """Tests for EditedLinenumsDiffer.head_vs_worktree()"""
-    paths = git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
-    paths['a.py'].write('1\n2\nthree\n4\n5\n6\nseven\n8\n')
+    paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
+    paths["a.py"].write("1\n2\nthree\n4\n5\n6\nseven\n8\n")
     differ = EditedLinenumsDiffer(git_repo.root)
 
-    result = differ.revision_vs_worktree(Path('a.py'), context_lines)
+    result = differ.revision_vs_worktree(Path("a.py"), context_lines)
 
     assert result == expect
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -101,6 +101,15 @@ edited_linenums_differ_cases = pytest.mark.parametrize(
 
 
 @edited_linenums_differ_cases
+def test_edited_linenums_differ_head_vs_worktree(git_repo, context_lines, expect):
+    paths = git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
+    paths['a.py'].write('1\n2\nthree\n4\n5\n6\nseven\n8\n')
+    differ = EditedLinenumsDiffer(git_repo.root)
+    result = differ.revision_vs_worktree(Path('a.py'), context_lines)
+    assert result == expect
+
+
+@edited_linenums_differ_cases
 def test_edited_linenums_differ_head_vs_lines(git_repo, context_lines, expect):
     git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
     lines = ['1', '2', 'three', '4', '5', '6', 'seven', '8']

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -10,13 +10,13 @@ from darker.linting import _parse_linter_line, run_linter
 
 
 @pytest.mark.parametrize(
-    'line, expect',
+    "line, expect",
     [
-        ('module.py:42: Description', (Path("module.py"), 42)),
-        ('module.py:42:5: Description', (Path("module.py"), 42)),
-        ('no-linenum.py: Description', (None, None)),
-        ('mod.py:invalid-linenum:5: Description', (None, None)),
-        ('invalid linter output', (None, None)),
+        ("module.py:42: Description", (Path("module.py"), 42)),
+        ("module.py:42:5: Description", (Path("module.py"), 42)),
+        ("no-linenum.py: Description", (None, None)),
+        ("mod.py:invalid-linenum:5: Description", (None, None)),
+        ("invalid linter output", (None, None)),
     ],
 )
 def test_parse_linter_line(git_repo, monkeypatch, line, expect):
@@ -27,55 +27,55 @@ def test_parse_linter_line(git_repo, monkeypatch, line, expect):
 
 
 @pytest.mark.parametrize(
-    '_descr, paths, location, expect',
+    "_descr, paths, location, expect",
     [
-        ("No files to check, no output", [], 'test.py:1:', []),
+        ("No files to check, no output", [], "test.py:1:", []),
         (
             "Check one file, report on a modified line in test.py",
-            ['one.py'],
-            'test.py:1:',
-            ['test.py:1: {git_repo.root}/one.py'],
+            ["one.py"],
+            "test.py:1:",
+            ["test.py:1: {git_repo.root}/one.py"],
         ),
         (
             "Check one file, report on a column of a modified line in test.py",
-            ['one.py'],
-            'test.py:1:42:',
-            ['test.py:1:42: {git_repo.root}/one.py'],
+            ["one.py"],
+            "test.py:1:42:",
+            ["test.py:1:42: {git_repo.root}/one.py"],
         ),
         (
             "No output if report is on an unmodified line in test.py",
-            ['one.py'],
-            'test.py:2:42:',
+            ["one.py"],
+            "test.py:2:42:",
             [],
         ),
         (
             "No output if report is on a column of an unmodified line in test.py",
-            ['one.py'],
-            'test.py:2:42:',
+            ["one.py"],
+            "test.py:2:42:",
             [],
         ),
         (
             "Check two files, rpeort on a modified line in test.py",
-            ['one.py', 'two.py'],
-            'test.py:1:',
-            ['test.py:1: {git_repo.root}/one.py {git_repo.root}/two.py'],
+            ["one.py", "two.py"],
+            "test.py:1:",
+            ["test.py:1: {git_repo.root}/one.py {git_repo.root}/two.py"],
         ),
         (
             "Check two files, rpeort on a column of a modified line in test.py",
-            ['one.py', 'two.py'],
-            'test.py:1:42:',
-            ['test.py:1:42: {git_repo.root}/one.py {git_repo.root}/two.py'],
+            ["one.py", "two.py"],
+            "test.py:1:42:",
+            ["test.py:1:42: {git_repo.root}/one.py {git_repo.root}/two.py"],
         ),
         (
             "No output if 2-file report is on an unmodified line in test.py",
-            ['one.py', 'two.py'],
-            'test.py:2:',
+            ["one.py", "two.py"],
+            "test.py:2:",
             [],
         ),
         (
             "No output if 2-file report is on a column of an unmodified line",
-            ['one.py', 'two.py'],
-            'test.py:2:42:',
+            ["one.py", "two.py"],
+            "test.py:2:42:",
             [],
         ),
     ],
@@ -94,8 +94,8 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
           test.py:1: git-repo-root/one.py git-repo-root/two.py
 
     """
-    src_paths = git_repo.add({'test.py': '1\n2\n'}, commit='Initial commit')
-    src_paths['test.py'].write('one\n2\n')
+    src_paths = git_repo.add({"test.py": "1\n2\n"}, commit="Initial commit")
+    src_paths["test.py"].write("one\n2\n")
     monkeypatch.chdir(git_repo.root)
     cmdline = ["echo", location]
 

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -1,0 +1,108 @@
+# pylint: disable=too-many-arguments
+
+"""Unit tests for :mod:`darker.linting`"""
+
+from pathlib import Path
+
+import pytest
+
+from darker.linting import _parse_linter_line, run_linter
+
+
+@pytest.mark.parametrize(
+    'line, expect',
+    [
+        ('module.py:42: Description', (Path("module.py"), 42)),
+        ('module.py:42:5: Description', (Path("module.py"), 42)),
+        ('no-linenum.py: Description', (None, None)),
+        ('mod.py:invalid-linenum:5: Description', (None, None)),
+        ('invalid linter output', (None, None)),
+    ],
+)
+def test_parse_linter_line(git_repo, monkeypatch, line, expect):
+    """Linter output is parsed correctly"""
+    monkeypatch.chdir(git_repo.root)
+    result = _parse_linter_line(line, git_repo.root)
+    assert result == expect
+
+
+@pytest.mark.parametrize(
+    '_descr, paths, location, expect',
+    [
+        ("No files to check, no output", [], 'test.py:1:', []),
+        (
+            "Check one file, report on a modified line in test.py",
+            ['one.py'],
+            'test.py:1:',
+            ['test.py:1: {git_repo.root}/one.py'],
+        ),
+        (
+            "Check one file, report on a column of a modified line in test.py",
+            ['one.py'],
+            'test.py:1:42:',
+            ['test.py:1:42: {git_repo.root}/one.py'],
+        ),
+        (
+            "No output if report is on an unmodified line in test.py",
+            ['one.py'],
+            'test.py:2:42:',
+            [],
+        ),
+        (
+            "No output if report is on a column of an unmodified line in test.py",
+            ['one.py'],
+            'test.py:2:42:',
+            [],
+        ),
+        (
+            "Check two files, rpeort on a modified line in test.py",
+            ['one.py', 'two.py'],
+            'test.py:1:',
+            ['test.py:1: {git_repo.root}/one.py {git_repo.root}/two.py'],
+        ),
+        (
+            "Check two files, rpeort on a column of a modified line in test.py",
+            ['one.py', 'two.py'],
+            'test.py:1:42:',
+            ['test.py:1:42: {git_repo.root}/one.py {git_repo.root}/two.py'],
+        ),
+        (
+            "No output if 2-file report is on an unmodified line in test.py",
+            ['one.py', 'two.py'],
+            'test.py:2:',
+            [],
+        ),
+        (
+            "No output if 2-file report is on a column of an unmodified line",
+            ['one.py', 'two.py'],
+            'test.py:2:42:',
+            [],
+        ),
+    ],
+)
+def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expect):
+    """Linter gets correct paths on command line and outputs just changed lines
+
+    We use ``echo`` as our "linter". It just adds the paths of each file to lint as an
+    "error" on a line of ``test.py``. What this test does is the equivalent of e.g.::
+
+    - creating a ``test.py`` such that the first line is modified after the last commit
+    - creating and committing ``one.py`` and ``two.py``
+    - running::
+
+          $ darker -L 'echo test.py:1:' one.py two.py
+          test.py:1: git-repo-root/one.py git-repo-root/two.py
+
+    """
+    src_paths = git_repo.add({'test.py': '1\n2\n'}, commit='Initial commit')
+    src_paths['test.py'].write('one\n2\n')
+    monkeypatch.chdir(git_repo.root)
+    cmdline = ["echo", location]
+
+    run_linter(cmdline, git_repo.root, {Path(p) for p in paths})
+
+    # We can now verify that the linter received the correct paths on its command line
+    # by checking standard output from the our `echo` "linter".
+    # The test cases also verify that only linter reports on modified lines are output.
+    result = capsys.readouterr().out.splitlines()
+    assert result == [line.format(git_repo=git_repo) for line in expect]

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -57,7 +57,7 @@ def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args
 def test_format_edited_parts_empty():
     with pytest.raises(ValueError):
 
-        list(darker.__main__.format_edited_parts([], "HEAD", False, {}))
+        list(darker.__main__.format_edited_parts([], "HEAD", False, [], {}))
 
 
 A_PY = ['import sys', 'import os', "print( '42')", '']
@@ -119,7 +119,7 @@ def test_format_edited_parts(git_repo, monkeypatch, enable_isort, black_args, ex
 
     changes = list(
         darker.__main__.format_edited_parts(
-            [Path("a.py")], "HEAD", enable_isort, black_args
+            [Path("a.py")], "HEAD", enable_isort, [], black_args
         )
     )
 
@@ -134,7 +134,9 @@ def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
     paths['a.py'].write('"properly"\n"formatted"\n')
     paths['b.py'].write('"not"\n"checked"\n')
 
-    result = list(darker.__main__.format_edited_parts([Path("a.py")], "HEAD", True, {}))
+    result = list(
+        darker.__main__.format_edited_parts([Path("a.py")], "HEAD", True, [], {})
+    )
 
     assert result == []
 


### PR DESCRIPTION
In addition to Black and Isort, darker gains here the ability to run a linter or linters, and only output linting errors/warnings for edited lines.

This has been tested with
- Pylint (`-L pylint`; requires an upcoming Pylint release with Isort 5 support)
- Mypy (`-L mypy`)
- Flake8 (`-L flake8`)

Probably others work as well – this only depends on the error/warning lines in the output to be in one of the following formats:
- `<path>:<linenum>: <description>`
- `<path>:<linenum>:<column>: <description>`