### PR TITLE
Use new pip to solve pytest/attrs version conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.8-dev"  # 3.8 development branch
 install:
   - git fetch origin --depth=1 master:master
+  - pip install 'pip>=20.3'  # strict dependency resolution added in pip 20.3
   - pip install -e '.[isort,test]'
 script: pytest


### PR DESCRIPTION
With old pip we got:

```bash
$ pip install -e '.[isort,test]'
[...]
Collecting pytest-mypy; extra == "test"
  Using cached pytest_mypy-0.8.0-py3-none-any.whl (6.6 kB)
Collecting pytest>=6.1.0; extra == "test"
  Downloading pytest-6.2.1-py3-none-any.whl (279 kB)
[...]
Requirement already satisfied: attrs>=19.0 in /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages (from pytest-mypy; extra == "test"->darker==1.2.2.dev0) (19.1.0)
[...]
ERROR: pytest 6.2.1 has requirement attrs>=19.2.0, but you'll have attrs 19.1.0 which is incompatible.
[...]
Successfully installed appdirs-1.4.4 astroid-2.4.2 black-20.8b1 click-7.1.2 darker filelock-3.0.12 flake8-3.8.4 iniconfig-1.1.1 isort-5.6.4 lazy-object-proxy-1.4.3 mccabe-0.6.1 mypy-0.790 mypy-extensions-0.4.3 pathspec-0.8.1 py-1.10.0 pycodestyle-2.6.0 pyflakes-2.2.0 pygments-2.7.3 pylint-2.6.0 pytest-6.2.1 pytest-darker-0.1.2 pytest-flake8-1.0.7 pytest-isort-1.2.0 pytest-mypy-0.8.0 regex-2020.11.13 toml-0.10.2 typed-ast-1.4.1 typing-extensions-3.7.4.3 wrapt-1.12.1
$ pytest
Traceback (most recent call last):
  [...]
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/_pytest/_code/code.py", line 942, in <module>
    @attr.s(eq=False)
TypeError: attrs() got an unexpected keyword argument 'eq'

The command "pytest" exited with 1.
```
`
After upgrading pip, we get this instead:
```bash
$ pip install -e '.[isort,test]'
[...]
Collecting pytest>=6.1.0
Using cached pytest-6.2.1-py3-none-any.whl (279 kB)
[...]
Collecting attrs>=19.2.0
Downloading attrs-20.3.0-py2.py3-none-any.whl (49 kB)
[...]
Successfully installed appdirs-1.4.4 astroid-2.4.2 attrs-20.3.0 black-20.8b1 click-7.1.2 darker filelock-3.0.12 flake8-3.8.4 iniconfig-1.1.1 isort-5.6.4 lazy-object-proxy-1.4.3 mccabe-0.6.1 mypy-0.790 mypy-extensions-0.4.3 pathspec-0.8.1 py-1.10.0 pycodestyle-2.6.0 pyflakes-2.2.0 pygments-2.7.3 pylint-2.6.0 pytest-6.2.1 pytest-darker-0.1.2 pytest-flake8-1.0.7 pytest-isort-1.2.0 pytest-mypy-0.8.0 regex-2020.11.13 toml-0.10.2 typed-ast-1.4.1 typing-extensions-3.7.4.3 wrapt-1.12.1
$ pytest
[...]
The command "pytest" exited with 0.
```