### PR TITLE
Binary search to minimize number of context lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Added
 -----
 - A unified ``TextDocument`` class to represent source code file contents
 - Move help texts into the separate ``darker.help`` module
+- If AST differs with zero context lines, search for the lowest successful number of
+  context lines using a binary search to improve performance
 
 Fixed
 -----
@@ -18,6 +20,7 @@ Fixed
   ``--revision :PRE-COMMIT:`` is set, but ``PRE_COMMIT_FROM_REF`` or
   ``PRE_COMMIT_TO_REF`` are not set.
 
+  
 1.2.2_ - 2020-12-30
 ===================
 

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -16,7 +16,7 @@ from darker.help import ISORT_INSTRUCTION
 from darker.import_sorting import apply_isort, isort
 from darker.linting import run_linters
 from darker.utils import TextDocument, get_common_root
-from darker.verification import NotEquivalentError, verify_ast_unchanged
+from darker.verification import BinarySearch, NotEquivalentError, verify_ast_unchanged
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,16 @@ def format_edited_parts(
         else:
             edited = worktree_content
         max_context_lines = len(edited.lines)
-        for context_lines in range(max_context_lines + 1):
+        minimum_context_lines = BinarySearch(0, max_context_lines + 1)
+        last_successful_reformat = None
+        while not minimum_context_lines.found:
+            context_lines = minimum_context_lines.get_next()
+            if context_lines > 0:
+                logger.warning(
+                    "Trying with %s lines of context for `git diff -U %s`",
+                    context_lines,
+                    src,
+                )
             # 2. diff the given revision and worktree for the file
             # 3. extract line numbers in the edited to-file for changed lines
             edited_linenums = edited_linenums_differ.revision_vs_lines(
@@ -99,21 +108,26 @@ def format_edited_parts(
                 # a partially re-formatted Python file which produces an identical AST.
                 # Try again with a larger `-U<context_lines>` option for `git diff`,
                 # or give up if `context_lines` is already very large.
-                if context_lines == max_context_lines:
-                    raise
-                logger.debug(
-                    "AST verification failed. "
-                    "Trying again with %s lines of context for `git diff -U`",
-                    context_lines + 1,
+                logger.warning(
+                    "AST verification of %s with %s lines of context failed",
+                    src,
+                    context_lines,
                 )
-                continue
+                minimum_context_lines.respond(False)
             else:
-                # 9. A re-formatted Python file which produces an identical AST was
-                #    created successfully - write an updated file or print the diff if
-                #    there were any changes to the original
-                if chosen != worktree_content:
-                    yield src, worktree_content, chosen
-                break
+                minimum_context_lines.respond(True)
+                last_successful_reformat = (src, worktree_content, chosen)
+        if not last_successful_reformat:
+            raise NotEquivalentError(path_in_repo)
+        # 9. A re-formatted Python file which produces an identical AST was
+        #    created successfully - write an updated file or print the diff if
+        #    there were any changes to the original
+        src, worktree_content, chosen = last_successful_reformat
+        if chosen != worktree_content:
+            # `result_str` is just `chosen_lines` concatenated with newlines.
+            # We need both forms when showing diffs or modifying files.
+            # Pass them both on to avoid back-and-forth conversion.
+            yield src, worktree_content, chosen
 
 
 def modify_file(path: Path, new_content: TextDocument) -> None:

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -62,7 +62,7 @@ def format_edited_parts(
         while not minimum_context_lines.found:
             context_lines = minimum_context_lines.get_next()
             if context_lines > 0:
-                logger.warning(
+                logger.debug(
                     "Trying with %s lines of context for `git diff -U %s`",
                     context_lines,
                     src,
@@ -108,7 +108,7 @@ def format_edited_parts(
                 # a partially re-formatted Python file which produces an identical AST.
                 # Try again with a larger `-U<context_lines>` option for `git diff`,
                 # or give up if `context_lines` is already very large.
-                logger.warning(
+                logger.debug(
                     "AST verification of %s with %s lines of context failed",
                     src,
                     context_lines,

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -1,5 +1,10 @@
+"""Unit tests for :mod:`darker.__main__`"""
+
+import os
+import re
 from pathlib import Path
 from subprocess import check_call
+from textwrap import dedent
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -10,6 +15,7 @@ import darker.__main__
 import darker.import_sorting
 from darker.git import RevisionRange
 from darker.utils import TextDocument
+from darker.verification import NotEquivalentError
 
 
 def test_isort_option_without_isort(tmpdir, without_isort, caplog):
@@ -156,6 +162,41 @@ def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
     assert result == []
 
 
+def test_format_edited_parts_ast_changed(git_repo, caplog):
+    """``darker.__main__.format_edited_parts()`` when reformatting changes the AST"""
+    paths = git_repo.add({"a.py": "1\n2\n3\n4\n5\n6\n7\n8\n"}, commit="Initial commit")
+    paths["a.py"].write_bytes(b"8\n7\n6\n5\n4\n3\n2\n1\n")
+    with patch.object(
+        darker.__main__, "verify_ast_unchanged"
+    ) as verify_ast_unchanged, pytest.raises(NotEquivalentError):
+        verify_ast_unchanged.side_effect = NotEquivalentError
+
+        _ = list(
+            darker.__main__.format_edited_parts(
+                git_repo.root,
+                [Path("a.py")],
+                RevisionRange("HEAD"),
+                enable_isort=False,
+                black_args={},
+            )
+        )
+
+    a_py = str(paths["a.py"])
+    main = "darker.__main__:__main__.py"
+    log = re.sub(r":\d+", "", caplog.text)
+    assert log == dedent(
+        f"""\
+        WARNING  {main} AST verification of {a_py} with 0 lines of context failed
+        WARNING  {main} Trying with 5 lines of context for `git diff -U {a_py}`
+        WARNING  {main} AST verification of {a_py} with 5 lines of context failed
+        WARNING  {main} Trying with 7 lines of context for `git diff -U {a_py}`
+        WARNING  {main} AST verification of {a_py} with 7 lines of context failed
+        WARNING  {main} Trying with 8 lines of context for `git diff -U {a_py}`
+        WARNING  {main} AST verification of {a_py} with 8 lines of context failed
+    """
+    )
+
+
 @pytest.mark.kwparametrize(
     dict(
         arguments=["--diff"],
@@ -224,7 +265,7 @@ def test_main(
     retval = darker.__main__.main(arguments + ['a.py'])
 
     stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
-    assert stdout.split("\n") == expect_stdout
+    assert stdout.replace(os.sep, "/").split("\n") == expect_stdout
     assert paths["a.py"].read_bytes().decode("ascii") == newline.join(expect_a_py)
     assert paths["b.py"].read_bytes().decode("ascii") == "print(42 ){newline}"
     assert retval == expect_retval

--- a/src/darker/tests/test_verification.py
+++ b/src/darker/tests/test_verification.py
@@ -48,3 +48,12 @@ def test_binary_search():
         search.respond(tries[-1] > 2)
     assert search.result == 3
     assert tries == [0, 3, 2]
+
+
+@pytest.mark.parametrize("i", range(50))
+def test_binary_search_in_50(i):
+    """Simple 'fuzzy test' for BinarySearch"""
+    search = BinarySearch(0, 50)
+    while not search.found:
+        search.respond(search.get_next() >= i)
+    assert search.result == i

--- a/src/darker/tests/test_verification.py
+++ b/src/darker/tests/test_verification.py
@@ -1,12 +1,11 @@
 """Unit tests for :mod:`darker.verification`"""
 
-
 from typing import List
 
 import pytest
 
 from darker.utils import DiffChunk, TextDocument
-from darker.verification import NotEquivalentError, verify_ast_unchanged
+from darker.verification import BinarySearch, NotEquivalentError, verify_ast_unchanged
 
 
 @pytest.mark.parametrize(
@@ -30,3 +29,22 @@ def test_verify_ast_unchanged(src_content, dst_content, expect):
         assert expect is AssertionError
     else:
         assert expect is None
+
+
+def test_binary_search_premature_result():
+    """``darker.verification.BinarySearch``"""
+    with pytest.raises(RuntimeError):
+
+        _ = BinarySearch(0, 5).result
+
+
+def test_binary_search():
+    """``darker.verification.BinarySearch``"""
+    search = BinarySearch(0, 5)
+    tries = []
+    while not search.found:
+        tries.append(search.get_next())
+
+        search.respond(tries[-1] > 2)
+    assert search.result == 3
+    assert tries == [0, 3, 2]

--- a/src/darker/verification.py
+++ b/src/darker/verification.py
@@ -11,6 +11,50 @@ class NotEquivalentError(Exception):
     pass
 
 
+class BinarySearch:
+    """Effectively search the first index for which a condition is ``True``
+
+    Example usage to find first number between 0 and 100 whose square is larger than
+    1000::
+
+        s = BinarySearch(0, 100)
+        while not s.found:
+            s.respond(s.get_next() ** 2 > 1000)
+        answer = s.result
+
+    """
+
+    def __init__(self, low: int, high: int):
+        self.low = self.mid = low
+        self.high = high
+
+    def get_next(self) -> int:
+        """Get the next integer index to try"""
+        return self.mid
+
+    def respond(self, value: bool) -> None:
+        """Provide a ``False`` or ``True`` answer for the current integer index"""
+        if value:
+            self.high = self.mid
+        else:
+            self.low = self.mid + 1
+        self.mid = (self.low + self.high) // 2
+
+    @property
+    def found(self) -> bool:
+        """Return ``True`` if the lowest ``True`` response index has been found"""
+        return self.low >= self.high
+
+    @property
+    def result(self) -> int:
+        """Return the lowest index with a ``True`` response"""
+        if not self.found:
+            raise RuntimeError(
+                "Trying to get binary search result before search has been exhausted"
+            )
+        return self.high
+
+
 def verify_ast_unchanged(
     edited_to_file: TextDocument,
     reformatted: TextDocument,

--- a/src/darker/verification.py
+++ b/src/darker/verification.py
@@ -15,12 +15,12 @@ class BinarySearch:
     """Effectively search the first index for which a condition is ``True``
 
     Example usage to find first number between 0 and 100 whose square is larger than
-    1000::
+    1000:
 
-        s = BinarySearch(0, 100)
-        while not s.found:
-            s.respond(s.get_next() ** 2 > 1000)
-        answer = s.result
+    >>> s = BinarySearch(0, 100)
+    >>> while not s.found:
+    ...     s.respond(s.get_next() ** 2 > 1000)
+    >>> assert s.result == 32
 
     """
 


### PR DESCRIPTION
If the AST differs after reformatting when diffing and chunking with zero context lines, search for the lowest successful number of context lines using a binary search instead of by incrementing one by one. This vastly improves performance in such problematic cases.