### PR TITLE
`--check` option, mirroring `black --check`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,12 @@ These features will be included in the next release:
 Added
 -----
 
+- ``--check`` returns 1 from the process but leaves files untouched if any file would
+  require reformatting
+
 Fixed
 -----
+
 
 1.0.0_ - 2020-07-15
 ===================

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,9 @@ The following `command line arguments`_ can also be used to modify the defaults:
 
 .. code-block:: shell
 
+     --check               Don't write the files back, just return the status.
+                           Return code 0 means nothing would change. Return code
+                           1 means some files would be reformatted.
      -c PATH, --config PATH
                            Ask `black` and `isort` to read configuration from PATH.
      -S, --skip-string-normalization
@@ -122,6 +125,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
 *New in version 1.0.0:* The ``-c``, ``-S`` and ``-l`` command line options.
 
 *New in version 1.0.0:* isort_ is configured with ``-c`` and ``-l``, too.
+
+*New in version 1.1.0:* The ``--check`` command line option.
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 def format_edited_parts(
     srcs: Iterable[Path],
-    isort: bool,
+    enable_isort: bool,
     black_args: BlackArgs,
     print_diff: bool,
     check_only: bool,
@@ -43,7 +43,7 @@ def format_edited_parts(
     10. write the reformatted source back to the original file
 
     :param srcs: Directories and files to re-format
-    :param isort: ``True`` to also run ``isort`` first on each changed file
+    :param enable_isort: ``True`` to also run ``isort`` first on each changed file
     :param black_args: Command-line arguments to send to ``black.FileMode``
     :param print_diff: ``True`` to output diffs instead of modifying source files
     :param check_only: ``True`` to not modify files but return a boolean stating whether
@@ -62,7 +62,7 @@ def format_edited_parts(
         worktree_content = src.read_text()
 
         # 1. run isort
-        if isort:
+        if enable_isort:
             edited_content = apply_isort(
                 worktree_content,
                 src,
@@ -79,7 +79,11 @@ def format_edited_parts(
             edited_linenums = edited_linenums_differ.head_vs_lines(
                 path_in_repo, edited_lines, context_lines
             )
-            if isort and not edited_linenums and edited_content == worktree_content:
+            if (
+                enable_isort
+                and not edited_linenums
+                and edited_content == worktree_content
+            ):
                 logger.debug("No changes in %s after isort", src)
                 break
 
@@ -190,5 +194,5 @@ def main(argv: List[str] = None) -> int:
 
 
 if __name__ == "__main__":
-    retval = main()
-    sys.exit(retval)
+    RETVAL = main()
+    sys.exit(RETVAL)

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -39,6 +39,15 @@ def parse_command_line(argv: List[str]) -> Namespace:
         help="Don't write the files back, just output a diff for each file on stdout",
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Don't write the files back, just return the status.  Return code 0 means"
+            " nothing would change.  Return code 1 means some files would be"
+            " reformatted."
+        ),
+    )
+    parser.add_argument(
         "-i", "--isort", action="store_true", help="".join(isort_help),
     )
     parser.add_argument(

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -104,6 +104,22 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
 def test_options(options, expect):
     with patch('darker.__main__.format_edited_parts') as format_edited_parts:
 
-        main(options)
+        retval = main(options)
 
     format_edited_parts.assert_called_once_with(*expect)
+    assert retval == 0
+
+
+@pytest.mark.parametrize(
+    'check, all_unchanged, expect_retval',
+    [(False, True, 0), (False, False, 0), (True, True, 0), (True, False, 1)],
+)
+def test_main_retval(check, all_unchanged, expect_retval):
+    """main() return value is correct based on --check and the need to reformat files"""
+    with patch("darker.__main__.format_edited_parts") as format_edited_parts:
+        format_edited_parts.return_value = all_unchanged
+        check_arg_maybe = ['--check'] if check else []
+
+        retval = main(check_arg_maybe + ['a.py'])
+
+    assert retval == expect_retval

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -84,21 +84,21 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
 @pytest.mark.parametrize(
     'options, expect',
     [
-        (['a.py'], ({Path('a.py')}, False, {}, False)),
-        (['--isort', 'a.py'], ({Path('a.py')}, True, {}, False)),
+        (['a.py'], ({Path('a.py')}, False, {}, False, False)),
+        (['--isort', 'a.py'], ({Path('a.py')}, True, {}, False, False)),
         (
             ['--config', 'my.cfg', 'a.py'],
-            ({Path('a.py')}, False, {'config': 'my.cfg'}, False),
+            ({Path('a.py')}, False, {'config': 'my.cfg'}, False, False),
         ),
         (
             ['--line-length', '90', 'a.py'],
-            ({Path('a.py')}, False, {'line_length': 90}, False),
+            ({Path('a.py')}, False, {'line_length': 90}, False, False),
         ),
         (
             ['--skip-string-normalization', 'a.py'],
-            ({Path('a.py')}, False, {'skip_string_normalization': True}, False),
+            ({Path('a.py')}, False, {'skip_string_normalization': True}, False, False),
         ),
-        (['--diff', 'a.py'], ({Path('a.py')}, False, {}, True)),
+        (['--diff', 'a.py'], ({Path('a.py')}, False, {}, True, False)),
     ],
 )
 def test_options(options, expect):

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -57,7 +57,7 @@ def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args
 def test_format_edited_parts_empty():
     with pytest.raises(ValueError):
 
-        darker.__main__.format_edited_parts([], False, {}, True)
+        darker.__main__.format_edited_parts([], False, {}, True, False)
 
 
 A_PY = ['import sys', 'import os', "print( '42')", '']
@@ -135,7 +135,9 @@ def test_format_edited_parts(
     paths = git_repo.add({'a.py': '\n', 'b.py': '\n'}, commit='Initial commit')
     paths['a.py'].write('\n'.join(A_PY))
     paths['b.py'].write('print(42 )\n')
-    darker.__main__.format_edited_parts([Path('a.py')], isort, black_args, print_diff)
+    darker.__main__.format_edited_parts(
+        [Path('a.py')], isort, black_args, print_diff, False
+    )
     stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
     assert stdout.split('\n') == expect_stdout
     assert paths['a.py'].readlines(cr=False) == expect_a_py

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -106,7 +106,7 @@ A_PY_DIFF_BLACK_ISORT = [
 
 
 @pytest.mark.parametrize(
-    'isort, black_args, print_diff, expect_stdout, expect_a_py',
+    'enable_isort, black_args, print_diff, expect_stdout, expect_a_py',
     [
         (False, {}, True, A_PY_DIFF_BLACK, A_PY),
         (True, {}, False, [''], A_PY_BLACK_ISORT,),
@@ -125,7 +125,7 @@ def test_format_edited_parts(
     git_repo,
     monkeypatch,
     capsys,
-    isort,
+    enable_isort,
     black_args,
     print_diff,
     expect_stdout,
@@ -137,7 +137,7 @@ def test_format_edited_parts(
     paths['b.py'].write('print(42 )\n')
 
     all_unchanged = darker.__main__.format_edited_parts(
-        [Path('a.py')], isort, black_args, print_diff, False
+        [Path('a.py')], enable_isort, black_args, print_diff, False
     )
 
     stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
@@ -148,6 +148,7 @@ def test_format_edited_parts(
 
 
 def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
+    """``format_edited_parts()`` returns ``True`` if no reformatting was needed"""
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'a.py': 'pass\n', 'b.py': 'pass\n'}, commit='Initial commit')
     paths['a.py'].write('"properly"\n"formatted"\n')

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -57,11 +57,12 @@ def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args
 def test_format_edited_parts_empty():
     with pytest.raises(ValueError):
 
-        darker.__main__.format_edited_parts([], False, {}, True, False)
+        list(darker.__main__.format_edited_parts([], False, {}))
 
 
 A_PY = ['import sys', 'import os', "print( '42')", '']
 A_PY_BLACK = ['import sys', 'import os', '', 'print("42")', '']
+A_PY_BLACK_UNNORMALIZE = ['import sys', 'import os', '', "print('42')", '']
 A_PY_BLACK_ISORT = ['import os', 'import sys', '', 'print("42")', '']
 
 A_PY_DIFF_BLACK = [
@@ -106,57 +107,100 @@ A_PY_DIFF_BLACK_ISORT = [
 
 
 @pytest.mark.parametrize(
-    'enable_isort, black_args, print_diff, expect_stdout, expect_a_py',
+    'enable_isort, black_args, expect',
     [
-        (False, {}, True, A_PY_DIFF_BLACK, A_PY),
-        (True, {}, False, [''], A_PY_BLACK_ISORT,),
-        (
-            False,
-            {'skip_string_normalization': True},
-            True,
-            A_PY_DIFF_BLACK_NO_STR_NORMALIZE,
-            A_PY,
-        ),
-        (False, {}, False, [''], A_PY_BLACK),
-        (True, {}, True, A_PY_DIFF_BLACK_ISORT, A_PY,),
+        (False, {}, A_PY_BLACK),
+        (True, {}, A_PY_BLACK_ISORT),
+        (False, {'skip_string_normalization': True}, A_PY_BLACK_UNNORMALIZE),
     ],
 )
-def test_format_edited_parts(
-    git_repo,
-    monkeypatch,
-    capsys,
-    enable_isort,
-    black_args,
-    print_diff,
-    expect_stdout,
-    expect_a_py,
-):
+def test_format_edited_parts(git_repo, monkeypatch, enable_isort, black_args, expect):
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'a.py': '\n', 'b.py': '\n'}, commit='Initial commit')
     paths['a.py'].write('\n'.join(A_PY))
     paths['b.py'].write('print(42 )\n')
 
-    all_unchanged = darker.__main__.format_edited_parts(
-        [Path('a.py')], enable_isort, black_args, print_diff, False
+    changes = list(
+        darker.__main__.format_edited_parts([Path('a.py')], enable_isort, black_args)
     )
 
-    stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
-    assert stdout.split('\n') == expect_stdout
-    assert paths['a.py'].readlines(cr=False) == expect_a_py
-    assert paths['b.py'].readlines(cr=False) == ['print(42 )', '']
-    assert not all_unchanged
+    expect_changes = [(paths['a.py'], '\n'.join(A_PY), '\n'.join(expect), expect[:-1])]
+    assert changes == expect_changes
 
 
 def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
-    """``format_edited_parts()`` returns ``True`` if no reformatting was needed"""
+    """``format_edited_parts()`` yields nothing if no reformatting was needed"""
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'a.py': 'pass\n', 'b.py': 'pass\n'}, commit='Initial commit')
     paths['a.py'].write('"properly"\n"formatted"\n')
     paths['b.py'].write('"not"\n"checked"\n')
 
-    all_unchanged = darker.__main__.format_edited_parts(
-        [Path('a.py')], True, {}, False, False
+    result = list(darker.__main__.format_edited_parts([Path('a.py')], True, {}))
+
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    'arguments, expect_stdout, expect_a_py, expect_retval',
+    [
+        (['--diff'], A_PY_DIFF_BLACK, A_PY, 0),
+        (['--isort'], [''], A_PY_BLACK_ISORT, 0),
+        (
+            ['--skip-string-normalization', '--diff'],
+            A_PY_DIFF_BLACK_NO_STR_NORMALIZE,
+            A_PY,
+            0,
+        ),
+        ([], [''], A_PY_BLACK, 0),
+        (['--isort', '--diff'], A_PY_DIFF_BLACK_ISORT, A_PY, 0),
+        (['--check'], [''], A_PY, 1),
+        (['--check', '--diff'], A_PY_DIFF_BLACK, A_PY, 1),
+        (['--check', '--isort'], [''], A_PY, 1),
+        (['--check', '--diff', '--isort'], A_PY_DIFF_BLACK_ISORT, A_PY, 1),
+    ],
+)
+def test_main(
+    git_repo, monkeypatch, capsys, arguments, expect_stdout, expect_a_py, expect_retval
+):  # pylint: disable=too-many-arguments
+    """Main function outputs diffs and modifies files correctly"""
+    monkeypatch.chdir(git_repo.root)
+    paths = git_repo.add({'a.py': '\n', 'b.py': '\n'}, commit='Initial commit')
+    paths['a.py'].write('\n'.join(A_PY))
+    paths['b.py'].write('print(42 )\n')
+
+    retval = darker.__main__.main(arguments + ['a.py'])
+
+    stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
+    assert stdout.split('\n') == expect_stdout
+    assert paths['a.py'].readlines(cr=False) == expect_a_py
+    assert paths['b.py'].readlines(cr=False) == ['print(42 )', '']
+    assert retval == expect_retval
+
+
+def test_output_diff(capsys):
+    """output_diff() prints Black-style diff output"""
+    darker.__main__.print_diff(
+        Path('a.py'),
+        'unchanged\nremoved\nkept 1\n2\n3\n4\n5\n6\n7\nchanged\n',
+        ['inserted', 'unchanged', 'kept 1', '2', '3', '4', '5', '6', '7', 'Changed'],
     )
 
-    assert paths['a.py'].read() == '"properly"\n"formatted"\n'
-    assert all_unchanged
+    assert capsys.readouterr().out.splitlines() == [
+        '--- a.py',
+        '+++ a.py',
+        '@@ -1,5 +1,5 @@',
+        '',
+        '+inserted',
+        ' unchanged',
+        '-removed',
+        ' kept 1',
+        ' 2',
+        ' 3',
+        '@@ -7,4 +7,4 @@',
+        '',
+        ' 5',
+        ' 6',
+        ' 7',
+        '-changed',
+        '+Changed',
+    ]

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.1.dev"
+__version__ = "1.1.0.dev"

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,1 +1,3 @@
+"""The version number for Darker is governed by this file"""
+
 __version__ = "1.1.0.dev"


### PR DESCRIPTION
`--check` skips writing changes to files, and returns a return value of 1 from the `darker` process in case any modified lines in any of the given files are not already properly formatted.

The return value will allow using `darker` with more different tools. It for example opens the possibility for a `pytest-darker` plugin.