### PR TITLE
Get revision range from pre-commit environment variables

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: darker
   name: darker
   description: "Black reformatting to Python files only in regions changed since last commit"
-  entry: darker
+  entry: "darker -r :PRE-COMMIT:"
   language: python
   language_version: python3
   require_serial: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ These features will be included in the next release:
 
 Added
 -----
+- Get revision range from pre-commit_'s ``PRE_COMMIT_FROM_REF`` and
+  ``PRE_COMMIT_TO_REF`` environment variables when using the ``--revision :PRE-COMMIT:``
+  option
 - Configure a pre-commit hook for Darker itself
 
 Fixed

--- a/README.rst
+++ b/README.rst
@@ -205,11 +205,13 @@ The following `command line arguments`_ can also be used to modify the defaults:
 .. code-block:: shell
 
      -r REVISION, --revision REVISION
-                           Git revision against which to compare the working
-                           tree. Tags, branch names, commit hashes, and other
-                           expressions like HEAD~5 work here. Also a range like
-                           master...HEAD or master... can be used to compare the
-                           best common ancestor.
+                           Git revision against which to compare the working tree.
+                           Tags, branch names, commit hashes, and other expressions
+                           like HEAD~5 work here. Also a range like master...HEAD or
+                           master... can be used to compare the best common ancestor.
+                           With the magic value :PRE-COMMIT:, Darker expects the
+                           revision range from the PRE_COMMIT_FROM_REF and
+                           PRE_COMMIT_TO_REF environment variables.
 
      --diff                Don't write the files back, just output a diff for
                            each file on stdout. Highlight syntax on screen if
@@ -271,6 +273,8 @@ For example:
 
 - commit ranges in ``-r`` / ``--revision``.
 - a ``[tool.darker]`` section in ``pyproject.toml``.
+
+*New in version 1.2.2:* Support for ``-r :PRE-COMMIT:`` / ``--revision=:PRE_COMMIT:``
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/
@@ -418,7 +422,7 @@ do the following:
 1. Append to the created ``.pre-commit-config.yaml`` the following lines::
 
        -   repo: https://github.com/akaihola/darker
-           rev: 1.2.1
+           rev: 1.2.2
            hooks:
            -   id: darker
 

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -51,7 +51,9 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
             "Git revision against which to compare the working tree. Tags, branch"
             " names, commit hashes, and other expressions like HEAD~5 work here. Also"
             " a range like master...HEAD or master... can be used to compare the best"
-            " common ancestor."
+            " common ancestor. With the magic value :PRE-COMMIT:, Darker expects the"
+            " revision range from the PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF"
+            " environment variables."
         ),
     )
     isort_help = ["Also sort imports using the `isort` package"]


### PR DESCRIPTION
When using the `-r :PRE-COMMIT:` / `--revision=:PRE-COMMIT:` parameter, Darker will expect to find the revision range from the `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF` environment variables as set by `pre-commit`.

Based on #108, should be merged after that one.