### PR TITLE
Common ancestor fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- ``<commit>...`` now compares always correctly to the latest common ancestor
 
 
 1.2.1_ - 2020-11-30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ known_third_party = ["pytest"]
 src = [
     "src",
 ]
-revision = "master"
+revision = "master..."
 lint = [
     "pylint",
 ]

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -9,6 +9,7 @@ import toml
 from darker import black_diff
 from darker.__main__ import main
 from darker.command_line import make_argument_parser, parse_command_line
+from darker.git import RevisionRange
 from darker.tests.helpers import filter_dict, raises_if_exception
 from darker.utils import joinlines
 
@@ -339,21 +340,27 @@ def test_black_options_skip_string_normalization(git_repo, config, options, expe
 @pytest.mark.parametrize(
     'options, expect',
     [
-        (["a.py"], ({Path("a.py")}, "HEAD", False, [], {})),
-        (["--isort", "a.py"], ({Path("a.py")}, "HEAD", True, [], {})),
+        (["a.py"], ({Path("a.py")}, RevisionRange("HEAD"), False, [], {})),
+        (["--isort", "a.py"], ({Path("a.py")}, RevisionRange("HEAD"), True, [], {})),
         (
             ["--config", "my.cfg", "a.py"],
-            ({Path("a.py")}, "HEAD", False, [], {"config": "my.cfg"}),
+            ({Path("a.py")}, RevisionRange("HEAD"), False, [], {"config": "my.cfg"}),
         ),
         (
             ["--line-length", "90", "a.py"],
-            ({Path("a.py")}, "HEAD", False, [], {"line_length": 90}),
+            ({Path("a.py")}, RevisionRange("HEAD"), False, [], {"line_length": 90}),
         ),
         (
             ["--skip-string-normalization", "a.py"],
-            ({Path("a.py")}, "HEAD", False, [], {"skip_string_normalization": True}),
+            (
+                {Path("a.py")},
+                RevisionRange("HEAD"),
+                False,
+                [],
+                {"skip_string_normalization": True},
+            ),
         ),
-        (["--diff", "a.py"], ({Path("a.py")}, "HEAD", False, [], {})),
+        (["--diff", "a.py"], ({Path("a.py")}, RevisionRange("HEAD"), False, [], {})),
     ],
 )
 def test_options(tmpdir, monkeypatch, options, expect):

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from darker.git import RevisionRange
 from darker.linting import _parse_linter_line, run_linter
 
 
@@ -99,7 +100,7 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
     monkeypatch.chdir(git_repo.root)
     cmdline = f"echo {location}"
 
-    run_linter(cmdline, git_repo.root, {Path(p) for p in paths}, "HEAD")
+    run_linter(cmdline, git_repo.root, {Path(p) for p in paths}, RevisionRange("HEAD"))
 
     # We can now verify that the linter received the correct paths on its command line
     # by checking standard output from the our `echo` "linter".

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -8,6 +8,7 @@ from black import find_project_root
 
 import darker.__main__
 import darker.import_sorting
+from darker.git import RevisionRange
 
 
 def test_isort_option_without_isort(tmpdir, without_isort, caplog):
@@ -57,7 +58,11 @@ def test_isort_option_with_isort_calls_sortimports(tmpdir, run_isort, isort_args
 def test_format_edited_parts_empty():
     with pytest.raises(ValueError):
 
-        list(darker.__main__.format_edited_parts([], "HEAD", False, [], {}))
+        list(
+            darker.__main__.format_edited_parts(
+                [], RevisionRange("HEAD"), False, [], {}
+            )
+        )
 
 
 A_PY = ['import sys', 'import os', "print( '42')", '']
@@ -119,7 +124,7 @@ def test_format_edited_parts(git_repo, monkeypatch, enable_isort, black_args, ex
 
     changes = list(
         darker.__main__.format_edited_parts(
-            [Path("a.py")], "HEAD", enable_isort, [], black_args
+            [Path("a.py")], RevisionRange("HEAD"), enable_isort, [], black_args
         )
     )
 
@@ -135,7 +140,9 @@ def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
     paths['b.py'].write('"not"\n"checked"\n')
 
     result = list(
-        darker.__main__.format_edited_parts([Path("a.py")], "HEAD", True, [], {})
+        darker.__main__.format_edited_parts(
+            [Path("a.py")], RevisionRange("HEAD"), True, [], {}
+        )
     )
 
     assert result == []


### PR DESCRIPTION
Bugfix: `<commit>...` now compares always correctly to the latest common ancestor

This merge request used to be even larger, but I've managed to trim it down. I hope someone is willing to review it in one go.

**Note:** #107 will fix the build failure.