### PR TITLE
Reformat newly added files, too

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 - ``--check`` returns 1 from the process but leaves files untouched if any file would
   require reformatting
+- Untracked i.e. freshly created Python files are now also reformatted
 
 Fixed
 -----

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -10,7 +10,7 @@ from darker.black_diff import BlackArgs, run_black
 from darker.chooser import choose_lines
 from darker.command_line import ISORT_INSTRUCTION, parse_command_line
 from darker.diff import diff_and_get_opcodes, opcodes_to_chunks
-from darker.git import EditedLinenumsDiffer, git_diff_name_only
+from darker.git import EditedLinenumsDiffer, git_get_modified_files
 from darker.import_sorting import apply_isort, isort
 from darker.utils import get_common_root, joinlines
 from darker.verification import NotEquivalentError, verify_ast_unchanged
@@ -46,7 +46,7 @@ def format_edited_parts(
 
     """
     git_root = get_common_root(srcs)
-    changed_files = git_diff_name_only(srcs, git_root)
+    changed_files = git_get_modified_files(srcs, git_root)
     edited_linenums_differ = EditedLinenumsDiffer(git_root)
 
     for path_in_repo in changed_files:

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -4,7 +4,7 @@ import pytest
 
 from darker.git import (
     EditedLinenumsDiffer,
-    git_diff_name_only,
+    git_get_modified_files,
     git_get_unmodified_content,
     should_reformat_file,
 )
@@ -55,9 +55,12 @@ def test_should_reformat_file(tmpdir, path, create, expect):
         ({'c/e.js': 'new'}, ['c/e.js'], []),
         ({'a.py': 'original'}, ['a.py'], []),
         ({'a.py': None}, ['a.py'], []),
+        ({"h.py": "untracked"}, ["h.py"], ["h.py"]),
+        ({}, ["h.py"], []),
     ],
 )
-def test_git_diff_name_only(git_repo, modify_paths, paths, expect):
+def test_git_get_modified_files(git_repo, modify_paths, paths, expect):
+    """Tests for `darker.git.git_get_modified_files()`"""
     root = Path(git_repo.root)
     git_repo.add(
         {
@@ -74,7 +77,7 @@ def test_git_diff_name_only(git_repo, modify_paths, paths, expect):
             absolute_path.remove()
         else:
             absolute_path.write(content, ensure=True)
-    result = git_diff_name_only({root / p for p in paths}, cwd=root)
+    result = git_get_modified_files({root / p for p in paths}, cwd=root)
     assert {str(p) for p in result} == set(expect)
 
 


### PR DESCRIPTION
`git diff --name-only` didn't include newly created untracked files so they were not included in reformatting. A call to `git ls-files` with suitable arguments is now made in addition so untracked files will be included.