### PR TITLE
Refactor conditional raise assertion in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ isort =
     isort>=5.0.1
 test =
     pylint
-    pytest>=5.4
+    pytest>=6.1.0
     pytest-darker
     pytest-flake8>=1.0.6
     pytest-isort>=1.1.0

--- a/src/darker/tests/helpers.py
+++ b/src/darker/tests/helpers.py
@@ -1,8 +1,31 @@
 """Helper functions for unit tests"""
 
-from typing import Any, Dict
+import sys
+from typing import Any, ContextManager, Dict, Union
+
+import pytest
+from _pytest.python_api import RaisesContext
+
+if sys.version_info >= (3, 7):
+    from contextlib import nullcontext
+else:
+    from contextlib import suppress as nullcontext
 
 
 def filter_dict(dct: Dict[str, Any], filter_key: str) -> Dict[str, Any]:
     """Return only given keys with their values from a dictionary"""
     return {key: value for key, value in dct.items() if key == filter_key}
+
+
+def raises_if_exception(expect: Any) -> Union[RaisesContext[Any], ContextManager[None]]:
+    """Return a ``pytest.raises`` context manager only if expecting an exception
+
+    If the expected value is not an exception, return a dummy context manager.
+    On Python 3.8+ :class:`contextlib.nullcontext` is returned,
+    while on older Pythons :class:`contextlib.suppress` is used instead.
+
+    """
+    if isinstance(expect, type) and issubclass(expect, BaseException):
+        return pytest.raises(expect)
+    else:
+        return nullcontext()

--- a/src/darker/tests/test_argparse_helpers.py
+++ b/src/darker/tests/test_argparse_helpers.py
@@ -1,12 +1,12 @@
 """Tests for the ``darker.argparse_helpers`` module"""
 
 from argparse import ArgumentParser, Namespace
-from contextlib import suppress
 from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
 
 import pytest
 
 from darker import argparse_helpers
+from darker.tests.helpers import raises_if_exception
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,7 @@ from darker import argparse_helpers
 )
 def test_fill_line(line, width, indent, expect):
     """``_fill_line()`` wraps lines correctly"""
-    with pytest.raises(expect) if isinstance(expect, type) else suppress():
+    with raises_if_exception(expect):
 
         result = argparse_helpers._fill_line(  # pylint: disable=protected-access
             line, width, indent

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import DEFAULT, Mock, call, patch
@@ -10,14 +9,8 @@ import toml
 from darker import black_diff
 from darker.__main__ import main
 from darker.command_line import make_argument_parser, parse_command_line
-from darker.tests.helpers import filter_dict
+from darker.tests.helpers import filter_dict, raises_if_exception
 from darker.utils import joinlines
-
-if sys.version_info >= (3, 7):
-    from contextlib import nullcontext
-else:
-    from contextlib import suppress as nullcontext
-
 
 pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 
@@ -26,7 +19,7 @@ pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 def test_make_argument_parser(require_src, expect):
     """Parser from ``make_argument_parser()`` fails if src required but not provided"""
     parser = make_argument_parser(require_src)
-    with pytest.raises(expect) if isinstance(expect, type) else nullcontext():
+    with raises_if_exception(expect):
 
         args = parser.parse_args([])
 
@@ -77,7 +70,7 @@ def test_parse_command_line_config_src(
     monkeypatch.chdir(tmpdir)
     if config is not None:
         toml.dump({"tool": {"darker": config}}, tmpdir / "pyproject.toml")
-    with pytest.raises(SystemExit) if isinstance(expect, type) else nullcontext():
+    with raises_if_exception(expect):
 
         args, effective_cfg, modified_cfg = parse_command_line(argv)
 

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -1,13 +1,7 @@
-import sys
-
-if sys.version_info >= (3, 7):
-    from contextlib import nullcontext
-else:
-    from contextlib import suppress as nullcontext
-
 import pytest
 
 from darker.__main__ import main
+from darker.tests.helpers import raises_if_exception
 
 # The following test is a bit dense, so some explanation is due.
 #
@@ -97,12 +91,10 @@ def test_revision(git_repo, monkeypatch, capsys, revision, worktree_content, exp
     for path in paths.values():
         path.write(worktree_content)
     arguments = ["--diff", "--revision", revision, "."]
-    should_raise = expect is SystemExit
 
-    with pytest.raises(SystemExit) if should_raise else nullcontext():
+    with raises_if_exception(expect):
         main(arguments)
 
-    if not should_raise:
         modified_files = [
             line[4:-3]
             for line in capsys.readouterr().out.splitlines()


### PR DESCRIPTION
- [x] refactor context manager conditionals into a helper
- [x] fix test failures for Python 3.8
- [x] fix test failures for Python 3.7
- [x] fix test failures for Python 3.6

Some parameterized tests have both values and exceptions as expected outcomes. With recent Pytest and Mypy versions, the type of the conditional context manager doesn't check when written using Python's ternary operator. We get these errors when Pytest runs Mypy checks for Darker:
```python
__________________ src/darker/tests/test_argparse_helpers.py ___________________
33: error: "object" has no attribute "__enter__"
33: error: "object" has no attribute "__exit__"
____________________ src/darker/tests/test_command_line.py _____________________
31: error: "object" has no attribute "__enter__"
31: error: "object" has no attribute "__exit__"
86: error: "object" has no attribute "__enter__"
86: error: "object" has no attribute "__exit__"
____________________ src/darker/tests/test_main_revision.py ____________________
102: error: "object" has no attribute "__enter__"
102: error: "object" has no attribute "__exit__"
```
The problem is that `pytest.raises` and `contextlib.nullcontext` in an `... if ... else ...` ternary operator have no common ancestor classes, so Mypy assigns it the type `object`. To reproduce, create this Python source file:
```python
# ternary_context_manager.py

import pytest
from contextlib import nullcontext

def myfunc(should_raise: bool) -> None:
    cm = pytest.raises(Exception) if should_raise else nullcontext()
    reveal_type(cm)
    with cm:
        pass
```
Analyze it with Mypy in a Python 3.8 virtualenv:
```bash
python3.8 -m venv venv
. venv/bin/activate
pip install pytest==6.1.1 mypy==0.782
mypy ternary_context_manager.py
```
You'll get:
```python
ternary_context_manager.py:8: note: Revealed type is 'builtins.object'
ternary_context_manager.py:9: error: "object" has no attribute "__enter__"
ternary_context_manager.py:9: error: "object" has no attribute "__exit__"
Found 2 errors in 1 file (checked 1 source file)
```
The `with` statement expects the expression to have `__enter__` and `__exit__` methods (i.e. to be a context manager), which `object` of course doesn't have. At run time this isn't a problem, but for Mypy it is.

Fix this by refactoring the conditional into a helper function which returns different context managers using an `if..else` instead. This also reduces duplication of code in tests.
