### PR TITLE
WIP: Add a Pytest plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 - ``--check`` returns 1 from the process but leaves files untouched if any file would
   require reformatting
+- Include a Pytest plugin. ``pytest --darker`` causes a test failure for each file which
+  needs reformatting.
 
 Fixed
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,12 @@ These features will be included in the next release:
 Added
 -----
 
+- ``--check`` returns 1 from the process but leaves files untouched if any file would
+  require reformatting
+
 Fixed
 -----
+
 
 1.0.0_ - 2020-07-15
 ===================

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,9 @@ The following `command line arguments`_ can also be used to modify the defaults:
 
 .. code-block:: shell
 
+     --check               Don't write the files back, just return the status.
+                           Return code 0 means nothing would change. Return code
+                           1 means some files would be reformatted.
      -c PATH, --config PATH
                            Ask `black` and `isort` to read configuration from PATH.
      -S, --skip-string-normalization
@@ -122,6 +125,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
 *New in version 1.0.0:* The ``-c``, ``-S`` and ``-l`` command line options.
 
 *New in version 1.0.0:* isort_ is configured with ``-c`` and ``-l``, too.
+
+*New in version 1.1.0:* The ``--check`` command line option.
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,6 +38,11 @@ disallow_untyped_defs = False
 [mypy-darker.utils]
 warn_return_any = False
 
+[mypy-darker.pytest_darker]
+disallow_any_decorated = False
+disallow_any_explicit = False
+disallow_untyped_calls = False
+
 [mypy-black.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ isort =
     isort>=5.0.1
 test =
     mypy>=0.782
-    pytest
+    pytest>=6.0.1
     pytest-black
     pytest-isort>=1.1.0
     pytest-mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ pytest11 =
 isort =
     isort>=5.0.1
 test =
+    mypy>=0.782
     pytest
     pytest-black
     pytest-isort>=1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ where = src
 [options.entry_points]
 console_scripts =
     darker = darker.__main__:main
+pytest11 =
+    darker = darker.pytest_darker
 
 [options.extras_require]
 isort =

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -23,8 +23,12 @@ logger = logging.getLogger(__name__)
 
 
 def format_edited_parts(
-    srcs: Iterable[Path], isort: bool, black_args: BlackArgs, print_diff: bool,
-) -> None:
+    srcs: Iterable[Path],
+    isort: bool,
+    black_args: BlackArgs,
+    print_diff: bool,
+    check_only: bool,
+) -> bool:
     """Black (and optional isort) formatting for chunks with edits since the last commit
 
     1. run isort on each edited file
@@ -46,6 +50,10 @@ def format_edited_parts(
     :param isort: ``True`` to also run ``isort`` first on each changed file
     :param black_args: Command-line arguments to send to ``black.FileMode``
     :param print_diff: ``True`` to output diffs instead of modifying source files
+    :param check_only: ``True`` to not modify files but return a boolean stating whether
+                       all files are already Black formatted
+    :return: ``True`` if all files were already properly formatted, or ``False`` if at
+             least one file was (or should be) reformatted
 
     """
     git_root = get_common_root(srcs)
@@ -66,6 +74,7 @@ def format_edited_parts(
     else:
         edited_srcs = worktree_srcs
 
+    all_unchanged = True
     for src_relative, edited_content in edited_srcs.items():
         max_context_lines = len(edited_content)
         for context_lines in range(max_context_lines + 1):
@@ -131,9 +140,10 @@ def format_edited_parts(
                 continue
             else:
                 # 10. A re-formatted Python file which produces an identical AST was
-                #     created successfully - write an updated file
-                #     or print the diff
-                if print_diff:
+                #     created successfully - write an updated file or print the diff
+                #     if there were any changes to the original
+                if result_str != worktree_srcs[src_relative]:
+                    all_unchanged = False
                     difflines = list(
                         unified_diff(
                             worktree_srcs[src_relative].splitlines(),
@@ -142,19 +152,26 @@ def format_edited_parts(
                             src.as_posix(),
                         )
                     )
-                    if len(difflines) > 2:
+                    if print_diff:
                         h1, h2, *rest = difflines
                         print(h1, end="")
                         print(h2, end="")
                         print("\n".join(rest))
-                else:
-                    logger.info("Writing %s bytes into %s", len(result_str), src)
-                    src.write_text(result_str)
+                    if not check_only and not print_diff:
+                        logger.info("Writing %s bytes into %s", len(result_str), src)
+                        src.write_text(result_str)
                 break
+    return all_unchanged
 
 
-def main(argv: List[str] = None) -> None:
-    """Parse the command line and apply black formatting for each source file"""
+def main(argv: List[str] = None) -> int:
+    """Parse the command line and apply black formatting for each source file
+
+    :param argv: The command line arguments to the ``darker`` command
+    :return: 1 if the ``--check`` argument was provided and at least one file was (or
+             should be) reformatted; 0 otherwise.
+
+    """
     if argv is None:
         argv = sys.argv[1:]
     args = parse_command_line(argv)
@@ -180,8 +197,12 @@ def main(argv: List[str] = None) -> None:
         black_args["skip_string_normalization"] = args.skip_string_normalization
 
     paths = {Path(p) for p in args.src}
-    format_edited_parts(paths, args.isort, black_args, args.diff)
+    all_unchanged = format_edited_parts(
+        paths, args.isort, black_args, args.diff, args.check
+    )
+    return 1 if args.check and not all_unchanged else 0
 
 
 if __name__ == "__main__":
-    main()
+    retval = main()
+    sys.exit(retval)

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def format_edited_parts(
     srcs: Iterable[Path],
-    isort: bool,
+    enable_isort: bool,
     black_args: BlackArgs,
     print_diff: bool,
     check_only: bool,
@@ -47,7 +47,7 @@ def format_edited_parts(
     10. write the reformatted source back to the original file
 
     :param srcs: Directories and files to re-format
-    :param isort: ``True`` to also run ``isort`` first on each changed file
+    :param enable_isort: ``True`` to also run ``isort`` first on each changed file
     :param black_args: Command-line arguments to send to ``black.FileMode``
     :param print_diff: ``True`` to output diffs instead of modifying source files
     :param check_only: ``True`` to not modify files but return a boolean stating whether
@@ -64,7 +64,7 @@ def format_edited_parts(
     worktree_srcs = {src: (git_root / src).read_text() for src in changed_files}
 
     # 1. run isort
-    if isort:
+    if enable_isort:
         config = black_args.get("config")
         line_length = black_args.get("line_length")
         edited_srcs = {
@@ -90,7 +90,7 @@ def format_edited_parts(
                 opcodes_to_edit_linenums(edited_opcodes, context_lines)
             )
             if (
-                isort
+                enable_isort
                 and not edited_linenums
                 and edited_content == worktree_srcs[src_relative]
             ):
@@ -204,5 +204,5 @@ def main(argv: List[str] = None) -> int:
 
 
 if __name__ == "__main__":
-    retval = main()
-    sys.exit(retval)
+    RETVAL = main()
+    sys.exit(RETVAL)

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -39,6 +39,15 @@ def parse_command_line(argv: List[str]) -> Namespace:
         help="Don't write the files back, just output a diff for each file on stdout",
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Don't write the files back, just return the status.  Return code 0 means"
+            " nothing would change.  Return code 1 means some files would be"
+            " reformatted."
+        ),
+    )
+    parser.add_argument(
         "-i", "--isort", action="store_true", help="".join(isort_help),
     )
     parser.add_argument(

--- a/src/darker/pytest_darker.py
+++ b/src/darker/pytest_darker.py
@@ -1,0 +1,128 @@
+import re
+import subprocess
+import sys
+from typing import Any, Optional, Tuple, Union, cast
+
+import py
+import pytest
+import toml
+from _pytest._code.code import ExceptionInfo, TerminalRepr
+from _pytest.cacheprovider import Cache
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+
+HISTKEY = "darker/mtimes"
+
+
+class DarkerError(Exception):
+    pass
+
+
+class DarkerItem(pytest.Item, pytest.File):
+    def __init__(self, fspath: py.path.local, parent: pytest.Session):
+        super(DarkerItem, self).__init__(fspath, parent)
+        self._nodeid += "::DARKER"
+        self.add_marker("darker")
+        try:
+            with open("pyproject.toml") as toml_file:
+                self.pyproject = toml.load(toml_file)["tool"]["darker"]
+        except Exception:
+            self.pyproject = {}
+
+    @classmethod
+    def from_parent(  # type: ignore[override]
+        cls, parent: pytest.Session, *, fspath: py.path.local, **kw: Any
+    ) -> "DarkerItem":
+        """The public constructor"""
+        return cast(DarkerItem, super().from_parent(parent=parent, fspath=fspath, **kw))
+
+    def setup(self) -> None:
+        pytest.importorskip("darker")
+        mtimes = getattr(self.config, "_darkermtimes", {})
+        self._darkermtime = self.fspath.mtime()
+        old = mtimes.get(str(self.fspath), 0)
+        if self._darkermtime == old:
+            pytest.skip("file(s) previously passed darker format checks")
+
+        if self._skip_test():
+            pytest.skip("file(s) excluded by pyproject.toml")
+
+    def runtest(self) -> None:
+        cmd = [
+            sys.executable,
+            "-m",
+            "darker",
+            "--check",
+            "--diff",
+            "--quiet",
+            str(self.fspath),
+        ]
+        try:
+            subprocess.run(
+                cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True
+            )
+        except subprocess.CalledProcessError as e:
+            raise DarkerError(e)
+
+        mtimes = getattr(self.config, "_darkermtimes", {})
+        mtimes[str(self.fspath)] = self._darkermtime
+
+    def repr_failure(  # type: ignore[override]
+        self, excinfo: ExceptionInfo[BaseException]
+    ) -> Union[str, TerminalRepr]:
+        if excinfo.errisinstance(DarkerError):
+            return cast(TerminalRepr, excinfo.value.args[0].stdout)
+        return super(DarkerItem, self).repr_failure(excinfo)
+
+    def reportinfo(self) -> Tuple[Union[py.path.local, str], Optional[int], str]:
+        return self.fspath, -1, "Darker format check"
+
+    def _skip_test(self) -> bool:
+        return self._excluded() or (not self._included())
+
+    def _included(self) -> bool:
+        if "include" not in self.pyproject:
+            return True
+        return bool(re.search(self.pyproject["include"], str(self.fspath)))
+
+    def _excluded(self) -> bool:
+        if "exclude" not in self.pyproject:
+            return False
+        return bool(re.search(self.pyproject["exclude"], str(self.fspath)))
+
+
+def pytest_addoption(parser: Parser) -> None:
+    group = parser.getgroup("general")
+    group.addoption(
+        "--darker", action="store_true", help="enable format checking with darker"
+    )
+
+
+def pytest_collect_file(
+    path: py.path.local, parent: pytest.Session
+) -> Optional[DarkerItem]:
+    config = parent.config
+    if config.option.darker and path.ext == ".py":
+        if hasattr(DarkerItem, "from_parent"):
+            return DarkerItem.from_parent(parent, fspath=path)
+        else:
+            return DarkerItem(path, parent)
+    else:
+        return None
+
+
+def pytest_configure(config: Config) -> None:
+    # load cached mtimes at session startup
+    if config.option.darker and hasattr(config, "cache"):
+        assert isinstance(config.cache, Cache)
+        config._darkermtimes = config.cache.get(  # type: ignore[attr-defined]
+            HISTKEY, {}
+        )
+    config.addinivalue_line("markers", "darker: enable format checking with darker")
+
+
+def pytest_unconfigure(config: Config) -> None:
+    # save cached mtimes at end of session
+    if hasattr(config, "_darkermtimes"):
+        assert isinstance(config.cache, Cache)
+        config.cache.set(HISTKEY, config._darkermtimes)  # type: ignore[attr-defined]

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -104,6 +104,22 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
 def test_options(options, expect):
     with patch('darker.__main__.format_edited_parts') as format_edited_parts:
 
-        main(options)
+        retval = main(options)
 
     format_edited_parts.assert_called_once_with(*expect)
+    assert retval == 0
+
+
+@pytest.mark.parametrize(
+    'check, all_unchanged, expect_retval',
+    [(False, True, 0), (False, False, 0), (True, True, 0), (True, False, 1)],
+)
+def test_main_retval(check, all_unchanged, expect_retval):
+    """main() return value is correct based on --check and the need to reformat files"""
+    with patch("darker.__main__.format_edited_parts") as format_edited_parts:
+        format_edited_parts.return_value = all_unchanged
+        check_arg_maybe = ['--check'] if check else []
+
+        retval = main(check_arg_maybe + ['a.py'])
+
+    assert retval == expect_retval

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -84,21 +84,21 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
 @pytest.mark.parametrize(
     'options, expect',
     [
-        (['a.py'], ({Path('a.py')}, False, {}, False)),
-        (['--isort', 'a.py'], ({Path('a.py')}, True, {}, False)),
+        (['a.py'], ({Path('a.py')}, False, {}, False, False)),
+        (['--isort', 'a.py'], ({Path('a.py')}, True, {}, False, False)),
         (
             ['--config', 'my.cfg', 'a.py'],
-            ({Path('a.py')}, False, {'config': 'my.cfg'}, False),
+            ({Path('a.py')}, False, {'config': 'my.cfg'}, False, False),
         ),
         (
             ['--line-length', '90', 'a.py'],
-            ({Path('a.py')}, False, {'line_length': 90}, False),
+            ({Path('a.py')}, False, {'line_length': 90}, False, False),
         ),
         (
             ['--skip-string-normalization', 'a.py'],
-            ({Path('a.py')}, False, {'skip_string_normalization': True}, False),
+            ({Path('a.py')}, False, {'skip_string_normalization': True}, False, False),
         ),
-        (['--diff', 'a.py'], ({Path('a.py')}, False, {}, True)),
+        (['--diff', 'a.py'], ({Path('a.py')}, False, {}, True, False)),
     ],
 )
 def test_options(options, expect):

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -57,7 +57,7 @@ def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args
 def test_format_edited_parts_empty():
     with pytest.raises(ValueError):
 
-        darker.__main__.format_edited_parts([], False, {}, True)
+        darker.__main__.format_edited_parts([], False, {}, True, False)
 
 
 A_PY = ['import sys', 'import os', "print( '42')", '']
@@ -135,7 +135,9 @@ def test_format_edited_parts(
     paths = git_repo.add({'a.py': '\n', 'b.py': '\n'}, commit='Initial commit')
     paths['a.py'].write('\n'.join(A_PY))
     paths['b.py'].write('print(42 )\n')
-    darker.__main__.format_edited_parts([Path('a.py')], isort, black_args, print_diff)
+    darker.__main__.format_edited_parts(
+        [Path('a.py')], isort, black_args, print_diff, False
+    )
     stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
     assert stdout.split('\n') == expect_stdout
     assert paths['a.py'].readlines(cr=False) == expect_a_py

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -148,6 +148,7 @@ def test_format_edited_parts(
 
 
 def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
+    """``format_edited_parts()`` returns ``True`` if no reformatting was needed"""
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'a.py': 'pass\n', 'b.py': 'pass\n'}, commit='Initial commit')
     paths['a.py'].write('"properly"\n"formatted"\n')

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.1.dev"
+__version__ = "1.1.0.dev"

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,1 +1,3 @@
+"""The version number for Darker is governed by this file"""
+
 __version__ = "1.1.0.dev"


### PR DESCRIPTION
`pytest --darker` now runs `darker --check --diff` for each Python source file and reports test failures for required reformatting on any modified lines.

#36 should be merged before this PR is reviewed.

**Edit:** Create a separate `pytest-darker` package and repository instead?

**Edit 2:** [pytest-darker](https://github.com/akaihola/pytest-darker) created. Requires the upcoming Darker 1.1.0 release with `--check` support.