### PR TITLE
Allow to give a commitish reference.

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -192,7 +192,7 @@ def main(argv: List[str] = None) -> int:
     # We need both forms when showing diffs or modifying files.
     # Pass them both on to avoid back-and-forth conversion.
     for path, old_content, new_content, new_lines in format_edited_parts(
-        paths, args.isort, black_args, commitish=args.commitish[0]
+        paths, args.isort, black_args, args.commitish[0]
     ):
         some_files_changed = True
         if args.diff:

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def format_edited_parts(
-    srcs: Iterable[Path], enable_isort: bool, black_args: BlackArgs, commitish:str
+    srcs: Iterable[Path], enable_isort: bool, black_args: BlackArgs, commitish: str
 ) -> Generator[Tuple[Path, str, str, List[str]], None, None]:
     """Black (and optional isort) formatting for chunks with edits since the last commit
 

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -43,7 +43,7 @@ def parse_command_line(argv: List[str]) -> Namespace:
         help="Commit to consider for the diff, default to HEAD (unstaged changes).",
         nargs=1,
         default=[''],
-        metavar='COMMITISH'
+        metavar='COMMITISH',
     )
     parser.add_argument(
         "--check",

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -39,6 +39,13 @@ def parse_command_line(argv: List[str]) -> Namespace:
         help="Don't write the files back, just output a diff for each file on stdout",
     )
     parser.add_argument(
+        "--commitish",
+        help="Commit to consider for the diff, default to HEAD (unstaged changes).",
+        nargs=1,
+        default=[''],
+        metavar='COMMITISH'
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help=(

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -26,7 +26,9 @@ def should_reformat_file(path: Path) -> bool:
     return path.exists() and path.suffix == ".py"
 
 
-def git_diff_name_only(paths: Iterable[Path], cwd: Path, commitish=None) -> Set[Path]:
+def git_diff_name_only(
+    paths: Iterable[Path], cwd: Path, commitish: str = ''
+) -> Set[Path]:
     """Run ``git diff --name-only`` and return file names from the output
 
     Return file names relative to the Git repository root.

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -10,7 +10,7 @@ from darker.diff import diff_and_get_opcodes, opcodes_to_edit_linenums
 logger = logging.getLogger(__name__)
 
 
-def git_get_unmodified_content(path: Path, cwd: Path, commitish:str) -> List[str]:
+def git_get_unmodified_content(path: Path, cwd: Path, commitish: str) -> List[str]:
     """Get unmodified text lines of a file at Git HEAD
 
     :param path: The relative path of the file in the Git repository
@@ -37,17 +37,12 @@ def git_diff_name_only(paths: Iterable[Path], cwd: Path, commitish=None) -> Set[
 
     """
     relative_paths = {p.resolve().relative_to(cwd) for p in paths}
-    cmd = [
-        "git",
-        "diff",
-        "--name-only",
-        "--relative"]
+    cmd = ["git", "diff", "--name-only", "--relative"]
     if commitish:
         cmd.append(commitish)
-    cmd.extend([
-        "--",
-        *[str(path) for path in relative_paths],
-    ])
+    cmd.extend(
+        ["--", *[str(path) for path in relative_paths],]
+    )
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     lines = check_output(cmd, cwd=str(cwd)).decode("utf-8").splitlines()
     changed_paths = (Path(line) for line in lines)
@@ -64,7 +59,9 @@ class EditedLinenumsDiffer:
     def head_vs_lines(
         self, path_in_repo: Path, lines: List[str], context_lines: int
     ) -> List[int]:
-        head_lines = git_get_unmodified_content(path_in_repo, self._git_root, self._commitish)
+        head_lines = git_get_unmodified_content(
+            path_in_repo, self._git_root, self._commitish
+        )
 
         edited_opcodes = diff_and_get_opcodes(head_lines, lines)
         return list(opcodes_to_edit_linenums(edited_opcodes, context_lines))

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -84,21 +84,25 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
 @pytest.mark.parametrize(
     'options, expect',
     [
-        (['a.py'], ({Path('a.py')}, False, {})),
-        (['--isort', 'a.py'], ({Path('a.py')}, True, {})),
+        (['a.py'], ({Path('a.py')}, False, {}, ''),),
+        (['--isort', 'a.py'], ({Path('a.py')}, True, {}, '')),
         (
             ['--config', 'my.cfg', 'a.py'],
-            ({Path('a.py')}, False, {'config': 'my.cfg'}),
+            ({Path('a.py')}, False, {'config': 'my.cfg'}, ''),
         ),
         (
             ['--line-length', '90', 'a.py'],
-            ({Path('a.py')}, False, {'line_length': 90}),
+            ({Path('a.py')}, False, {'line_length': 90}, ''),
         ),
         (
             ['--skip-string-normalization', 'a.py'],
-            ({Path('a.py')}, False, {'skip_string_normalization': True}),
+            ({Path('a.py')}, False, {'skip_string_normalization': True}, ''),
         ),
-        (['--diff', 'a.py'], ({Path('a.py')}, False, {})),
+        (['--diff', 'a.py'], ({Path('a.py')}, False, {}, '')),
+        (
+            ['--diff', 'a.py', '--commitish', 'HEAD~1'],
+            ({Path('a.py')}, False, {}, 'HEAD~1'),
+        ),
     ],
 )
 def test_options(options, expect):

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -14,7 +14,9 @@ def test_get_unmodified_content(git_repo):
     paths = git_repo.add({'my.txt': 'original content'}, commit='Initial commit')
     paths['my.txt'].write('new content')
 
-    original_content = git_get_unmodified_content(Path('my.txt'), cwd=git_repo.root)
+    original_content = git_get_unmodified_content(
+        Path('my.txt'), cwd=git_repo.root, commitish=''
+    )
 
     assert original_content == ['original content']
 
@@ -93,6 +95,6 @@ edited_linenums_differ_cases = pytest.mark.parametrize(
 def test_edited_linenums_differ_head_vs_lines(git_repo, context_lines, expect):
     git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
     lines = ['1', '2', 'three', '4', '5', '6', 'seven', '8']
-    differ = EditedLinenumsDiffer(git_repo.root)
+    differ = EditedLinenumsDiffer(git_repo.root, commitish='')
     result = differ.head_vs_lines(Path('a.py'), lines, context_lines)
     assert result == expect


### PR DESCRIPTION
This allow to give a commit-ish reference and can thus work across
multiple commits.

I find this convenient as I usually want to run darker after having
committed or on a pull-request with many changes. I'm also thinking that
for example  if the commit-ish is `origin/master`, or in a config file,
some commit at some point in time; eventually all the lines will be
touched and this will become equivalent to isort + black.

I'm opened to better names for the option.

The PR itself is in 2 commits, second one being the result of `darker  . --commitish HEAD~1` on self.