### PR TITLE
Strip raw HTML from `README.rst` when packaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -634,6 +634,7 @@ Thanks goes to these wonderful people (`emoji key`_):
 This project follows the all-contributors_ specification.
 Contributions of any kind are welcome!
 
+.. _README.rst: https://github.com/akaihola/darker/README.rst
 .. _emoji key: https://allcontributors.org/docs/en/emoji-key
 .. _all-contributors: https://allcontributors.org
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author_email = 13725+akaihola@users.noreply.github.com
 license = BSD
 license_file = LICENSE.rst
 description = Apply Black formatting only in regions changed since last commit
-long_description = file:README.rst
+# long_description is read and manipulated in setup.py
 long_description_content_type = text/x-rst
 classifiers =
     Programming Language :: Python :: 3 :: Only

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def make_pypi_compliant_readme() -> str:
     with open("README.rst") as fp:
         original_readme = fp.read()
     modified_readme = CONTRIBUTORS_RE.sub(
-        "\nSee README.rst_ for the list of contributors.\n" "\nThis project follows ",
+        "\nSee README.rst_ for the list of contributors.\n\nThis project follows ",
         original_readme,
     )
     if modified_readme == original_readme:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,35 @@
+import re
+
 from setuptools import setup
 
-setup()
+CONTRIBUTORS_RE = re.compile(r"""\nThanks goes .*\nThis project follows """, re.DOTALL)
+
+
+def make_pypi_compliant_readme() -> str:
+    """Remove raw HTML from ``README.rst`` before packaging
+
+    The contributors table should only be shown on GitHub. It must be removed before
+    being displayed on PyPI. The simplest way to do this is to simply match and strip it
+    when creating a distribution archive.
+
+    This function reads the contents of ``README.rst``, replaces the row HTML section
+    with a plain-text link to the README on GitHub and returns the resulting string.
+
+    :return: The contents of a PyPI compliant ``README.rst``
+
+    """
+    with open("README.rst") as fp:
+        original_readme = fp.read()
+    modified_readme = CONTRIBUTORS_RE.sub(
+        "\nSee README.rst_ for the list of contributors.\n" "\nThis project follows ",
+        original_readme,
+    )
+    if modified_readme == original_readme:
+        raise RuntimeError(
+            f"The contributors table couldn't be found in README.rst using the pattern "
+            f"'{CONTRIBUTORS_RE.pattern}'"
+        )
+    return modified_readme
+
+
+setup(long_description=make_pypi_compliant_readme())


### PR DESCRIPTION
PyPI doesn't allow raw HTML in the README. Strip it out before creating distribution archives.

Raw HTML is used for the contributors table to be displayed on GitHub.

To verify that this works correctly, you can do the following:
```bash
pip install wheel twine
rm dist/*.whl dist/*.tar.gz
python setup.py sdist ; python setup.py bdist_wheel ; twine check dist/*
```

For more information, see [Validating reStructuredText markup](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup) in the [Making a PyPI-friendly README](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup) section of the [Python Packaging User Guide](https://packaging.python.org/).