### PR TITLE
Support commit ranges for `-r` / `--revision`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Added
   pytest-darker_. Currently the formatting is a mix of `Black 19.10`_ and `Black 20.8`_
   rules, and Travis CI only requires Black 20.8 formatting for lines modified in merge
   requests. In a way, Darker is now eating its own dogfood.
+- Support commit ranges for ``-r``/``--revision``. Useful for comparing to the best
+  common ancestor, e.g. ``master...``.
 
 Fixed
 -----

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,9 @@ The following `command line arguments`_ can also be used to modify the defaults:
      -r REVISION, --revision REVISION
                            Git revision against which to compare the working
                            tree. Tags, branch names, commit hashes, and other
-                           expressions like HEAD~5 work here.
+                           expressions like HEAD~5 work here. Also a range like
+                           master...HEAD or master... can be used to compare the
+                           best common ancestor.
 
      --diff                Don't write the files back, just output a diff for
                            each file on stdout. Highlight syntax on screen if

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -49,7 +49,9 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         default="HEAD",
         help=(
             "Git revision against which to compare the working tree. Tags, branch"
-            " names, commit hashes, and other expressions like HEAD~5 work here."
+            " names, commit hashes, and other expressions like HEAD~5 work here. Also"
+            " a range like master...HEAD or master... can be used to compare the best"
+            " common ancestor."
         ),
     )
     isort_help = ["Also sort imports using the `isort` package"]


### PR DESCRIPTION
This is useful for comparing to the best common ancestor, e.g. `master...`.

I noticed the need for this when I had merges and other commits in `master` after the branch point from which the checked branch started. Without a range, code removed in `master` would get reformatted in the branch.