### PR TITLE
Improve compatibility with `pre-commit`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Fixed
 - Compatibility with MyPy 0.812
 - Keep newline character sequence and text encoding intact when modifying files
 
+- Improve compatibility with pre-commit. Fallback to compare against HEAD if
+  ``--revision :PRE-COMMIT:`` is set, but ``PRE_COMMIT_FROM_REF`` or
+  ``PRE_COMMIT_TO_REF`` are not set.
 
 1.2.2_ - 2020-12-30
 ===================

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -51,9 +51,10 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
             "Git revision against which to compare the working tree. Tags, branch"
             " names, commit hashes, and other expressions like HEAD~5 work here. Also"
             " a range like master...HEAD or master... can be used to compare the best"
-            " common ancestor. With the magic value :PRE-COMMIT:, Darker expects the"
-            " revision range from the PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF"
-            " environment variables."
+            " common ancestor. With the magic value :PRE-COMMIT:, Darker works in"
+            " pre-commit compatible mode. Darker expects the revision range from the"
+            " PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF environment variables. If those"
+            " are not found, darker works against HEAD."
         ),
     )
     isort_help = ["Also sort imports using the `isort` package"]

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -105,12 +105,8 @@ class RevisionRange:
                     use_common_ancestor=True,
                 )
             except KeyError:
-                logger.error(
-                    "The environment variables PRE_COMMIT_FROM_REF and"
-                    " PRE_COMMIT_TO_REF must be defined when using -r / --revision"
-                    " :PRE-COMMIT:"
-                )
-                sys.exit(123)
+                # Fallback to running against HEAD
+                revision_range = "HEAD"
         match = COMMIT_RANGE_RE.match(revision_range)
         if match:
             rev1, range_dots, rev2 = match.groups()

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -282,24 +282,30 @@ def test_git_get_modified_files_revision_range(
 
 
 @pytest.mark.parametrize(
-    "environ, expect",
+    "environ, expect_rev1, expect_rev2, expect_use_common_ancestor",
     [
-        ({}, SystemExit),
-        ({"PRE_COMMIT_FROM_REF": "old"}, SystemExit),
-        ({"PRE_COMMIT_TO_REF": "new"}, SystemExit),
-        ({"PRE_COMMIT_FROM_REF": "old", "PRE_COMMIT_TO_REF": "new"}, ["old", "new"]),
+        ({}, "HEAD", ":WORKTREE:", False),
+        ({"PRE_COMMIT_FROM_REF": "old"}, "HEAD", ":WORKTREE:", False),
+        ({"PRE_COMMIT_TO_REF": "new"}, "HEAD", ":WORKTREE:", False),
+        (
+            {"PRE_COMMIT_FROM_REF": "old", "PRE_COMMIT_TO_REF": "new"},
+            "old",
+            "new",
+            True,
+        ),
     ],
 )
-def test_revisionrange_parse_pre_commit(environ, expect):
+def test_revisionrange_parse_pre_commit(
+    environ, expect_rev1, expect_rev2, expect_use_common_ancestor
+):
     """RevisionRange.parse(':PRE-COMMIT:') gets the range from environment variables"""
-    with patch.dict(os.environ, environ), raises_if_exception(expect):
+    with patch.dict(os.environ, environ):
 
         result = RevisionRange.parse(":PRE-COMMIT:")
 
-        expect_rev1, expect_rev2 = expect
         assert result.rev1 == expect_rev1
         assert result.rev2 == expect_rev2
-        assert result.use_common_ancestor
+        assert result.use_common_ancestor == expect_use_common_ancestor
 
 
 edited_linenums_differ_cases = pytest.mark.parametrize(


### PR DESCRIPTION
Improve compatibility with `pre-commit` by falling back to comparing against HEAD, when running in `:PRE-COMMIT:` mode and the relevant environment variables are not set.

Resolves #113 