### PR TITLE
Release version 1.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,16 @@ These features will be included in the next release:
 
 Added
 -----
-- Configure Flake8 verification for Darker source code
+
+Fixed
+-----
+
+
+1.2.0_ - 2020-09-09
+===================
+
+Added
+-----
 - Configuration for Darker can now be done in ``pyproject.toml``.
 - The formatting of the Darker code base itself is now checked using Darker itself and
   pytest-darker_. Currently the formatting is a mix of `Black 19.10`_ and `Black 20.8`_
@@ -13,9 +22,7 @@ Added
   requests. In a way, Darker is now eating its own dogfood.
 - Support commit ranges for ``-r``/``--revision``. Useful for comparing to the best
   common ancestor, e.g. ``master...``.
-
-Fixed
------
+- Configure Flake8 verification for Darker's own source code
 
 
 1.1.0_ - 2020-08-15
@@ -81,7 +88,8 @@ Added
 -----
 - Initial implementation
 
-.. _Unreleased: https://github.com/akaihola/darker/compare/1.1.0...HEAD
+.. _Unreleased: https://github.com/akaihola/darker/compare/1.2.0...HEAD
+.. _1.2.0: https://github.com/akaihola/darker/compare/1.1.0...1.2.0
 .. _1.1.0: https://github.com/akaihola/darker/compare/1.0.0...1.1.0
 .. _1.0.0: https://github.com/akaihola/darker/compare/0.2.0...1.0.0
 .. _0.2.0: https://github.com/akaihola/darker/compare/0.1.1...0.2.0

--- a/README.rst
+++ b/README.rst
@@ -124,10 +124,10 @@ Example:
 
    if False: print('there')
 
-Customizing Black and isort behavior
-====================================
+Customizing ``darker``, Black and isort behavior
+================================================
 
-Project-specific default options for Black_ and isort_
+Project-specific default options for ``darker``, Black_ and isort_
 are read from the project's ``pyproject.toml`` file in the repository root.
 isort_ also looks for a few other places for configuration.
 
@@ -171,19 +171,42 @@ The following `command line arguments`_ can also be used to modify the defaults:
      -l LINE_LENGTH, --line-length LINE_LENGTH
                            How many characters per line to allow [default: 88]
 
-*New in version 1.0.0:* The ``-c``, ``-S`` and ``-l`` command line options.
+To change default values for these options for a given project,
+add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory.
+For example:
 
-*New in version 1.0.0:* isort_ is configured with ``-c`` and ``-l``, too.
+.. code-block:: toml
 
-*New in version 1.1.0:* The ``-r`` / ``--revision`` command line option.
+   [tool.darker]
+   src = [
+       "src/mypackage",
+   ]
+   revision = "master"
+   diff = true
+   check = true
+   isort = true
+   lint = [
+       "pylint",
+   ]
+   log_level = "INFO"
 
-*New in version 1.1.0:* The ``--diff`` command line option.
+*New in version 1.0.0:*
 
-*New in version 1.1.0:* The ``--check`` command line option.
+- The ``-c``, ``-S`` and ``-l`` command line options.
+- isort_ is configured with ``-c`` and ``-l``, too.
 
-*New in version 1.1.0:* The ``--no-skip-string-normalization`` command line option.
+*New in version 1.1.0:* The command line options
 
-*New in version 1.1.0:* The ``-L`` / ``--lint`` command line option.
+- ``-r`` / ``--revision``
+- ``--diff``
+- ``--check``
+- ``--no-skip-string-normalization``
+- ``-L`` / ``--lint``
+
+*New in version 1.2.0:* Support for
+
+- commit ranges in ``-r`` / ``--revision``.
+- a ``[tool.darker]`` section in ``pyproject.toml``.
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,3 +1,3 @@
 """The version number for Darker is governed by this file"""
 
-__version__ = "1.1.1.dev0"
+__version__ = "1.2.0"


### PR DESCRIPTION
- Configuration for Darker can now be done in ``pyproject.toml``.
- The formatting of the Darker code base itself is now checked using Darker itself and pytest-darker. Currently the formatting is a mix of Black 19.10 and Black 20.8 rules, and Travis CI only requires Black 20.8 formatting for lines modified in merge requests. In a way, Darker is now eating its own dogfood.
- Support commit ranges for `-r`/`--revision`. Useful for comparing to the best common ancestor, e.g. `master...`.
- Configure Flake8 verification for Darker's own source code