### PR TITLE
`--no-skip-string-normalization` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,12 +9,13 @@ Added
 - ``--check`` returns 1 from the process but leaves files untouched if any file would
   require reformatting
 - Untracked i.e. freshly created Python files are now also reformatted
+- ``--no-skip-string-normalization`` flag to override
+  ``skip_string_normalization = true`` from a configuration file
 
 Fixed
 -----
 - Paths from ``--diff`` are now relative to current working directory, similar to output
   from ``black --diff``
-
 
 
 1.0.0_ - 2020-07-15

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,10 @@ The following `command line arguments`_ can also be used to modify the defaults:
                            Ask `black` and `isort` to read configuration from PATH.
      -S, --skip-string-normalization
                            Don't normalize string quotes or prefixes
+     --no-skip-string-normalization
+                           Normalize string quotes or prefixes. This can be used
+                           to override `skip_string_normalization = true` from a
+                           configuration file.
      -l LINE_LENGTH, --line-length LINE_LENGTH
                            How many characters per line to allow [default: 88]
 
@@ -135,6 +139,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
 *New in version 1.1.0:* The ``--check`` command line option.
 
 *New in version 1.1.0:* The ``--diff`` command line option.
+
+*New in version 1.1.0:* The ``--no-skip-string-normalization`` command line option.
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -179,7 +179,7 @@ def main(argv: List[str] = None) -> int:
         black_args["config"] = args.config
     if args.line_length:
         black_args["line_length"] = args.line_length
-    if args.skip_string_normalization:
+    if args.skip_string_normalization is not None:
         black_args["skip_string_normalization"] = args.skip_string_normalization
 
     paths = {Path(p) for p in args.src}

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -81,9 +81,20 @@ def parse_command_line(argv: List[str]) -> Namespace:
     parser.add_argument(
         "-S",
         "--skip-string-normalization",
-        action="store_true",
+        action="store_const",
+        const=True,
         dest="skip_string_normalization",
         help="Don't normalize string quotes or prefixes",
+    )
+    parser.add_argument(
+        "--no-skip-string-normalization",
+        action="store_const",
+        const=False,
+        dest="skip_string_normalization",
+        help=(
+            "Normalize string quotes or prefixes. This can be used to override"
+            " `skip_string_normalization = true` from a configuration file."
+        ),
     )
     parser.add_argument(
         "-l",

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -40,6 +40,8 @@ class GitRepoFixture:
 
 
 @pytest.fixture
-def git_repo(tmpdir):
+def git_repo(tmpdir, monkeypatch):
+    """Create a temporary Git repository and change current working directory into it"""
     check_call(["git", "init"], cwd=tmpdir)
+    monkeypatch.chdir(tmpdir)
     return GitRepoFixture(tmpdir)


### PR DESCRIPTION
This option can be used to override
```toml
[tool.black]
skip-string-normalization = true
```
from `pyproject.toml` (or another configuration file used via the `--config` option).