### PR TITLE
Make `--diff` output identical to Black

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ These features will be included in the next release:
 Added
 -----
 - Support for Black's ``--skip-magic-trailing-comma`` option
+- ``darker --diff`` output is now identical to that of ``black --diff``
 
 Fixed
 -----

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -150,11 +150,27 @@ def modify_file(path: Path, new_content: TextDocument) -> None:
 
 
 def print_diff(path: Path, old: TextDocument, new: TextDocument) -> None:
-    """Print ``black --diff`` style output for the changes"""
+    """Print ``black --diff`` style output for the changes
+
+    :param path: The relative path of the file to print the diff output for
+    :param old: Old contents of the file
+    :param new: New contents of the file
+
+    Modification times should be in the format "YYYY-MM-DD HH:MM:SS:mmmmmm +0000"
+
+    """
     relative_path = path.resolve().relative_to(Path.cwd()).as_posix()
     diff = "\n".join(
         line.rstrip("\n")
-        for line in unified_diff(old.lines, new.lines, relative_path, relative_path)
+        for line in unified_diff(
+            old.lines,
+            new.lines,
+            fromfile=relative_path,
+            tofile=relative_path,
+            fromfiledate=old.mtime,
+            tofiledate=new.mtime,
+            n=5,  # Black shows 5 lines of context, do the same
+        )
     )
 
     if sys.stdout.isatty():

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from argparse import Action, ArgumentError
+from datetime import datetime
 from difflib import unified_diff
 from pathlib import Path
 from typing import Generator, Iterable, List, Tuple
@@ -22,7 +23,7 @@ from darker.git import (
 from darker.help import ISORT_INSTRUCTION
 from darker.import_sorting import apply_isort, isort
 from darker.linting import run_linters
-from darker.utils import TextDocument, get_common_root
+from darker.utils import GIT_DATEFORMAT, TextDocument, get_common_root
 from darker.verification import BinarySearch, NotEquivalentError, verify_ast_unchanged
 
 logger = logging.getLogger(__name__)
@@ -104,6 +105,7 @@ def format_edited_parts(
                 choose_lines(black_chunks, edited_linenums),
                 encoding=rev2_content.encoding,
                 newline=rev2_content.newline,
+                mtime=datetime.utcnow().strftime(GIT_DATEFORMAT),
             )
 
             # 8. verify

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
@@ -39,7 +40,7 @@ def git_get_mtime_at_commit(path: Path, revision: str, cwd: Path) -> str:
     :param cwd: The root of the Git repository
 
     """
-    cmd = ["git", "log", "-1", "--format=%ct", revision, "--", str(path)]
+    cmd = ["log", "-1", "--format=%ct", revision, "--", str(path)]
     lines = _git_check_output_lines(cmd, cwd)
     return datetime.utcfromtimestamp(int(lines[0])).strftime(GIT_DATEFORMAT)
 
@@ -64,7 +65,8 @@ def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDoc
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:
         return TextDocument.from_lines(
-            _git_check_output_lines(cmd, cwd, exit_on_error=False)
+            _git_check_output_lines(cmd, cwd, exit_on_error=False),
+            mtime=git_get_mtime_at_commit(path, revision, cwd),
         )
     except CalledProcessError as exc_info:
         if exc_info.returncode != 128:
@@ -145,7 +147,7 @@ def _git_check_output_lines(
     """Log command line, run Git, split stdout to lines, exit with 123 on error"""
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:
-        return check_output(["git"] + cmd, cwd=str(cwd)).decode("utf-8").splitlines()
+        return check_output(["git"] + cmd, cwd=str(cwd), encoding="utf-8").splitlines()
     except CalledProcessError as exc_info:
         if exc_info.returncode == 128 and exit_on_error:
             # Bad revision or another Git failure. Follow Black's example and return the
@@ -213,9 +215,7 @@ class EditedLinenumsDiffer:
     @lru_cache(maxsize=1)
     def compare_revisions(self, path_in_repo: Path, context_lines: int) -> List[int]:
         """Return numbers of lines changed between a given revision and the worktree"""
-        content = git_get_content_at_revision(
-            path_in_repo, self.revrange.rev2, self.git_root
-        )
+        content = TextDocument.from_file(self.git_root / path_in_repo)
         return self.revision_vs_lines(path_in_repo, content, context_lines)
 
     def revision_vs_lines(

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -11,7 +11,7 @@ from subprocess import CalledProcessError, check_output
 from typing import Iterable, List, Set
 
 from darker.diff import diff_and_get_opcodes, opcodes_to_edit_linenums
-from darker.utils import TextDocument
+from darker.utils import GIT_DATEFORMAT, TextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,19 @@ COMMIT_RANGE_RE = re.compile(r"(.*?)(\.{2,3})(.*)$")
 #   for determining the revision range
 WORKTREE = ":WORKTREE:"
 PRE_COMMIT_FROM_TO_REFS = ":PRE-COMMIT:"
+
+
+def git_get_mtime_at_commit(path: Path, revision: str, cwd: Path) -> str:
+    """Return the committer date of the given file at the given revision
+
+    :param path: The relative path of the file in the Git repository
+    :param revision: The Git revision for which to get the file modification time
+    :param cwd: The root of the Git repository
+
+    """
+    cmd = ["git", "log", "-1", "--format=%ct", revision, "--", str(path)]
+    lines = _git_check_output_lines(cmd, cwd)
+    return datetime.utcfromtimestamp(int(lines[0])).strftime(GIT_DATEFORMAT)
 
 
 def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDocument:

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -62,5 +62,7 @@ def apply_isort(
         )
     )
     return TextDocument.from_str(
-        isort_code(code=content.string, **isort_args), encoding=content.encoding
+        isort_code(code=content.string, **isort_args),
+        encoding=content.encoding,
+        mtime=content.mtime,
     )

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`darker.git`"""
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,protected-access
 
 import os
 from datetime import datetime, timedelta
@@ -12,16 +12,6 @@ from unittest.mock import patch
 import pytest
 
 from darker import git
-from darker.git import (
-    COMMIT_RANGE_RE,
-    WORKTREE,
-    EditedLinenumsDiffer,
-    RevisionRange,
-    _git_check_output_lines,
-    git_get_content_at_revision,
-    git_get_modified_files,
-    should_reformat_file,
-)
 from darker.tests.conftest import GitRepoFixture
 from darker.tests.helpers import raises_or_matches
 from darker.utils import GIT_DATEFORMAT, TextDocument
@@ -43,7 +33,7 @@ from darker.utils import GIT_DATEFORMAT, TextDocument
 )
 def test_commit_range_re(revision_range, expect):
     """Test for ``COMMIT_RANGE_RE``"""
-    match = COMMIT_RANGE_RE.match(revision_range)
+    match = git.COMMIT_RANGE_RE.match(revision_range)
     if expect is None:
         assert match is None
     else:
@@ -53,13 +43,13 @@ def test_commit_range_re(revision_range, expect):
 
 def test_worktree_symbol():
     """Test for the ``WORKTREE`` symbol"""
-    assert WORKTREE == ":WORKTREE:"
+    assert git.WORKTREE == ":WORKTREE:"
 
 
 def test_git_get_mtime_at_commit():
     """darker.git.git_get_mtime_at_commit()"""
-    with patch.object(git, "_git_check_output_lines") as _git_check_output_lines:
-        _git_check_output_lines.return_value = ["1609104839"]
+    with patch.object(git, "_git_check_output_lines"):
+        git._git_check_output_lines.return_value = ["1609104839"]  # type: ignore
 
         result = git.git_get_mtime_at_commit(
             Path("dummy path"), "dummy revision", Path("dummy cwd")
@@ -92,7 +82,7 @@ def test_git_get_content_at_revision(git_repo, revision, expect_lines, expect_mt
     paths["my.txt"].write_bytes(b"new content")
     os.utime(paths["my.txt"], (1000000000, 1000000000))
 
-    result = git_get_content_at_revision(
+    result = git.git_get_content_at_revision(
         Path("my.txt"), revision, cwd=Path(git_repo.root)
     )
 
@@ -124,7 +114,7 @@ def test_git_get_content_at_revision(git_repo, revision, expect_lines, expect_mt
 )
 def test_revisionrange_parse(revision_range, expect):
     """Test for :meth:`RevisionRange.parse`"""
-    revrange = RevisionRange.parse(revision_range)
+    revrange = git.RevisionRange.parse(revision_range)
     assert (revrange.rev1, revrange.rev2, revrange.use_common_ancestor) == expect
 
 
@@ -157,7 +147,7 @@ def test_git_get_content_at_revision_git_calls(revision, expect):
         # a dummy Unix timestamp:
         check_output.return_value = b"1000000"
 
-        git_get_content_at_revision(Path("my.txt"), revision, Path("cwd"))
+        git.git_get_content_at_revision(Path("my.txt"), revision, Path("cwd"))
 
         assert check_output.call_count == len(expect)
         for expect_call in expect:
@@ -182,7 +172,7 @@ def test_should_reformat_file(tmpdir, path, create, expect):
     if create:
         (tmpdir / path).ensure()
 
-    result = should_reformat_file(Path(tmpdir / path))
+    result = git.should_reformat_file(Path(tmpdir / path))
 
     assert result == expect
 
@@ -246,7 +236,7 @@ def test_git_check_output_lines(branched_repo, cmd, exit_on_error, expect_templa
         expect = [replacements.get(line, line) for line in expect_template]
     with raises_or_matches(expect, ["returncode", "code"]) as check:
 
-        check(_git_check_output_lines(cmd, branched_repo.root, exit_on_error))
+        check(git._git_check_output_lines(cmd, branched_repo.root, exit_on_error))
 
 
 @pytest.mark.kwparametrize(
@@ -287,8 +277,8 @@ def test_git_get_modified_files(git_repo, modify_paths, paths, expect):
             absolute_path.parent.mkdir(parents=True, exist_ok=True)
             absolute_path.write_bytes(content.encode("ascii"))
 
-    result = git_get_modified_files(
-        {root / p for p in paths}, RevisionRange("HEAD"), cwd=root
+    result = git.git_get_modified_files(
+        {root / p for p in paths}, git.RevisionRange("HEAD"), cwd=root
     )
 
     assert result == {Path(p) for p in expect}
@@ -440,9 +430,9 @@ def test_git_get_modified_files_revision_range(
     _description, branched_repo, revrange, expect
 ):
     """Test for :func:`darker.git.git_get_modified_files` with a revision range"""
-    result = git_get_modified_files(
+    result = git.git_get_modified_files(
         [Path(branched_repo.root)],
-        RevisionRange.parse(revrange),
+        git.RevisionRange.parse(revrange),
         Path(branched_repo.root),
     )
 
@@ -481,7 +471,7 @@ def test_revisionrange_parse_pre_commit(
     """RevisionRange.parse(':PRE-COMMIT:') gets the range from environment variables"""
     with patch.dict(os.environ, environ):
 
-        result = RevisionRange.parse(":PRE-COMMIT:")
+        result = git.RevisionRange.parse(":PRE-COMMIT:")
 
         assert result.rev1 == expect_rev1
         assert result.rev2 == expect_rev2
@@ -501,7 +491,7 @@ def test_edited_linenums_differ_compare_revisions(git_repo, context_lines, expec
     """Tests for EditedLinenumsDiffer.revision_vs_worktree()"""
     paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
     paths["a.py"].write_bytes(b"1\n2\nthree\n4\n5\n6\nseven\n8\n")
-    differ = EditedLinenumsDiffer(Path(git_repo.root), RevisionRange("HEAD"))
+    differ = git.EditedLinenumsDiffer(Path(git_repo.root), git.RevisionRange("HEAD"))
 
     linenums = differ.compare_revisions(Path("a.py"), context_lines)
 
@@ -513,7 +503,7 @@ def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expec
     """Tests for EditedLinenumsDiffer.revision_vs_lines()"""
     git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
     content = TextDocument.from_lines(["1", "2", "three", "4", "5", "6", "seven", "8"])
-    differ = EditedLinenumsDiffer(git_repo.root, RevisionRange("HEAD"))
+    differ = git.EditedLinenumsDiffer(git_repo.root, git.RevisionRange("HEAD"))
 
     linenums = differ.revision_vs_lines(Path("a.py"), content, context_lines)
 

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -142,7 +142,7 @@ def test_revision(git_repo, monkeypatch, capsys, revision, worktree_content, exp
         main(arguments)
 
         modified_files = [
-            line[4:-3]
+            line.split("\t")[0][4:-3]
             for line in capsys.readouterr().out.splitlines()
             if line.startswith("+++ ")
         ]


### PR DESCRIPTION
- [x] 5 lines of context
- [x] include modification times
- [x] fix any failing tests
- [x] add test coverage for new code and code paths

This may also fix (or might not) #67 – VS Code compatibility problem.

ping @virtuald @shangxiao @Carreau 