### PR TITLE
Bugfix: Linter support to diff against given revision

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -150,7 +150,7 @@ def format_edited_parts(
     # 13. extract line numbers in each file reported by a linter for changed lines
     # 14. print only linter error lines which fall on changed lines
     for linter_cmdline in linter_cmdlines:
-        run_linter(linter_cmdline, git_root, changed_files)
+        run_linter(linter_cmdline, git_root, changed_files, revision)
 
 
 def modify_file(path: Path, new_content: str) -> None:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -98,7 +98,7 @@ class EditedLinenumsDiffer:
     """Find out changed lines for a file compared to a given Git revision"""
 
     git_root: Path
-    revision: str = "HEAD"
+    revision: str
 
     @lru_cache(maxsize=1)
     def revision_vs_worktree(self, path_in_repo: Path, context_lines: int) -> List[int]:

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -58,12 +58,15 @@ def _parse_linter_line(
     return path_in_repo, linenum
 
 
-def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
+def run_linter(
+    cmdline: List[str], git_root: Path, paths: Set[Path], revision: str
+) -> None:
     """Run the given linter and print linting errors falling on changed lines
 
     :param cmdline: The command line for running the linter
     :param git_root: The repository root for the changed files
     :param paths: Paths of files to check, relative to ``git_root``
+    :param revision: The Git revision against which to compare the working tree
 
     """
     if not paths:
@@ -75,7 +78,7 @@ def run_linter(cmdline: List[str], git_root: Path, paths: Set[Path]) -> None:
     )
     # assert needed for MyPy (see https://stackoverflow.com/q/57350490/15770)
     assert linter_process.stdout is not None
-    edited_linenums_differ = EditedLinenumsDiffer(git_root)
+    edited_linenums_differ = EditedLinenumsDiffer(git_root, revision)
     for line in linter_process.stdout:
         path_in_repo, linter_error_linenum = _parse_linter_line(line, git_root)
         if path_in_repo is None:

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -105,7 +105,7 @@ def test_edited_linenums_differ_revision_vs_worktree(git_repo, context_lines, ex
     """Tests for EditedLinenumsDiffer.revision_vs_worktree()"""
     paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
     paths["a.py"].write("1\n2\nthree\n4\n5\n6\nseven\n8\n")
-    differ = EditedLinenumsDiffer(git_repo.root)
+    differ = EditedLinenumsDiffer(git_repo.root, "HEAD")
 
     result = differ.revision_vs_worktree(Path("a.py"), context_lines)
 
@@ -117,7 +117,7 @@ def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expec
     """Tests for EditedLinenumsDiffer.revision_vs_lines()"""
     git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
     lines = ['1', '2', 'three', '4', '5', '6', 'seven', '8']
-    differ = EditedLinenumsDiffer(git_repo.root)
+    differ = EditedLinenumsDiffer(git_repo.root, "HEAD")
 
     result = differ.revision_vs_lines(Path("a.py"), lines, context_lines)
 

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -99,7 +99,7 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
     monkeypatch.chdir(git_repo.root)
     cmdline = ["echo", location]
 
-    run_linter(cmdline, git_repo.root, {Path(p) for p in paths})
+    run_linter(cmdline, git_repo.root, {Path(p) for p in paths}, "HEAD")
 
     # We can now verify that the linter received the correct paths on its command line
     # by checking standard output from the our `echo` "linter".


### PR DESCRIPTION
When rebasing linter support in #33, I missed the need to pass the `-r` / `--revision` option there, too.

With this patch, linter output is now filtered correctly by comparing the working tree against the given revision, instead of against `HEAD`.

Could you @Carreau or @samoylovfp take a look at this quick fix?