### PR TITLE
Clean up the `debug_dump()` function

### DIFF
--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -16,12 +16,7 @@ from darker.utils import (
 
 
 def test_debug_dump(capsys):
-    debug_dump(
-        [(1, ("black",), ("chunks",))],
-        TextDocument.from_str("old content"),
-        TextDocument.from_str("new content"),
-        [2, 3],
-    )
+    debug_dump([(1, ("black",), ("chunks",))], [2, 3])
     assert capsys.readouterr().out == (
         dedent(
             """\

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Unit tests for :mod:`darker.utils`"""
 
+import logging
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -15,7 +16,9 @@ from darker.utils import (
 )
 
 
-def test_debug_dump(capsys):
+def test_debug_dump(caplog, capsys):
+    """darker.utils.debug_dump()"""
+    caplog.set_level(logging.DEBUG)
     debug_dump([(1, ("black",), ("chunks",))], [2, 3])
     assert capsys.readouterr().out == (
         dedent(

--- a/src/darker/utils.py
+++ b/src/darker/utils.py
@@ -1,11 +1,14 @@
 """Miscellaneous utility functions"""
 
 import io
+import logging
 import tokenize
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
 from typing import Iterable, List, Tuple, Union
+
+logger = logging.getLogger(__name__)
 
 TextLines = Tuple[str, ...]
 
@@ -157,13 +160,10 @@ class TextDocument:
 DiffChunk = Tuple[int, TextLines, TextLines]
 
 
-def debug_dump(
-    black_chunks: List[DiffChunk],
-    old_content: TextDocument,
-    new_content: TextDocument,
-    edited_linenums: List[int],
-) -> None:
+def debug_dump(black_chunks: List[DiffChunk], edited_linenums: List[int]) -> None:
     """Print debug output. This is used in case of an unexpected failure."""
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        return
     for offset, old_lines, new_lines in black_chunks:
         print(80 * "-")
         for delta, old_line in enumerate(old_lines):

--- a/src/darker/verification.py
+++ b/src/darker/verification.py
@@ -21,5 +21,5 @@ def verify_ast_unchanged(
     try:
         assert_equivalent(edited_to_file.string, reformatted.string)
     except AssertionError as exc_info:
-        debug_dump(black_chunks, edited_to_file, reformatted, edited_linenums)
+        debug_dump(black_chunks, edited_linenums)
         raise NotEquivalentError(str(exc_info))


### PR DESCRIPTION
The function dumps debug output whenever AST verification fails.

- drop unused arguments
- only print the dump if the `-vv` option has been specified