### PR TITLE
DRAFT: Apply pyupgrade.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -90,6 +90,9 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
+[mypy-pyupgrade.*]
+ignore_missing_imports = True
+
 [mypy-setuptools.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ isort =
     isort>=5.0.1
 color =
     Pygments>=2.4.0
+pyupgrade =
+    pyupgrade>=2.31.0
 test =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     airium>=0.2.3

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -370,6 +370,24 @@ def _drop_changes_on_unedited_lines(
     return last_successful_reformat
 
 
+def pyup(content: TextDocument) -> TextDocument:
+    """Upgrade syntax to newer version of Python using `pyupgrade`
+
+    :param content: The Python source code to upgrade
+    :return: The upgraded Python source code
+
+    """
+
+    from pyupgrade._main import _fix_plugins, _fix_tokens, _fix_py36_plus, Settings
+
+    min_version = (3, 6)
+    result = _fix_plugins(content.string, Settings(min_version=min_version))
+    result = _fix_tokens(result, min_version)
+    result = _fix_py36_plus(result, min_version=min_version)
+
+    return TextDocument(result)
+
+
 def modify_file(path: Path, new_content: TextDocument) -> None:
     """Write new content to a file and inform the user by logging"""
     logger.info("Writing %s bytes into %s", len(new_content.string), path)

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -370,24 +370,6 @@ def _drop_changes_on_unedited_lines(
     return last_successful_reformat
 
 
-def pyup(content: TextDocument) -> TextDocument:
-    """Upgrade syntax to newer version of Python using `pyupgrade`
-
-    :param content: The Python source code to upgrade
-    :return: The upgraded Python source code
-
-    """
-
-    from pyupgrade._main import _fix_plugins, _fix_tokens, _fix_py36_plus, Settings
-
-    min_version = (3, 6)
-    result = _fix_plugins(content.string, Settings(min_version=min_version))
-    result = _fix_tokens(result, min_version)
-    result = _fix_py36_plus(result, min_version=min_version)
-
-    return TextDocument(result)
-
-
 def modify_file(path: Path, new_content: TextDocument) -> None:
     """Write new content to a file and inform the user by logging"""
     logger.info("Writing %s bytes into %s", len(new_content.string), path)

--- a/src/darker/syntax_upgrade.py
+++ b/src/darker/syntax_upgrade.py
@@ -1,0 +1,29 @@
+"""Wrapper for applying `pyupgrade` on Python source code"""
+
+from darker.utils import TextDocument
+
+try:
+    from pyupgrade import _main as pyupgrade_main
+except ImportError:
+    # `pyupgrade` is an optional dependency. Prevent the `ImportError` if it's missing.
+    pyupgrade_main = None
+
+
+__all__ = ["apply_pyupgrade", "pyupgrade_main"]
+
+
+def apply_pyupgrade(content: TextDocument) -> TextDocument:
+    """Upgrade syntax to newer version of Python using `pyupgrade`
+
+    :param content: The Python source code to upgrade
+    :return: The upgraded Python source code
+
+    """
+    # pylint: disable=protected-access
+    min_version = (3, 6)
+    result = pyupgrade_main._fix_plugins(
+        content.string, pyupgrade_main.Settings(min_version=min_version)
+    )
+    result = pyupgrade_main._fix_tokens(result, min_version)
+    result = pyupgrade_main._fix_py36_plus(result, min_version=min_version)
+    return TextDocument.from_str(result)


### PR DESCRIPTION
- [x] Merge #308
- [x] Rebase after #308 has been merged
- [ ] Evaluate whether the approach in #308 fits directly or needs to be adjusted
- [ ] Unit tests
- [ ] Documentation

----

([pyupgrade](https://github.com/asottile/pyupgrade) is _"a tool (and pre-commit hook) to automatically upgrade syntax for newer versions of the language."_)

Just seeing how it looks like, we would of course need to pass options in, so i'm thinking only once there is a config file; likely.

This is likely incorrect as the edited lines could likely be off once Black has been ran as it can rewrap stuff.

It also does use pyupgrade private internal API, and the author has explicitly stated they they were not willing to have public API beyond the CLI.

We should also likely run this _before_ Black; maybe even before isort? Not sure if it might remove imports... But at least it does not pass the AST unchange part.

--- 

Late for today, just submitting in case you decide to _also_ write the same thing.