### PR TITLE
Read configuration from pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.7"
   - "3.8"
   - "3.8-dev"  # 3.8 development branch
-  - "nightly"  # nightly build
 install:
   - pip install -e '.[isort,test]'
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
   - "3.8"
   - "3.8-dev"  # 3.8 development branch
 install:
+  - git fetch origin --depth=1 master:master
   - pip install -e '.[isort,test]'
 script: pytest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ These features will be included in the next release:
 Added
 -----
 - Configure Flake8 verification for Darker source code
+- Configuration can now be loaded from ``pyproject.toml``.
 
 Fixed
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ These features will be included in the next release:
 Added
 -----
 - Configure Flake8 verification for Darker source code
-- Configuration can now be loaded from ``pyproject.toml``.
+- Configuration for Darker can now be done in ``pyproject.toml``.
 
 Fixed
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Added
 -----
 - Configure Flake8 verification for Darker source code
 - Configuration for Darker can now be done in ``pyproject.toml``.
+- The formatting of the Darker code base itself is now checked using Darker itself and
+  pytest-darker_. Currently the formatting is a mix of `Black 19.10`_ and `Black 20.8`_
+  rules, and Travis CI only requires Black 20.8 formatting for lines modified in merge
+  requests. In a way, Darker is now eating its own dogfood.
 
 Fixed
 -----
@@ -81,3 +85,6 @@ Added
 .. _0.2.0: https://github.com/akaihola/darker/compare/0.1.1...0.2.0
 .. _0.1.1: https://github.com/akaihola/darker/compare/0.1.0...0.1.1
 .. _0.1.0: https://github.com/akaihola/darker/releases/tag/0.1.0
+.. _pytest-darker: https://pypi.org/project/pytest-darker/
+.. _Black 19.10: https://github.com/psf/black/blob/master/CHANGES.md#1910b0
+.. _Black 20.8: https://github.com/psf/black/blob/master/CHANGES.md#208b0

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,6 +28,12 @@ allow_untyped_globals = False
 implicit_reexport = False
 strict_equality = True
 
+[mypy-darker.command_line]
+disallow_any_explicit = False
+
+[mypy-darker.config]
+disallow_subclassing_any = False
+
 [mypy-darker.tests.conftest]
 disallow_any_unimported = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,7 +28,7 @@ allow_untyped_globals = False
 implicit_reexport = False
 strict_equality = True
 
-[mypy-darker.command_line]
+[mypy-darker.argparse_helpers]
 disallow_any_explicit = False
 
 [mypy-darker.config]

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,6 +37,9 @@ disallow_subclassing_any = False
 [mypy-darker.tests.conftest]
 disallow_any_unimported = False
 
+[mypy-darker.tests.helpers]
+disallow_any_explicit = False
+
 [mypy-darker.tests.*]
 disallow_any_decorated = False
 disallow_untyped_defs = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel"]  # PEP 508 specifications.
 
-[tool.black]
-skip-string-normalization = true
-
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
@@ -18,9 +15,3 @@ src = [
     "src",
 ]
 revision = "master"
-isort = true
-lint = [
-    "flake8",
-    "mypy",
-    "pylint",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,15 @@ force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
 known_third_party = ["pytest"]
+
+[tool.darker]
+src = [
+    "src",
+]
+revision = "master"
+isort = true
+lint = [
+    "flake8",
+    "mypy",
+    "pylint",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 doctest_optionflags = NORMALIZE_WHITESPACE
 show_capture = no
 addopts =
-  --black
+  --darker
   --flake8
   --isort
   --mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    black
+    black>=20.8b1
     toml
     typing-extensions ; python_version < "3.8"
     dataclasses ; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,8 @@ isort =
     isort>=5.0.1
 test =
     pylint
-    pytest
-    pytest-black
+    pytest>=5.4
+    pytest-darker
     pytest-flake8>=1.0.6
     pytest-isort>=1.1.0
     pytest-mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ console_scripts =
 isort =
     isort>=5.0.1
 test =
+    pylint
     pytest
     pytest-black
     pytest-flake8>=1.0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ package_dir =
 packages = find:
 install_requires =
     black
+    toml
     typing-extensions ; python_version < "3.8"
     dataclasses ; python_version < "3.7"
 python_requires = >=3.6

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -6,8 +6,6 @@ from difflib import unified_diff
 from pathlib import Path
 from typing import Generator, Iterable, List, Tuple
 
-import toml
-
 from darker.black_diff import BlackArgs, run_black
 from darker.chooser import choose_lines
 from darker.command_line import ISORT_INSTRUCTION, parse_command_line

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -204,9 +204,9 @@ def main(argv: List[str] = None) -> int:
 
     if args.log_level <= logging.DEBUG:
         print("\n# Effective configuration:\n")
-        dump_config(config)
+        print(dump_config(config))
         print("\n# Configuration options which differ from defaults:\n")
-        dump_config(config_nondefault)
+        print(dump_config(config_nondefault))
         print("\n")
 
     if args.isort and not isort:

--- a/src/darker/argparse_helpers.py
+++ b/src/darker/argparse_helpers.py
@@ -1,3 +1,5 @@
+"""Custom formatter and action for argparse"""
+
 import logging
 import re
 from argparse import Action, ArgumentParser, HelpFormatter, Namespace
@@ -27,15 +29,17 @@ class NewlinePreservingFormatter(HelpFormatter):
         return super()._fill_text(text, width, indent)
 
 
-class LogLevelAction(Action):
-    def __init__(
+class LogLevelAction(Action):  # pylint: disable=too-few-public-methods
+    """Support for command line actions which increment/decrement the log level"""
+
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         option_strings: List[str],
         dest: str,
         const: int,
         default: int = logging.WARNING,
         required: bool = False,
-        help: str = None,
+        help: str = None,  # pylint: disable=redefined-builtin
         metavar: str = None,
     ):
         super().__init__(

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -36,7 +36,7 @@ import logging
 import sys
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Optional, Set, cast
+from typing import Callable, Dict, List, Optional, Set, Union, cast
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -64,6 +64,12 @@ class BlackModeAttributes(TypedDict, total=False):
     is_pyi: bool
 
 
+BLACK_ARG_CONVERSIONS: Dict[str, Callable[[str], Union[int, bool]]] = {
+    "line_length": int,
+    "skip_string_normalization": lambda value: value == "True",
+}
+
+
 @lru_cache(maxsize=1)
 def read_black_config(src: Path, value: Optional[str]) -> BlackArgs:
     """Read the black configuration from pyproject.toml"""
@@ -79,7 +85,7 @@ def read_black_config(src: Path, value: Optional[str]) -> BlackArgs:
     return cast(
         BlackArgs,
         {
-            key: value
+            key: BLACK_ARG_CONVERSIONS[key](value)
             for key, value in (context.default_map or {}).items()
             if key in ["line_length", "skip_string_normalization"]
         },

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -1,8 +1,7 @@
-import logging
-from argparse import Action, ArgumentParser, Namespace
-from typing import Any, List, Sequence, Tuple, Union
+from argparse import ArgumentParser, Namespace
+from typing import List, Tuple
 
-from darker.argparse_helpers import NewlinePreservingFormatter
+from darker.argparse_helpers import LogLevelAction, NewlinePreservingFormatter
 from darker.config import (
     DarkerConfig,
     get_effective_config,
@@ -12,44 +11,6 @@ from darker.config import (
 from darker.version import __version__
 
 ISORT_INSTRUCTION = "Please run `pip install 'darker[isort]'`"
-
-
-class _LogLevelAction(Action):
-    def __init__(
-        self,
-        option_strings: List[str],
-        dest: str,
-        const: int,
-        default: int = logging.WARNING,
-        required: bool = False,
-        help: str = None,
-        metavar: str = None,
-    ):
-        super().__init__(
-            option_strings=option_strings,
-            dest=dest,
-            nargs=0,
-            const=const,
-            default=default,
-            required=required,
-            help=help,
-            metavar=metavar,
-        )
-
-    def __call__(
-        self,
-        parser: ArgumentParser,
-        namespace: Namespace,
-        values: Union[str, Sequence[Any], None],
-        option_string: str = None,
-    ) -> None:
-        assert isinstance(values, list)
-        assert all(isinstance(v, str) for v in values)
-        current_level = getattr(namespace, self.dest, self.default)
-        new_level = current_level + self.const
-        new_level = max(new_level, logging.DEBUG)
-        new_level = min(new_level, logging.CRITICAL)
-        setattr(namespace, self.dest, new_level)
 
 
 def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, DarkerConfig]:
@@ -78,7 +39,7 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     parser = ArgumentParser(
         description="\n".join(description), formatter_class=NewlinePreservingFormatter,
     )
-    parser.register('action', 'log_level', _LogLevelAction)
+    parser.register("action", "log_level", LogLevelAction)
     parser.add_argument(
         "src",
         nargs="+",

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -2,7 +2,7 @@
 
 import logging
 from argparse import ArgumentParser, Namespace
-from typing import Dict, List, Optional, Union, cast
+from typing import Dict, List, Union, cast
 
 import toml
 from black import find_project_root
@@ -27,12 +27,10 @@ def replace_log_level_name(config: DarkerConfig) -> None:
         config["log_level"] = logging.getLevelName(cast(int, config["log_level"]))
 
 
-def load_config(path: Optional[str], srcs: List[str]) -> DarkerConfig:
+def load_config() -> DarkerConfig:
     """Find and load Darker configuration from given path or pyproject.toml"""
-    if not path:
-        path_pyproject_toml = find_project_root(tuple(srcs)) / "pyproject.toml"
-        path = str(path_pyproject_toml) if path_pyproject_toml.is_file() else None
-    if path:
+    path = find_project_root((".",)) / "pyproject.toml"
+    if path.is_file():
         pyproject_toml = toml.load(path)
         config: DarkerConfig = pyproject_toml.get("tool", {}).get("darker", {}) or {}
         replace_log_level_name(config)
@@ -60,5 +58,5 @@ def get_modified_config(parser: ArgumentParser, args: Namespace) -> DarkerConfig
 
 def dump_config(config: DarkerConfig) -> None:
     """Print the configuration in TOML format"""
-    print('[tool.darker]')
+    print("[tool.darker]")
     print(toml.dumps(config, encoder=TomlArrayLinesEncoder()))  # type: ignore[call-arg]

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -14,7 +14,7 @@ class TomlArrayLinesEncoder(toml.TomlEncoder):  # type: ignore[name-defined]
     def dump_list(self, v: List[str]) -> str:
         """Format a list value"""
         return "[{}\n]".format(
-            "".join("\n    {}".format(self.dump_value(item)) for item in v)
+            "".join("\n    {},".format(self.dump_value(item)) for item in v)
         )
 
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -1,0 +1,57 @@
+import logging
+from argparse import ArgumentParser, Namespace
+from typing import Dict, List, Optional, Union
+
+import toml
+from black import find_project_root
+
+
+class TomlArrayLinesEncoder(toml.TomlEncoder):  # type: ignore[name-defined]
+    """Format TOML so list items are each on their own line"""
+
+    def dump_list(self, v: List[str]) -> str:
+        """Format a list value"""
+        return "[{}\n]".format(
+            "".join("\n    {}".format(self.dump_value(item)) for item in v)
+        )
+
+
+DarkerConfig = Dict[str, Union[str, bool, List[str]]]
+
+
+def load_config(path: Optional[str], srcs: List[str]) -> DarkerConfig:
+    """Find and load Darker configuration from given path or pyproject.toml"""
+    if not path:
+        path_pyproject_toml = find_project_root(tuple(srcs)) / "pyproject.toml"
+        path = str(path_pyproject_toml) if path_pyproject_toml.is_file() else None
+    if path:
+        pyproject_toml = toml.load(path)
+        config = pyproject_toml.get("tool", {}).get("darker", {}) or {}
+        if "log_level" in config:
+            config["log_level"] = logging.getLevelName(config["log_level"])
+        return config
+    return {}
+
+
+def get_effective_config(args: Namespace) -> DarkerConfig:
+    """Return all configuration options"""
+    config = vars(args).copy()
+    config["log_level"] = logging.getLevelName(config["log_level"])
+    return config
+
+
+def get_modified_config(parser: ArgumentParser, args: Namespace) -> DarkerConfig:
+    """Return configuration options which are set to non-default values"""
+    not_default = {
+        argument: value
+        for argument, value in vars(args).items()
+        if value != parser.get_default(argument)
+    }
+    if "log_level" in not_default:
+        not_default["log_level"] = logging.getLevelName(not_default["log_level"])
+    return not_default
+
+
+def dump_config(config: DarkerConfig) -> None:
+    print('[tool.darker]')
+    print(toml.dumps(config, encoder=TomlArrayLinesEncoder()))  # type: ignore[call-arg]

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -2,7 +2,7 @@
 
 import logging
 from argparse import ArgumentParser, Namespace
-from typing import Dict, List, Union, cast
+from typing import Dict, Iterable, List, Union, cast
 
 import toml
 from black import find_project_root
@@ -27,9 +27,14 @@ def replace_log_level_name(config: DarkerConfig) -> None:
         config["log_level"] = logging.getLevelName(cast(int, config["log_level"]))
 
 
-def load_config() -> DarkerConfig:
-    """Find and load Darker configuration from given path or pyproject.toml"""
-    path = find_project_root((".",)) / "pyproject.toml"
+def load_config(srcs: Iterable[str]) -> DarkerConfig:
+    """Find and load Darker configuration from given path or pyproject.toml
+
+    :param srcs: File(s) and directory/directories which will be processed. Their paths
+                 are used to look for the ``pyproject.toml`` configuration file.
+
+    """
+    path = find_project_root(tuple(srcs or ["."])) / "pyproject.toml"
     if path.is_file():
         pyproject_toml = toml.load(path)
         config: DarkerConfig = pyproject_toml.get("tool", {}).get("darker", {}) or {}

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -56,7 +56,7 @@ def get_modified_config(parser: ArgumentParser, args: Namespace) -> DarkerConfig
     return not_default
 
 
-def dump_config(config: DarkerConfig) -> None:
-    """Print the configuration in TOML format"""
-    print("[tool.darker]")
-    print(toml.dumps(config, encoder=TomlArrayLinesEncoder()))  # type: ignore[call-arg]
+def dump_config(config: DarkerConfig) -> str:
+    """Return the configuration in TOML format"""
+    dump = toml.dumps(config, encoder=TomlArrayLinesEncoder())  # type: ignore[call-arg]
+    return f"[tool.darker]\n{dump}"

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -1,3 +1,5 @@
+"""Load and save configuration in TOML format"""
+
 import logging
 from argparse import ArgumentParser, Namespace
 from typing import Dict, List, Optional, Union
@@ -53,5 +55,6 @@ def get_modified_config(parser: ArgumentParser, args: Namespace) -> DarkerConfig
 
 
 def dump_config(config: DarkerConfig) -> None:
+    """Print the configuration in TOML format"""
     print('[tool.darker]')
     print(toml.dumps(config, encoder=TomlArrayLinesEncoder()))  # type: ignore[call-arg]

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -58,9 +58,7 @@ def _parse_linter_line(
     return path_in_repo, linenum
 
 
-def run_linter(
-    cmdline: List[str], git_root: Path, paths: Set[Path], revision: str
-) -> None:
+def run_linter(cmdline: str, git_root: Path, paths: Set[Path], revision: str) -> None:
     """Run the given linter and print linting errors falling on changed lines
 
     :param cmdline: The command line for running the linter
@@ -72,7 +70,7 @@ def run_linter(
     if not paths:
         return
     linter_process = Popen(
-        cmdline + [str(git_root / path) for path in sorted(paths)],
+        cmdline.split() + [str(git_root / path) for path in sorted(paths)],
         stdout=PIPE,
         encoding="utf-8",
     )

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -22,7 +22,7 @@ provided that the ``<linenum>`` falls on a changed line.
 import logging
 from pathlib import Path
 from subprocess import PIPE, Popen
-from typing import List, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 from darker.git import EditedLinenumsDiffer
 

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 from unittest.mock import patch
 
 import pytest
+from black import find_project_root
 from py.path import local as LocalPath
 
 
@@ -58,3 +59,9 @@ def git_repo(tmpdir, monkeypatch):
     check_call(["git", "init"], cwd=tmpdir)
     monkeypatch.chdir(tmpdir)
     return GitRepoFixture(tmpdir)
+
+
+@pytest.fixture
+def find_project_root_cache_clear():
+    """Clear LRU caching in :func:`black.find_project_root` before each test"""
+    find_project_root.cache_clear()

--- a/src/darker/tests/helpers.py
+++ b/src/darker/tests/helpers.py
@@ -1,0 +1,8 @@
+"""Helper functions for unit tests"""
+
+from typing import Any, Dict
+
+
+def filter_dict(dct: Dict[str, Any], filter_key: str) -> Dict[str, Any]:
+    """Return only given keys with their values from a dictionary"""
+    return {key: value for key, value in dct.items() if key == filter_key}

--- a/src/darker/tests/test_argparse_helpers.py
+++ b/src/darker/tests/test_argparse_helpers.py
@@ -1,3 +1,5 @@
+"""Tests for the ``darker.argparse_helpers`` module"""
+
 from argparse import ArgumentParser, Namespace
 from contextlib import suppress
 from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
@@ -27,9 +29,12 @@ from darker import argparse_helpers
     ],
 )
 def test_fill_line(line, width, indent, expect):
-    with pytest.raises(expect) if type(expect) is type else suppress():
+    """``_fill_line()`` wraps lines correctly"""
+    with pytest.raises(expect) if isinstance(expect, type) else suppress():
 
-        result = argparse_helpers._fill_line(line, width, indent)
+        result = argparse_helpers._fill_line(  # pylint: disable=protected-access
+            line, width, indent
+        )
 
         assert result.splitlines() == expect
 
@@ -52,9 +57,12 @@ def test_fill_line(line, width, indent, expect):
     ],
 )
 def test_newline_preserving_formatter(text, width, indent, expect):
+    """``NewlinePreservingFormatter`` wraps lines and keeps newlines correctly"""
     formatter = argparse_helpers.NewlinePreservingFormatter("dummy")
 
-    result = formatter._fill_text(text, width, indent)
+    result = formatter._fill_text(  # pylint: disable=protected-access
+        text, width, indent
+    )
 
     assert result.splitlines() == expect
 
@@ -76,9 +84,11 @@ def test_newline_preserving_formatter(text, width, indent, expect):
     ],
 )
 def test_log_level_action(const, initial, expect):
+    """``LogLevelAction`` increments/decrements the log level value correctly"""
     action = argparse_helpers.LogLevelAction([], "log_level", const)
     parser = ArgumentParser()
-    namespace = Namespace(log_level=initial)
+    namespace = Namespace()
+    namespace.log_level = initial
 
     action(parser, namespace, [])
 
@@ -99,6 +109,7 @@ def test_log_level_action(const, initial, expect):
     ],
 )
 def test_argumentparser_log_level_action(const, count, expect):
+    """The log level action works correctly with an ``ArgumentParser``"""
     parser = ArgumentParser()
     parser.register("action", "log_level", argparse_helpers.LogLevelAction)
     parser.add_argument("-l", dest="log_level", action="log_level", const=const)

--- a/src/darker/tests/test_argparse_helpers.py
+++ b/src/darker/tests/test_argparse_helpers.py
@@ -1,0 +1,108 @@
+from argparse import ArgumentParser, Namespace
+from contextlib import suppress
+from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
+
+import pytest
+
+from darker import argparse_helpers
+
+
+@pytest.mark.parametrize(
+    "line, width, indent, expect",
+    [
+        ("", 0, "    ", ValueError),
+        ("", 1, "    ", []),
+        (
+            "lorem ipsum dolor sit amet",
+            9,
+            "    ",
+            ["    lorem", "    ipsum", "    dolor", "    sit", "    amet"],
+        ),
+        (
+            "lorem ipsum dolor sit amet",
+            15,
+            "    ",
+            ["    lorem ipsum", "    dolor sit", "    amet"],
+        ),
+    ],
+)
+def test_fill_line(line, width, indent, expect):
+    with pytest.raises(expect) if type(expect) is type else suppress():
+
+        result = argparse_helpers._fill_line(line, width, indent)
+
+        assert result.splitlines() == expect
+
+
+@pytest.mark.parametrize(
+    "text, width, indent, expect",
+    [
+        (
+            "lorem ipsum dolor sit amet",
+            15,
+            "    ",
+            ["    lorem ipsum", "    dolor sit", "    amet"],
+        ),
+        (
+            "lorem\nipsum dolor sit amet",
+            15,
+            "    ",
+            ["    lorem", "    ipsum dolor", "    sit amet"],
+        ),
+    ],
+)
+def test_newline_preserving_formatter(text, width, indent, expect):
+    formatter = argparse_helpers.NewlinePreservingFormatter("dummy")
+
+    result = formatter._fill_text(text, width, indent)
+
+    assert result.splitlines() == expect
+
+
+@pytest.mark.parametrize(
+    "const, initial, expect",
+    [
+        (10, NOTSET, DEBUG),
+        (10, DEBUG, INFO),
+        (10, INFO, WARNING),
+        (10, WARNING, ERROR),
+        (10, ERROR, CRITICAL),
+        (10, CRITICAL, CRITICAL),
+        (-10, DEBUG, DEBUG),
+        (-10, INFO, DEBUG),
+        (-10, WARNING, INFO),
+        (-10, ERROR, WARNING),
+        (-10, CRITICAL, ERROR),
+    ],
+)
+def test_log_level_action(const, initial, expect):
+    action = argparse_helpers.LogLevelAction([], "log_level", const)
+    parser = ArgumentParser()
+    namespace = Namespace(log_level=initial)
+
+    action(parser, namespace, [])
+
+    assert namespace.log_level == expect
+
+
+@pytest.mark.parametrize(
+    "const, count, expect",
+    [
+        (10, NOTSET, WARNING),
+        (10, 1, ERROR),
+        (10, 2, CRITICAL),
+        (10, 3, CRITICAL),
+        (-10, NOTSET, WARNING),
+        (-10, 1, INFO),
+        (-10, 2, DEBUG),
+        (-10, 3, DEBUG),
+    ],
+)
+def test_argumentparser_log_level_action(const, count, expect):
+    parser = ArgumentParser()
+    parser.register("action", "log_level", argparse_helpers.LogLevelAction)
+    parser.add_argument("-l", dest="log_level", action="log_level", const=const)
+
+    args = parser.parse_args(count * ["-l"])
+
+    assert args.log_level == expect

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -149,7 +149,14 @@ def test_black_options_skip_string_normalization(git_repo, config, options, expe
         (["--diff", "a.py"], ({Path("a.py")}, "HEAD", False, [], {})),
     ],
 )
-def test_options(options, expect):
+def test_options(tmpdir, monkeypatch, options, expect):
+    """The main engine is called with correct parameters based on the command line
+
+    Executed in a clean directory so Darker's own ``pyproject.toml`` doesn't interfere.
+
+    """
+    monkeypatch.chdir(tmpdir)
+    (tmpdir / "my.cfg").write("")
     with patch('darker.__main__.format_edited_parts') as format_edited_parts:
 
         retval = main(options)

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -6,7 +6,6 @@ from unittest.mock import DEFAULT, Mock, call, patch
 
 import pytest
 import toml
-from black import find_project_root
 
 from darker import black_diff
 from darker.__main__ import main
@@ -20,13 +19,7 @@ else:
     from contextlib import suppress as nullcontext
 
 
-pytestmark = pytest.mark.usefixtures("lru_cache_clear")
-
-
-@pytest.fixture
-def lru_cache_clear():
-    """Clear LRU caching in :func:`black.find_project_root` before each test"""
-    find_project_root.cache_clear()
+pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 
 
 @pytest.mark.parametrize("require_src, expect", [(False, []), (True, SystemExit)])

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -40,14 +40,34 @@ def darker_help_output(capsys):
     "config, argv, expect",
     [
         (None, [], SystemExit),
-        (None, ["file.py"], {"src": ["file.py"]},),
-        ({"src": ["file.py"]}, [], {"src": ["file.py"]},),
-        ({"src": ["file.py"]}, ["file.py"], {"src": ["file.py"]},),
-        ({"src": ["file1.py"]}, ["file2.py"], {"src": ["file2.py"]},),
+        (
+            None,
+            ["file.py"],
+            {"src": ["file.py"]},
+        ),
+        (
+            {"src": ["file.py"]},
+            [],
+            {"src": ["file.py"]},
+        ),
+        (
+            {"src": ["file.py"]},
+            ["file.py"],
+            {"src": ["file.py"]},
+        ),
+        (
+            {"src": ["file1.py"]},
+            ["file2.py"],
+            {"src": ["file2.py"]},
+        ),
     ],
 )
 def test_parse_command_line_config_src(
-    tmpdir, monkeypatch, config, argv, expect,
+    tmpdir,
+    monkeypatch,
+    config,
+    argv,
+    expect,
 ):
     """The ``src`` positional argument from config and cmdline is handled correctly"""
     monkeypatch.chdir(tmpdir)

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -10,7 +10,7 @@ from black import find_project_root
 
 from darker import black_diff
 from darker.__main__ import main
-from darker.command_line import parse_command_line
+from darker.command_line import make_argument_parser, parse_command_line
 from darker.tests.helpers import filter_dict
 from darker.utils import joinlines
 
@@ -27,6 +27,17 @@ pytestmark = pytest.mark.usefixtures("lru_cache_clear")
 def lru_cache_clear():
     """Clear LRU caching in :func:`black.find_project_root` before each test"""
     find_project_root.cache_clear()
+
+
+@pytest.mark.parametrize("require_src, expect", [(False, []), (True, SystemExit)])
+def test_make_argument_parser(require_src, expect):
+    """Parser from ``make_argument_parser()`` fails if src required but not provided"""
+    parser = make_argument_parser(require_src)
+    with pytest.raises(expect) if isinstance(expect, type) else nullcontext():
+
+        args = parser.parse_args([])
+
+        assert args.src == expect
 
 
 @pytest.fixture

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -86,6 +86,152 @@ def test_parse_command_line_config_src(
         assert filter_dict(modified_cfg, "src") == expect
 
 
+@pytest.mark.parametrize(
+    "argv, expect_value, expect_config, expect_modified",
+    [
+        (["."], ("src", ["."]), ("src", ["."]), ("src", ["."])),
+        (
+            ["."],
+            ("revision", "HEAD"),
+            ("revision", "HEAD"),
+            ("revision", ...),
+        ),
+        (
+            ["-rmaster", "."],
+            ("revision", "master"),
+            ("revision", "master"),
+            ("revision", "master"),
+        ),
+        (
+            ["--revision", "HEAD", "."],
+            ("revision", "HEAD"),
+            ("revision", "HEAD"),
+            ("revision", ...),
+        ),
+        (["."], ("diff", False), ("diff", False), ("diff", ...)),
+        (["--diff", "."], ("diff", True), ("diff", True), ("diff", True)),
+        (["."], ("check", False), ("check", False), ("check", ...)),
+        (["--check", "."], ("check", True), ("check", True), ("check", True)),
+        (["."], ("isort", False), ("isort", False), ("isort", ...)),
+        (["-i", "."], ("isort", True), ("isort", True), ("isort", True)),
+        (["--isort", "."], ("isort", True), ("isort", True), ("isort", True)),
+        (["."], ("lint", []), ("lint", []), ("lint", ...)),
+        (
+            ["-L", "pylint", "."],
+            ("lint", ["pylint"]),
+            ("lint", ["pylint"]),
+            ("lint", ["pylint"]),
+        ),
+        (
+            ["--lint", "flake8", "-L", "mypy", "."],
+            ("lint", ["flake8", "mypy"]),
+            ("lint", ["flake8", "mypy"]),
+            ("lint", ["flake8", "mypy"]),
+        ),
+        (["."], ("config", None), ("config", None), ("config", ...)),
+        (
+            ["-c", "my.cfg", "."],
+            ("config", "my.cfg"),
+            ("config", "my.cfg"),
+            ("config", "my.cfg"),
+        ),
+        (
+            ["--config=my.cfg", "."],
+            ("config", "my.cfg"),
+            ("config", "my.cfg"),
+            ("config", "my.cfg"),
+        ),
+        (["."], ("log_level", 30), ("log_level", "WARNING"), ("log_level", ...)),
+        (
+            ["-v", "."],
+            ("log_level", 20),
+            ("log_level", "INFO"),
+            ("log_level", "INFO"),
+        ),
+        (
+            ["--verbose", "-v", "."],
+            ("log_level", 10),
+            ("log_level", "DEBUG"),
+            ("log_level", "DEBUG"),
+        ),
+        (
+            ["-q", "."],
+            ("log_level", 40),
+            ("log_level", "ERROR"),
+            ("log_level", "ERROR"),
+        ),
+        (
+            ["--quiet", "-q", "."],
+            ("log_level", 50),
+            ("log_level", "CRITICAL"),
+            ("log_level", "CRITICAL"),
+        ),
+        (
+            ["."],
+            ("skip_string_normalization", None),
+            ("skip_string_normalization", None),
+            ("skip_string_normalization", ...),
+        ),
+        (
+            ["-S", "."],
+            ("skip_string_normalization", True),
+            ("skip_string_normalization", True),
+            ("skip_string_normalization", True),
+        ),
+        (
+            ["--skip-string-normalization", "."],
+            ("skip_string_normalization", True),
+            ("skip_string_normalization", True),
+            ("skip_string_normalization", True),
+        ),
+        (
+            ["--no-skip-string-normalization", "."],
+            ("skip_string_normalization", False),
+            ("skip_string_normalization", False),
+            ("skip_string_normalization", False),
+        ),
+        (
+            ["."],
+            ("line_length", None),
+            ("line_length", None),
+            ("line_length", ...),
+        ),
+        (
+            ["-l=88", "."],
+            ("line_length", 88),
+            ("line_length", 88),
+            ("line_length", 88),
+        ),
+        (
+            ["--line-length", "99", "."],
+            ("line_length", 99),
+            ("line_length", 99),
+            ("line_length", 99),
+        ),
+    ],
+)
+def test_parse_command_line(
+    tmpdir, monkeypatch, argv, expect_value, expect_config, expect_modified
+):
+    monkeypatch.chdir(tmpdir)
+    args, effective_cfg, modified_cfg = parse_command_line(argv)
+
+    arg_name, expect_arg_value = expect_value
+    assert getattr(args, arg_name) == expect_arg_value
+
+    option, expect_config_value = expect_config
+    if expect_config_value is ...:
+        assert option not in effective_cfg
+    else:
+        assert effective_cfg[option] == expect_config_value
+
+    modified_option, expect_modified_value = expect_modified
+    if expect_modified_value is ...:
+        assert modified_option not in modified_cfg
+    else:
+        assert modified_cfg[modified_option] == expect_modified_value
+
+
 def test_help_description_without_isort_package(without_isort, darker_help_output):
     assert (
         "Please run `pip install 'darker[isort]'` to enable sorting of import "

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from darker.config import TomlArrayLinesEncoder
+from darker.config import TomlArrayLinesEncoder, replace_log_level_name
 
 
 @pytest.mark.parametrize(
@@ -34,3 +34,32 @@ def test_toml_array_lines_encoder(list_value, expect):
     result = TomlArrayLinesEncoder().dump_list(list_value)
 
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    "log_level, expect",
+    [
+        (0, "NOTSET"),
+        (10, "DEBUG"),
+        (20, "INFO"),
+        (30, "WARNING"),
+        (40, "ERROR"),
+        (50, "CRITICAL"),
+        ("DEBUG", 10),
+        ("INFO", 20),
+        ("WARNING", 30),
+        ("WARN", 30),
+        ("ERROR", 40),
+        ("CRITICAL", 50),
+        ("FOOBAR", "Level FOOBAR"),
+    ],
+)
+def test_replace_log_level_name(log_level, expect):
+    if log_level is None:
+        config = {}
+    else:
+        config = {"log_level": log_level}
+
+    replace_log_level_name(config)
+
+    assert config["log_level"] == expect

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,6 +1,8 @@
+from textwrap import dedent
+
 import pytest
 
-from darker.config import TomlArrayLinesEncoder, replace_log_level_name
+from darker.config import TomlArrayLinesEncoder, load_config, replace_log_level_name
 
 
 @pytest.mark.parametrize(
@@ -63,3 +65,105 @@ def test_replace_log_level_name(log_level, expect):
     replace_log_level_name(config)
 
     assert config["log_level"] == expect
+
+
+@pytest.mark.parametrize(
+    "srcs, cwd, expect",
+    [
+        ([], ".", {"CONFIG_PATH": "."}),
+        ([], "level1", {"CONFIG_PATH": "."}),
+        ([], "level1/level2", {"CONFIG_PATH": "."}),
+        ([], "has_git", {}),
+        ([], "has_git/level1", {}),
+        ([], "has_pyproject", {"CONFIG_PATH": "has_pyproject"}),
+        ([], "has_pyproject/level1", {"CONFIG_PATH": "has_pyproject"}),
+        (["root.py"], ".", {"CONFIG_PATH": "."}),
+        (["../root.py"], "level1", {"CONFIG_PATH": "."}),
+        (["../root.py"], "has_git", {"CONFIG_PATH": "."}),
+        (["../root.py"], "has_pyproject", {"CONFIG_PATH": "."}),
+        (["root.py", "level1/level1.py"], ".", {"CONFIG_PATH": "."}),
+        (["../root.py", "level1.py"], "level1", {"CONFIG_PATH": "."}),
+        (["../root.py", "../level1/level1.py"], "has_git", {"CONFIG_PATH": "."}),
+        (["../root.py", "../level1/level1.py"], "has_pyproject", {"CONFIG_PATH": "."}),
+        (["has_pyproject/pyp.py", "level1/level1.py"], ".", {"CONFIG_PATH": "."}),
+        (["../has_pyproject/pyp.py", "level1.py"], "level1", {"CONFIG_PATH": "."}),
+        (
+            ["../has_pyproject/pyp.py", "../level1/level1.py"],
+            "has_git",
+            {"CONFIG_PATH": "."},
+        ),
+        (["pyp.py", "../level1/level1.py"], "has_pyproject", {"CONFIG_PATH": "."}),
+        (
+            ["has_pyproject/level1/l1.py", "has_pyproject/level1b/l1b.py"],
+            ".",
+            {"CONFIG_PATH": "has_pyproject"},
+        ),
+        (
+            ["../has_pyproject/level1/l1.py", "../has_pyproject/level1b/l1b.py"],
+            "level1",
+            {"CONFIG_PATH": "has_pyproject"},
+        ),
+        (
+            ["../has_pyproject/level1/l1.py", "../has_pyproject/level1b/l1b.py"],
+            "has_git",
+            {"CONFIG_PATH": "has_pyproject"},
+        ),
+        (
+            ["level1/l1.py", "level1b/l1b.py"],
+            "has_pyproject",
+            {"CONFIG_PATH": "has_pyproject"},
+        ),
+        (
+            ["full_example/full.py"],
+            ".",
+            {
+                "check": True,
+                "diff": True,
+                "isort": True,
+                "lint": ["flake8", "mypy", "pylint"],
+                "log_level": 10,
+                "revision": "main",
+                "src": ["src", "tests"],
+            },
+        ),
+    ],
+)
+def test_load_config(
+    find_project_root_cache_clear, tmp_path, monkeypatch, srcs, cwd, expect
+):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pyproject.toml").write_text('[tool.darker]\nCONFIG_PATH = "."\n')
+    (tmp_path / "level1/level2").mkdir(parents=True)
+    (tmp_path / "has_git/.git").mkdir(parents=True)
+    (tmp_path / "has_git/level1").mkdir()
+    (tmp_path / "has_pyproject/level1").mkdir(parents=True)
+    (tmp_path / "has_pyproject/pyproject.toml").write_text(
+        '[tool.darker]\nCONFIG_PATH = "has_pyproject"\n'
+    )
+    (tmp_path / "full_example").mkdir()
+    (tmp_path / "full_example/pyproject.toml").write_text(
+        dedent(
+            """
+            [tool.darker]
+            src = [
+                "src",
+                "tests",
+            ]
+            revision = "main"
+            diff = true
+            check = true
+            isort = true
+            lint = [
+                "flake8",
+                "mypy",
+                "pylint",
+            ]
+            log_level = "DEBUG"
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path / cwd)
+
+    result = load_config(srcs)
+
+    assert result == expect

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,8 +1,14 @@
+from argparse import Namespace
 from textwrap import dedent
 
 import pytest
 
-from darker.config import TomlArrayLinesEncoder, load_config, replace_log_level_name
+from darker.config import (
+    TomlArrayLinesEncoder,
+    get_effective_config,
+    load_config,
+    replace_log_level_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -165,5 +171,23 @@ def test_load_config(
     monkeypatch.chdir(tmp_path / cwd)
 
     result = load_config(srcs)
+
+    assert result == expect
+
+
+@pytest.mark.parametrize(
+    "args, expect",
+    [
+        (Namespace(), {}),
+        (Namespace(one="option"), {"one": "option"}),
+        (Namespace(log_level=10), {"log_level": "DEBUG"}),
+        (
+            Namespace(two="options", log_level=20),
+            {"two": "options", "log_level": "INFO"},
+        ),
+    ],
+)
+def test_get_effective_config(args, expect):
+    result = get_effective_config(args)
 
     assert result == expect

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,0 +1,36 @@
+import pytest
+
+from darker.config import TomlArrayLinesEncoder
+
+
+@pytest.mark.parametrize(
+    "list_value, expect",
+    [
+        ([], "[\n]"),
+        (["one value"], '[\n    "one value",\n]'),
+        (["two", "values"], '[\n    "two",\n    "values",\n]'),
+        (
+            [
+                "a",
+                "dozen",
+                "short",
+                "string",
+                "values",
+                "in",
+                "the",
+                "list",
+                "of",
+                "strings",
+                "to",
+                "format",
+            ],
+            '[\n    "a",\n    "dozen",\n    "short",\n    "string",\n    "values"'
+            ',\n    "in",\n    "the",\n    "list",\n    "of",\n    "strings"'
+            ',\n    "to",\n    "format",\n]',
+        ),
+    ],
+)
+def test_toml_array_lines_encoder(list_value, expect):
+    result = TomlArrayLinesEncoder().dump_list(list_value)
+
+    assert result == expect

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from darker.config import (
     TomlArrayLinesEncoder,
+    dump_config,
     get_effective_config,
     get_modified_config,
     load_config,
@@ -208,5 +209,61 @@ def test_get_modified_config(args, expect):
     parser.add_argument("--int", dest="int", default=42)
     parser.add_argument("--string", default="fourty-two")
     result = get_modified_config(parser, args)
+
+    assert result == expect
+
+
+@pytest.mark.parametrize(
+    "config, expect",
+    [
+        ({}, "[tool.darker]\n"),
+        ({"str": "value"}, '[tool.darker]\nstr = "value"\n'),
+        ({"int": 42}, "[tool.darker]\nint = 42\n"),
+        ({"float": 4.2}, "[tool.darker]\nfloat = 4.2\n"),
+        (
+            {"list": ["foo", "bar"]},
+            dedent(
+                """\
+                [tool.darker]
+                list = [
+                    "foo",
+                    "bar",
+                ]
+                """
+            ),
+        ),
+        (
+            {
+                "src": ["main.py"],
+                "revision": "master",
+                "diff": False,
+                "check": False,
+                "isort": False,
+                "lint": [],
+                "config": None,
+                "log_level": "DEBUG",
+                "skip_string_normalization": None,
+                "line_length": None,
+            },
+            dedent(
+                """\
+                [tool.darker]
+                src = [
+                    "main.py",
+                ]
+                revision = "master"
+                diff = false
+                check = false
+                isort = false
+                lint = [
+                ]
+                log_level = "DEBUG"
+                """
+            ),
+        ),
+    ],
+)
+def test_dump_config(config, expect):
+    result = dump_config(config)
 
     assert result == expect

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -2,7 +2,6 @@ from itertools import chain
 from textwrap import dedent
 
 import pytest
-from black import FileMode, format_str
 
 from darker.diff import (
     diff_and_get_opcodes,
@@ -39,47 +38,83 @@ FUNCTIONS2_PY = dedent(
 """  # noqa: E501
 )
 
-OPCODES = [
-    ("replace", 0, 4, 0, 1),
-    ("equal", 4, 6, 1, 3),
-    ("replace", 6, 8, 3, 5),
-    ("equal", 8, 15, 5, 12),
-    ("insert", 15, 15, 12, 14),
-    ("equal", 15, 17, 14, 16),
-    ("insert", 17, 17, 16, 17),
-    ("equal", 17, 19, 17, 19),
-    ("insert", 19, 19, 19, 20),
-    ("equal", 19, 20, 20, 21),
-    ("insert", 20, 20, 21, 23),
-    ("equal", 20, 23, 23, 26),
-    ("insert", 23, 23, 26, 27),
-    ("equal", 23, 24, 27, 28),
+
+FUNCTIONS2_PY_REFORMATTED = dedent(
+    """\
+    def f(
+        a,
+        **kwargs,
+    ) -> A:
+        with cache_dir():
+            if something:
+                result = CliRunner().invoke(
+                    black.main, [str(src1), str(src2), "--diff", "--check"]
+                )
+        limited.append(-limited.pop())  # negate top
+        return A(
+            very_long_argument_name1=very_long_value_for_the_argument,
+            very_long_argument_name2=-very.long.value.for_the_argument,
+            **kwargs,
+        )
+
+
+    def g():
+        "Docstring."
+
+        def inner():
+            pass
+
+        print("Inner defs should breathe a little.")
+
+
+    def h():
+        def inner():
+            pass
+
+        print("Inner defs should breathe a little.")
+    """
+)
+
+
+EXPECT_OPCODES = [
+    ("equal", 0, 1, 0, 1),
+    ("replace", 1, 3, 1, 3),
+    ("equal", 3, 6, 3, 6),
+    ("replace", 6, 8, 6, 8),
+    ("equal", 8, 15, 8, 15),
+    ("insert", 15, 15, 15, 17),
+    ("equal", 15, 17, 17, 19),
+    ("insert", 17, 17, 19, 20),
+    ("equal", 17, 19, 20, 22),
+    ("insert", 19, 19, 22, 23),
+    ("equal", 19, 20, 23, 24),
+    ("insert", 20, 20, 24, 26),
+    ("equal", 20, 23, 26, 29),
+    ("insert", 23, 23, 29, 30),
+    ("equal", 23, 24, 30, 31),
 ]
 
 
 def test_diff_and_get_opcodes():
     src_lines = FUNCTIONS2_PY.splitlines()
-    dst_lines = format_str(FUNCTIONS2_PY, mode=FileMode()).splitlines()
+    dst_lines = FUNCTIONS2_PY_REFORMATTED.splitlines()
     opcodes = diff_and_get_opcodes(src_lines, dst_lines)
-    assert opcodes == OPCODES
+    assert opcodes == EXPECT_OPCODES
 
 
 def test_opcodes_to_chunks():
     src_lines = FUNCTIONS2_PY.splitlines()
-    dst_lines = format_str(FUNCTIONS2_PY, mode=FileMode()).splitlines()
+    dst_lines = FUNCTIONS2_PY_REFORMATTED.splitlines()
 
-    chunks = list(opcodes_to_chunks(OPCODES, src_lines, dst_lines))
+    chunks = list(opcodes_to_chunks(EXPECT_OPCODES, src_lines, dst_lines))
 
     assert chunks == [
+        (1, ["def f("], ["def f("]),
+        (2, ["  a,", "  **kwargs,"], ["    a,", "    **kwargs,"]),
         (
-            1,
-            ["def f(", "  a,", "  **kwargs,", ") -> A:"],
-            ["def f(a, **kwargs,) -> A:"],
-        ),
-        (
-            5,
-            ["    with cache_dir():", "        if something:"],
-            ["    with cache_dir():", "        if something:"],
+            4,
+            [") -> A:", "    with cache_dir():", "        if something:"],
+            [") -> A:", "    with cache_dir():", "        if something:"],
         ),
         (
             7,
@@ -143,6 +178,24 @@ def test_opcodes_to_chunks():
     ]
 
 
+EXAMPLE_OPCODES = [
+    ("replace", 0, 4, 0, 1),
+    ("equal", 4, 6, 1, 3),
+    ("replace", 6, 8, 3, 5),
+    ("equal", 8, 15, 5, 12),
+    ("insert", 15, 15, 12, 14),
+    ("equal", 15, 17, 14, 16),
+    ("insert", 17, 17, 16, 17),
+    ("equal", 17, 19, 17, 19),
+    ("insert", 19, 19, 19, 20),
+    ("equal", 19, 20, 20, 21),
+    ("insert", 20, 20, 21, 23),
+    ("equal", 20, 23, 23, 26),
+    ("insert", 23, 23, 26, 27),
+    ("equal", 23, 24, 27, 28),
+]
+
+
 @pytest.mark.parametrize(
     'context_lines, expect',
     [
@@ -152,7 +205,7 @@ def test_opcodes_to_chunks():
     ],
 )
 def test_opcodes_to_edit_linenums(context_lines, expect):
-    edit_linenums = list(opcodes_to_edit_linenums(OPCODES, context_lines))
+    edit_linenums = list(opcodes_to_edit_linenums(EXAMPLE_OPCODES, context_lines))
     expect_ranges = [[n, n] if isinstance(n, int) else n for n in expect]
     expect_linenums = list(chain(*(range(n[0], n[1] + 1) for n in expect_ranges)))
 

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -97,7 +97,7 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
     src_paths = git_repo.add({"test.py": "1\n2\n"}, commit="Initial commit")
     src_paths["test.py"].write("one\n2\n")
     monkeypatch.chdir(git_repo.root)
-    cmdline = ["echo", location]
+    cmdline = f"echo {location}"
 
     run_linter(cmdline, git_repo.root, {Path(p) for p in paths}, "HEAD")
 


### PR DESCRIPTION
Also dumps configuration on terminal if debug level logging is enabled with the `-vv` or `--verbose --verbose` command line option.