### PR TITLE
Unified text document class

### DIFF
--- a/src/darker/chooser.py
+++ b/src/darker/chooser.py
@@ -30,7 +30,9 @@ Example::
 """
 
 import logging
-from typing import Generator, Iterable, List, Tuple
+from typing import Generator, Iterable, List
+
+from darker.utils import DiffChunk
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +55,8 @@ def _any_item_in_range(items: List[int], start: int, length: int) -> bool:
 
 
 def choose_lines(
-    black_chunks: Iterable[Tuple[int, List[str], List[str]]], edit_linenums: List[int],
+    black_chunks: Iterable[DiffChunk],
+    edit_linenums: List[int],
 ) -> Generator[str, None, None]:
     """Choose formatted chunks for edited areas, original chunks for non-edited"""
     for original_lines_offset, original_lines, formatted_lines in black_chunks:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
@@ -41,7 +42,9 @@ def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDoc
 
     """
     if revision == WORKTREE:
-        return TextDocument.from_str((cwd / path).read_text("utf-8"))
+        abspath = cwd / path
+        mtime = datetime.utcfromtimestamp(abspath.stat().st_mtime)
+        return TextDocument.from_str(abspath.read_text("utf-8"), f"{mtime} +0000")
     cmd = ["git", "show", f"{revision}:./{path}"]
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from black import find_project_root
 
+from darker.utils import TextDocument
+
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -26,11 +28,11 @@ class IsortArgs(TypedDict, total=False):
 
 
 def apply_isort(
-    content: str,
+    content: TextDocument,
     src: Path,
     config: Optional[str] = None,
     line_length: Optional[int] = None,
-) -> str:
+) -> TextDocument:
     isort_args = IsortArgs()
     if config:
         isort_args["settings_file"] = config
@@ -44,5 +46,4 @@ def apply_isort(
             ", ".join(f"{k}={v!r}" for k, v in isort_args.items())
         )
     )
-    result: str = isort.code(code=content, **isort_args)
-    return result
+    return TextDocument.from_str(isort.code(code=content.string, **isort_args))

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from darker.black_diff import BlackArgs, read_black_config, run_black
+from darker.utils import TextDocument
 
 
 @pytest.mark.parametrize(
@@ -37,8 +38,8 @@ def test_black_config(tmpdir, config_path, config_lines, expect):
 
 
 def test_run_black(tmpdir):
-    src_contents = "print ( '42' )\n"
+    src = TextDocument.from_lines(["print ( '42' )"])
 
-    result = run_black(Path(tmpdir / "src.py"), src_contents, BlackArgs())
+    result = run_black(Path(tmpdir / "src.py"), src, BlackArgs())
 
-    assert result == ['print("42")']
+    assert result.lines == ('print("42")',)

--- a/src/darker/tests/test_chooser.py
+++ b/src/darker/tests/test_chooser.py
@@ -18,9 +18,9 @@ from darker.chooser import choose_lines
 )
 def test_choose_edited_lines(edited_line_numbers, expect):
     black_chunks = [
-        (0, ["original first line"], ["original first line"]),
-        (1, ["original second line"], ["changed second line"]),
-        (2, ["original third line"], ["original third line"]),
+        (0, ("original first line",), ("original first line",)),
+        (1, ("original second line",), ("changed second line",)),
+        (2, ("original third line",), ("original third line",)),
     ]
     result = list(choose_lines(black_chunks, edited_line_numbers))
     assert result == expect

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -11,7 +11,7 @@ from darker.__main__ import main
 from darker.command_line import make_argument_parser, parse_command_line
 from darker.git import RevisionRange
 from darker.tests.helpers import filter_dict, raises_if_exception
-from darker.utils import joinlines
+from darker.utils import TextDocument, joinlines
 
 pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 
@@ -387,7 +387,15 @@ def test_main_retval(check, changes, expect_retval):
     """main() return value is correct based on --check and the need to reformat files"""
     format_edited_parts = Mock()
     format_edited_parts.return_value = (
-        [(Path('/dummy.py'), 'old\n', 'new\n', ['new'])] if changes else []
+        [
+            (
+                Path("/dummy.py"),
+                TextDocument.from_lines(["old"]),
+                TextDocument.from_lines(["new"]),
+            )
+        ]
+        if changes
+        else []
     )
     check_arg_maybe = ['--check'] if check else []
     with patch.multiple(

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -8,6 +8,7 @@ from darker.diff import (
     opcodes_to_chunks,
     opcodes_to_edit_linenums,
 )
+from darker.utils import TextDocument
 
 FUNCTIONS2_PY = dedent(
     """\
@@ -96,41 +97,41 @@ EXPECT_OPCODES = [
 
 
 def test_diff_and_get_opcodes():
-    src_lines = FUNCTIONS2_PY.splitlines()
-    dst_lines = FUNCTIONS2_PY_REFORMATTED.splitlines()
-    opcodes = diff_and_get_opcodes(src_lines, dst_lines)
+    src = TextDocument.from_str(FUNCTIONS2_PY)
+    dst = TextDocument.from_str(FUNCTIONS2_PY_REFORMATTED)
+    opcodes = diff_and_get_opcodes(src, dst)
     assert opcodes == EXPECT_OPCODES
 
 
 def test_opcodes_to_chunks():
-    src_lines = FUNCTIONS2_PY.splitlines()
-    dst_lines = FUNCTIONS2_PY_REFORMATTED.splitlines()
+    src = TextDocument.from_str(FUNCTIONS2_PY)
+    dst = TextDocument.from_str(FUNCTIONS2_PY_REFORMATTED)
 
-    chunks = list(opcodes_to_chunks(EXPECT_OPCODES, src_lines, dst_lines))
+    chunks = list(opcodes_to_chunks(EXPECT_OPCODES, src, dst))
 
     assert chunks == [
-        (1, ["def f("], ["def f("]),
-        (2, ["  a,", "  **kwargs,"], ["    a,", "    **kwargs,"]),
+        (1, ("def f(",), ("def f(",)),
+        (2, ("  a,", "  **kwargs,"), ("    a,", "    **kwargs,")),
         (
             4,
-            [") -> A:", "    with cache_dir():", "        if something:"],
-            [") -> A:", "    with cache_dir():", "        if something:"],
+            (") -> A:", "    with cache_dir():", "        if something:"),
+            (") -> A:", "    with cache_dir():", "        if something:"),
         ),
         (
             7,
-            [
+            (
                 "            result = (",
                 "                CliRunner().invoke(black.main, [str(src1), str(src2), "
                 '"--diff", "--check"])',
-            ],
-            [
+            ),
+            (
                 "            result = CliRunner().invoke(",
                 '                black.main, [str(src1), str(src2), "--diff", "--check"]',  # noqa: E501
-            ],
+            ),
         ),
         (
             9,
-            [
+            (
                 "            )",
                 "    limited.append(-limited.pop())  # negate top",
                 "    return A(",
@@ -138,8 +139,8 @@ def test_opcodes_to_chunks():
                 "        very_long_argument_name2=-very.long.value.for_the_argument,",
                 "        **kwargs,",
                 "    )",
-            ],
-            [
+            ),
+            (
                 "            )",
                 "    limited.append(-limited.pop())  # negate top",
                 "    return A(",
@@ -147,33 +148,33 @@ def test_opcodes_to_chunks():
                 "        very_long_argument_name2=-very.long.value.for_the_argument,",
                 "        **kwargs,",
                 "    )",
-            ],
+            ),
         ),
-        (16, [], ["", ""]),
-        (16, ["def g():", '    "Docstring."'], ["def g():", '    "Docstring."']),
-        (18, [], [""]),
+        (16, (), ("", "")),
+        (16, ("def g():", '    "Docstring."'), ("def g():", '    "Docstring."')),
+        (18, (), ("",)),
         (
             18,
-            ["    def inner():", "        pass"],
-            ["    def inner():", "        pass"],
+            ("    def inner():", "        pass"),
+            ("    def inner():", "        pass"),
         ),
-        (20, [], [""]),
+        (20, (), ("",)),
         (
             20,
-            ['    print("Inner defs should breathe a little.")'],
-            ['    print("Inner defs should breathe a little.")'],
+            ('    print("Inner defs should breathe a little.")',),
+            ('    print("Inner defs should breathe a little.")',),
         ),
-        (21, [], ["", ""]),
+        (21, (), ("", "")),
         (
             21,
-            ["def h():", "    def inner():", "        pass"],
-            ["def h():", "    def inner():", "        pass"],
+            ("def h():", "    def inner():", "        pass"),
+            ("def h():", "    def inner():", "        pass"),
         ),
-        (24, [], [""]),
+        (24, (), ("",)),
         (
             24,
-            ['    print("Inner defs should breathe a little.")'],
-            ['    print("Inner defs should breathe a little.")'],
+            ('    print("Inner defs should breathe a little.")',),
+            ('    print("Inner defs should breathe a little.")',),
         ),
     ]
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -17,22 +17,29 @@ from darker.git import (
 )
 from darker.tests.conftest import GitRepoFixture
 from darker.tests.helpers import raises_if_exception
+from darker.utils import TextDocument
 
 
 @pytest.mark.parametrize(
     "revision, expect",
-    [("HEAD", ["modified content"]), ("HEAD^", ["original content"]), ("HEAD~2", [])],
+    [
+        (":WORKTREE:", ("new content",)),
+        ("HEAD", ("modified content",)),
+        ("HEAD^", ("original content",)),
+        ("HEAD~2", ()),
+    ],
 )
 def test_git_get_content_at_revision(git_repo, revision, expect):
+    """darker.git.git_get_content_at_revision()"""
     git_repo.add({"my.txt": "original content"}, commit="Initial commit")
     paths = git_repo.add({"my.txt": "modified content"}, commit="Initial commit")
-    paths['my.txt'].write('new content')
+    paths["my.txt"].write("new content")
 
-    original_content = git_get_content_at_revision(
-        Path("my.txt"), revision, cwd=git_repo.root
+    original = git_get_content_at_revision(
+        Path("my.txt"), revision, cwd=Path(git_repo.root)
     )
 
-    assert original_content == expect
+    assert original.lines == expect
 
 
 @pytest.mark.parametrize(
@@ -310,7 +317,7 @@ def test_edited_linenums_differ_revision_vs_worktree(git_repo, context_lines, ex
     """Tests for EditedLinenumsDiffer.revision_vs_worktree()"""
     paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
     paths["a.py"].write("1\n2\nthree\n4\n5\n6\nseven\n8\n")
-    differ = EditedLinenumsDiffer(git_repo.root, RevisionRange("HEAD"))
+    differ = EditedLinenumsDiffer(Path(git_repo.root), RevisionRange("HEAD"))
 
     result = differ.compare_revisions(Path("a.py"), context_lines)
 
@@ -321,9 +328,9 @@ def test_edited_linenums_differ_revision_vs_worktree(git_repo, context_lines, ex
 def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expect):
     """Tests for EditedLinenumsDiffer.revision_vs_lines()"""
     git_repo.add({'a.py': '1\n2\n3\n4\n5\n6\n7\n8\n'}, commit='Initial commit')
-    lines = ['1', '2', 'three', '4', '5', '6', 'seven', '8']
+    content = TextDocument.from_lines(["1", "2", "three", "4", "5", "6", "seven", "8"])
     differ = EditedLinenumsDiffer(git_repo.root, RevisionRange("HEAD"))
 
-    result = differ.revision_vs_lines(Path("a.py"), lines, context_lines)
+    result = differ.revision_vs_lines(Path("a.py"), content, context_lines)
 
     assert result == expect

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -5,15 +5,16 @@ import pytest
 from black import find_project_root
 
 from darker.import_sorting import apply_isort
+from darker.utils import TextDocument
 
-ORIGINAL_SOURCE = "import sys\nimport os\n"
-ISORTED_SOURCE = "import os\nimport sys\n"
+ORIGINAL_SOURCE = ("import sys", "import os")
+ISORTED_SOURCE = ("import os", "import sys")
 
 
 def test_apply_isort():
-    result = apply_isort(ORIGINAL_SOURCE, Path("test1.py"))
+    result = apply_isort(TextDocument.from_lines(ORIGINAL_SOURCE), Path("test1.py"))
 
-    assert result == ISORTED_SOURCE
+    assert result.lines == ISORTED_SOURCE
 
 
 @pytest.mark.parametrize(
@@ -60,5 +61,5 @@ def test_isort_config(monkeypatch, tmpdir, line_length, settings_file, expect):
     content = "from module import ab, cd, ef, gh, ij, kl, mn, op, qr, st, uv, wx, yz"
     config = str(tmpdir / settings_file) if settings_file else None
 
-    actual = apply_isort(content, Path("test1.py"), config)
-    assert actual == expect
+    actual = apply_isort(TextDocument.from_str(content), Path("test1.py"), config)
+    assert actual.string == expect

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -100,7 +100,9 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
     monkeypatch.chdir(git_repo.root)
     cmdline = f"echo {location}"
 
-    run_linter(cmdline, git_repo.root, {Path(p) for p in paths}, RevisionRange("HEAD"))
+    run_linter(
+        cmdline, Path(git_repo.root), {Path(p) for p in paths}, RevisionRange("HEAD")
+    )
 
     # We can now verify that the linter received the correct paths on its command line
     # by checking standard output from the our `echo` "linter".

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -1,3 +1,6 @@
+"""Unit tests for :mod:`darker.utils`"""
+
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -128,3 +131,29 @@ def test_textdocument_repr(document, expect):
     result = document.__repr__()
 
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    "document, expect",
+    [
+        (TextDocument(), ""),
+        (TextDocument(mtime=""), ""),
+        (TextDocument(mtime="dummy mtime"), "dummy mtime"),
+    ],
+)
+def test_textdocument_mtime(document, expect):
+    """TextDocument.mtime"""
+    assert document.mtime == expect
+
+
+def test_textdocument_from_file(tmp_path):
+    """TextDocument.from_file()"""
+    dummy_txt = tmp_path / "dummy.txt"
+    dummy_txt.write_text("dummy\ncontent\n")
+    os.utime(dummy_txt, (1_000_000_000, 1_000_000_000))
+
+    document = TextDocument.from_file(dummy_txt)
+
+    assert document.string == "dummy\ncontent\n"
+    assert document.lines == ("dummy", "content")
+    assert document.mtime == "2001-09-09 01:46:40.000000 +0000"

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -1,11 +1,24 @@
 from pathlib import Path
 from textwrap import dedent
 
-from darker.utils import debug_dump, get_common_root, get_path_ancestry, joinlines
+import pytest
+
+from darker.utils import (
+    TextDocument,
+    debug_dump,
+    get_common_root,
+    get_path_ancestry,
+    joinlines,
+)
 
 
 def test_debug_dump(capsys):
-    debug_dump([(1, ["black"], ["chunks"])], "old content", "new content", [2, 3])
+    debug_dump(
+        [(1, ("black",), ("chunks",))],
+        TextDocument.from_str("old content"),
+        TextDocument.from_str("new content"),
+        [2, 3],
+    )
     assert capsys.readouterr().out == (
         dedent(
             """\
@@ -19,7 +32,7 @@ def test_debug_dump(capsys):
 
 
 def test_joinlines():
-    result = joinlines(["a", "b", "c"])
+    result = joinlines(("a", "b", "c"))
     assert result == "a\nb\nc\n"
 
 
@@ -52,3 +65,66 @@ def test_get_path_ancestry_for_file(tmpdir):
     result = list(get_path_ancestry(dummy))
     assert result[-1] == tmpdir
     assert result[-2] == tmpdir.parent
+
+
+@pytest.mark.parametrize(
+    "document1, document2, expect",
+    [
+        (TextDocument(lines=["foo"]), TextDocument(lines=[]), False),
+        (TextDocument(lines=[]), TextDocument(lines=["foo"]), False),
+        (TextDocument(lines=["foo"]), TextDocument(lines=["bar"]), False),
+        (
+            TextDocument(lines=["line1", "line2"]),
+            TextDocument(lines=["line1", "line2"]),
+            True,
+        ),
+        (TextDocument(lines=["foo"]), TextDocument(""), False),
+        (TextDocument(lines=[]), TextDocument("foo\n"), False),
+        (TextDocument(lines=["foo"]), TextDocument("bar\n"), False),
+        (
+            TextDocument(lines=["line1", "line2"]),
+            TextDocument("line1\nline2\n"),
+            True,
+        ),
+        (TextDocument("foo\n"), TextDocument(lines=[]), False),
+        (TextDocument(""), TextDocument(lines=["foo"]), False),
+        (TextDocument("foo\n"), TextDocument(lines=["bar"]), False),
+        (
+            TextDocument("line1\nline2\n"),
+            TextDocument(lines=["line1", "line2"]),
+            True,
+        ),
+        (TextDocument("foo\n"), TextDocument(""), False),
+        (TextDocument(""), TextDocument("foo\n"), False),
+        (TextDocument("foo\n"), TextDocument("bar\n"), False),
+        (
+            TextDocument("line1\nline2\n"),
+            TextDocument("line1\nline2\n"),
+            True,
+        ),
+        (TextDocument("foo"), "line1\nline2\n", NotImplemented),
+    ],
+)
+def test_textdocument_eq(document1, document2, expect):
+    """TextDocument.__eq__()"""
+    result = document1.__eq__(document2)
+
+    assert result == expect
+
+
+@pytest.mark.parametrize(
+    "document, expect",
+    [
+        (TextDocument(""), "TextDocument([0 lines])"),
+        (TextDocument(lines=[]), "TextDocument([0 lines])"),
+        (TextDocument("One line\n"), "TextDocument([1 lines])"),
+        (TextDocument(lines=["One line"]), "TextDocument([1 lines])"),
+        (TextDocument("Two\nlines\n"), "TextDocument([2 lines])"),
+        (TextDocument(lines=["Two", "lines"]), "TextDocument([2 lines])"),
+    ],
+)
+def test_textdocument_repr(document, expect):
+    """TextDocument.__repr__()"""
+    result = document.__repr__()
+
+    assert result == expect

--- a/src/darker/tests/test_verification.py
+++ b/src/darker/tests/test_verification.py
@@ -1,20 +1,31 @@
+"""Unit tests for :mod:`darker.verification`"""
+
+
+from typing import List
+
 import pytest
 
+from darker.utils import DiffChunk, TextDocument
 from darker.verification import NotEquivalentError, verify_ast_unchanged
 
 
 @pytest.mark.parametrize(
     "src_content, dst_content, expect",
     [
-        ("if True: pass\n", "if False: pass\n", AssertionError),
-        ("if True: pass\n", "if True:\n    pass\n", None),
+        ("if True: pass", ["if False: pass"], AssertionError),
+        ("if True: pass", ["if True:", "    pass"], None),
     ],
 )
 def test_verify_ast_unchanged(src_content, dst_content, expect):
-    black_chunks = [(1, ["black"], ["chunks"])]
+    black_chunks: List[DiffChunk] = [(1, ("black",), ("chunks",))]
     edited_linenums = [1, 2]
     try:
-        verify_ast_unchanged(src_content, dst_content, black_chunks, edited_linenums)
+        verify_ast_unchanged(
+            TextDocument.from_lines([src_content]),
+            TextDocument.from_lines(dst_content),
+            black_chunks,
+            edited_linenums,
+        )
     except NotEquivalentError:
         assert expect is AssertionError
     else:

--- a/src/darker/utils.py
+++ b/src/darker/utils.py
@@ -13,6 +13,8 @@ GIT_DATEFORMAT = "%Y-%m-%d %H:%M:%S.%f +0000"
 
 
 class TextDocument:
+    """Store & handle a multi-line text document, either as a string or list of lines"""
+
     def __init__(
         self, string: str = None, lines: Iterable[str] = None, mtime: str = ""
     ):
@@ -22,34 +24,49 @@ class TextDocument:
 
     @property
     def string(self) -> str:
+        """Return the document as a string, converting and caching if necessary"""
         if self._string is None:
             self._string = joinlines(self._lines or ())
         return self._string
 
     @property
     def lines(self) -> TextLines:
+        """Return the document as a list of lines converting and caching if necessary"""
         if self._lines is None:
             self._lines = tuple((self._string or "").splitlines())
         return self._lines
 
     @property
     def mtime(self) -> str:
+        """Return the last modification time of the document"""
         return self._mtime
 
     @classmethod
-    def from_str(cls, s: str, mtime: str = "") -> "TextDocument":
-        return cls(s, None, mtime=mtime)
+    def from_str(cls, string: str, mtime: str = "") -> "TextDocument":
+        """Create a document object from a string"""
+        return cls(string, None, mtime=mtime)
 
     @classmethod
     def from_file(cls, path: Path) -> "TextDocument":
+        """Create a document object by reading an UTF-8 encoded text file
+
+        Also store the last modification time of the file.
+
+        """
         mtime = datetime.utcfromtimestamp(path.stat().st_mtime).strftime(GIT_DATEFORMAT)
         return cls.from_str(path.read_text(encoding="utf-8"), mtime=mtime)
 
     @classmethod
     def from_lines(cls, lines: Iterable[str], mtime: str = "") -> "TextDocument":
+        """Create a document object from a list of lines
+
+        The lines should be UTF-8 strings without trailing newlines.
+
+        """
         return cls(None, lines, mtime=mtime)
 
     def __eq__(self, other: object) -> bool:
+        """Compare the equality two text documents, ignoring the modification times"""
         if not isinstance(other, TextDocument):
             return NotImplemented
         if not self._string:
@@ -59,6 +76,7 @@ class TextDocument:
         return self._string == other.string
 
     def __repr__(self) -> str:
+        """Return a Python representation of the document object"""
         return f"{type(self).__name__}([{len(self.lines)} lines])"
 
 
@@ -128,6 +146,7 @@ class Buf:
             self._buf.seek(self._line_starts.pop())
 
     def next_line_startswith(self, prefix: Union[str, TextLines]) -> bool:
+        """Peek at the next line, return ``True`` if it starts with the given prefix"""
         try:
             return next(self).startswith(prefix)
         except StopIteration:

--- a/src/darker/verification.py
+++ b/src/darker/verification.py
@@ -1,10 +1,10 @@
 """Verification for unchanged AST before and after reformatting"""
 
-from typing import List, Tuple
+from typing import List
 
 from black import assert_equivalent
 
-from darker.utils import debug_dump
+from darker.utils import DiffChunk, TextDocument, debug_dump
 
 
 class NotEquivalentError(Exception):
@@ -12,14 +12,14 @@ class NotEquivalentError(Exception):
 
 
 def verify_ast_unchanged(
-    edited_to_file_str: str,
-    reformatted_str: str,
-    black_chunks: List[Tuple[int, List[str], List[str]]],
+    edited_to_file: TextDocument,
+    reformatted: TextDocument,
+    black_chunks: List[DiffChunk],
     edited_linenums: List[int],
 ) -> None:
     """Verify that source code parses to the same AST before and after reformat"""
     try:
-        assert_equivalent(edited_to_file_str, reformatted_str)
+        assert_equivalent(edited_to_file.string, reformatted.string)
     except AssertionError as exc_info:
-        debug_dump(black_chunks, edited_to_file_str, reformatted_str, edited_linenums)
+        debug_dump(black_chunks, edited_to_file, reformatted, edited_linenums)
         raise NotEquivalentError(str(exc_info))


### PR DESCRIPTION
We used to handle text documents either as strings or as lists of strings, or both, depending on in which format various 3rd party libraries needed them.

To simplify things, a `TextDocument` class has now been created. It automatically provides the contents of a document both in a string and a tuple of strings format. The objects are immutable, and tuples are used to achieve immutability of the text line collections.