### PR TITLE
Satisfy MyPy 0.812 using `__all__`

### DIFF
--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -51,6 +51,8 @@ else:
 from black import FileMode as Mode
 from black import TargetVersion, find_pyproject_toml, format_str, parse_pyproject_toml
 
+__all__ = ["BlackArgs", "Mode", "run_black"]
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -29,7 +29,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
     try:
         import isort
     except ImportError:
-        isort = None
+        isort = None  # type: ignore
         description.extend(
             ["", f"{ISORT_INSTRUCTION} to enable sorting of import definitions"]
         )

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -16,7 +16,12 @@ else:
 try:
     import isort
 except ImportError:
-    isort = None
+    isort = None  # type: ignore
+# Work around Mypy problem
+# https://github.com/python/mypy/issues/7030#issuecomment-504128883
+isort_code = getattr(isort, "code")
+
+__all__ = ["apply_isort", "isort"]
 
 logger = logging.getLogger(__name__)
 
@@ -46,4 +51,4 @@ def apply_isort(
             ", ".join(f"{k}={v!r}" for k, v in isort_args.items())
         )
     )
-    return TextDocument.from_str(isort.code(code=content.string, **isort_args))
+    return TextDocument.from_str(isort_code(code=content.string, **isort_args))

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -36,10 +36,10 @@ def run_isort(git_repo, monkeypatch, caplog, request):
         darker.__main__,
         run_black=Mock(return_value=TextDocument()),
         verify_ast_unchanged=Mock(),
-    ), patch("darker.import_sorting.isort.code"):
+    ), patch("darker.import_sorting.isort_code"):
         darker.__main__.main(["--isort", "./test1.py", *args])
         return SimpleNamespace(
-            isort_code=darker.import_sorting.isort.code, caplog=caplog
+            isort_code=darker.import_sorting.isort_code, caplog=caplog
         )
 
 


### PR DESCRIPTION
MyPy strict mode now disallows implicit re-export.
See https://github.com/tiangolo/typer/issues/112#issuecomment-648344361