### PR TITLE
Paths from `--diff` now relative to workdir (#34)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Added
 
 Fixed
 -----
+- Paths from ``--diff`` are now relative to current working directory, similar to output
+  from ``black --diff``
+
 
 
 1.0.0_ - 2020-07-15

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -140,10 +140,9 @@ def modify_file(path: Path, new_content: str) -> None:
 
 def print_diff(path: Path, old_content: str, new_lines: List[str]) -> None:
     """Print ``black --diff`` style output for the changes"""
+    relative_path = path.resolve().relative_to(Path.cwd()).as_posix()
     difflines = list(
-        unified_diff(
-            old_content.splitlines(), new_lines, path.as_posix(), path.as_posix(),
-        )
+        unified_diff(old_content.splitlines(), new_lines, relative_path, relative_path)
     )
     header1, header2, *rest = difflines
     print(header1, end="")

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -66,8 +66,8 @@ A_PY_BLACK_UNNORMALIZE = ['import sys', 'import os', '', "print('42')", '']
 A_PY_BLACK_ISORT = ['import os', 'import sys', '', 'print("42")', '']
 
 A_PY_DIFF_BLACK = [
-    '--- /a.py',
-    '+++ /a.py',
+    '--- a.py',
+    '+++ a.py',
     '@@ -1,3 +1,4 @@',
     '',
     ' import sys',
@@ -79,8 +79,8 @@ A_PY_DIFF_BLACK = [
 ]
 
 A_PY_DIFF_BLACK_NO_STR_NORMALIZE = [
-    '--- /a.py',
-    '+++ /a.py',
+    '--- a.py',
+    '+++ a.py',
     '@@ -1,3 +1,4 @@',
     '',
     ' import sys',
@@ -92,8 +92,8 @@ A_PY_DIFF_BLACK_NO_STR_NORMALIZE = [
 ]
 
 A_PY_DIFF_BLACK_ISORT = [
-    '--- /a.py',
-    '+++ /a.py',
+    '--- a.py',
+    '+++ a.py',
     '@@ -1,3 +1,4 @@',
     '',
     '+import os',


### PR DESCRIPTION
This is now similar to `black --diff`.

Fixes #34.