### PR TITLE
newline-unit-test-fix

### DIFF
--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -3,8 +3,9 @@
 In examples below, a simple two-line snippet is used.
 The first line will be reformatted by Black, and the second left intact::
 
+    >>> from pathlib import Path
     >>> from unittest.mock import Mock
-    >>> src = Mock()
+    >>> src = Path("dummy/file/path.py")
     >>> src_content = TextDocument.from_lines(
     ...     [
     ...         "for i in range(5): print(i)",
@@ -17,9 +18,7 @@ Reformatted lines are returned e.g.::
 
     >>> dst = run_black(src, src_content, black_args={})
     >>> dst.lines
-    ('for i in range(5):',
-     '    print(i)',
-     'print("done")')
+    ('for i in range(5):', '    print(i)', 'print("done")')
 
 See :mod:`darker.diff` and :mod:`darker.chooser`
 for how this result is further processed with:

--- a/src/darker/diff.py
+++ b/src/darker/diff.py
@@ -49,14 +49,9 @@ It combines line content with the 1-based line offset in the original content, e
     >>> len(chunks)
     2
     >>> chunks[0]  # (<offset in orig content>, <original lines>, <reformatted lines>)
-    (1,
-     ('for i in range(5): print(i)',),
-     ('for i in range(5):',
-      '    print(i)'))
+    (1, ('for i in range(5): print(i)',), ('for i in range(5):', '    print(i)'))
     >>> chunks[1]
-    (2,
-     ('print("done")',),
-     ('print("done")',))
+    (2, ('print("done")',), ('print("done")',))
 
 By concatenating the second items in these tuples, i.e. original lines,
 the original file can be reconstructed.

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -287,7 +287,7 @@ def test_black_options(monkeypatch, tmpdir, git_repo, options, expect):
     added_files = git_repo.add(
         {"main.py": 'print("Hello World!")\n'}, commit="Initial commit"
     )
-    added_files["main.py"].write('print ("Hello World!")\n')
+    added_files["main.py"].write_bytes(b'print ("Hello World!")\n')
     with patch.object(black_diff, 'Mode', wraps=black_diff.Mode) as Mode:
 
         main(options + [str(path) for path in added_files.values()])
@@ -332,7 +332,7 @@ def test_black_options_skip_string_normalization(git_repo, config, options, expe
         {"main.py": "foo", "pyproject.toml": joinlines(["[tool.black]"] + config)},
         commit="Initial commit",
     )
-    added_files["main.py"].write("bar")
+    added_files["main.py"].write_bytes(b"bar")
     mode_class_mock = Mock(wraps=black_diff.Mode)
     # Speed up tests by mocking `format_str` to skip running Black
     format_str = Mock(return_value="bar")

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -231,7 +231,7 @@ def test_git_get_modified_files(git_repo, modify_paths, paths, expect):
         {root / p for p in paths}, RevisionRange("HEAD"), cwd=root
     )
 
-    assert {str(p) for p in result} == set(expect)
+    assert result == {Path(p) for p in expect}
 
 
 @pytest.fixture(scope="module")

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -35,13 +35,13 @@ def test_parse_linter_line(git_repo, monkeypatch, line, expect):
             "Check one file, report on a modified line in test.py",
             ["one.py"],
             "test.py:1:",
-            ["test.py:1: {git_repo.root}/one.py"],
+            ["test.py:1: {git_repo.root / 'one.py'}"],
         ),
         (
             "Check one file, report on a column of a modified line in test.py",
             ["one.py"],
             "test.py:1:42:",
-            ["test.py:1:42: {git_repo.root}/one.py"],
+            ["test.py:1:42: {git_repo.root / 'one.py'}"],
         ),
         (
             "No output if report is on an unmodified line in test.py",
@@ -56,16 +56,16 @@ def test_parse_linter_line(git_repo, monkeypatch, line, expect):
             [],
         ),
         (
-            "Check two files, rpeort on a modified line in test.py",
+            "Check two files, report on a modified line in test.py",
             ["one.py", "two.py"],
             "test.py:1:",
-            ["test.py:1: {git_repo.root}/one.py {git_repo.root}/two.py"],
+            ["test.py:1: {git_repo.root / 'one.py'} {git_repo.root / 'two.py'}"],
         ),
         (
             "Check two files, rpeort on a column of a modified line in test.py",
             ["one.py", "two.py"],
             "test.py:1:42:",
-            ["test.py:1:42: {git_repo.root}/one.py {git_repo.root}/two.py"],
+            ["test.py:1:42: {git_repo.root / 'one.py'} {git_repo.root / 'two.py'}"],
         ),
         (
             "No output if 2-file report is on an unmodified line in test.py",
@@ -108,7 +108,8 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
     # by checking standard output from the our `echo` "linter".
     # The test cases also verify that only linter reports on modified lines are output.
     result = capsys.readouterr().out.splitlines()
-    assert result == [line.format(git_repo=git_repo) for line in expect]
+    # Use evil `eval()` so we get Windows compatible expected paths:
+    assert result == [eval(f'f"{line}"', {"git_repo": git_repo}) for line in expect]
 
 
 def test_run_linter_non_worktree():

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -96,7 +96,7 @@ def test_run_linter(git_repo, monkeypatch, capsys, _descr, paths, location, expe
 
     """
     src_paths = git_repo.add({"test.py": "1\n2\n"}, commit="Initial commit")
-    src_paths["test.py"].write("one\n2\n")
+    src_paths["test.py"].write_bytes(b"one\n2\n")
     monkeypatch.chdir(git_repo.root)
     cmdline = f"echo {location}"
 

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -30,7 +30,7 @@ def run_isort(git_repo, monkeypatch, caplog, request):
 
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({'test1.py': 'original'}, commit='Initial commit')
-    paths['test1.py'].write('changed')
+    paths["test1.py"].write_bytes(b"changed")
     args = getattr(request, "param", ())
     with patch.multiple(
         darker.__main__,
@@ -125,8 +125,8 @@ A_PY_DIFF_BLACK_ISORT = [
 def test_format_edited_parts(git_repo, enable_isort, black_args, newline, expect):
     """Correct reformatting and import sorting changes are produced"""
     paths = git_repo.add({"a.py": newline, "b.py": newline}, commit="Initial commit")
-    paths["a.py"].write(newline.join(A_PY))
-    paths["b.py"].write(f"print(42 ){newline}")
+    paths["a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
+    paths["b.py"].write_bytes("print(42 ){newline}".encode("ascii"))
 
     result = darker.__main__.format_edited_parts(
         [Path("a.py")], RevisionRange("HEAD"), enable_isort, [], black_args
@@ -145,9 +145,9 @@ def test_format_edited_parts(git_repo, enable_isort, black_args, newline, expect
 def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
     """``format_edited_parts()`` yields nothing if no reformatting was needed"""
     monkeypatch.chdir(git_repo.root)
-    paths = git_repo.add({'a.py': 'pass\n', 'b.py': 'pass\n'}, commit='Initial commit')
-    paths['a.py'].write('"properly"\n"formatted"\n')
-    paths['b.py'].write('"not"\n"checked"\n')
+    paths = git_repo.add({"a.py": "pass\n", "b.py": "pass\n"}, commit="Initial commit")
+    paths["a.py"].write_bytes(b'"properly"\n"formatted"\n')
+    paths["b.py"].write_bytes(b'"not"\n"checked"\n')
 
     result = list(
         darker.__main__.format_edited_parts(
@@ -161,7 +161,7 @@ def test_format_edited_parts_all_unchanged(git_repo, monkeypatch):
 def test_format_edited_parts_lint(git_repo):
     """Unit test for ``format_edited_parts`` with linters"""
     paths = git_repo.add({"a.py": "pass\n"}, commit="Initial commit")
-    paths["a.py"].write('"properly"\n"formatted"\n')
+    paths["a.py"].write_bytes(b'"properly"\n"formatted"\n')
     with patch.object(darker.__main__, "run_linter") as run_linter:
 
         _ = list(
@@ -218,15 +218,15 @@ def test_main(
     """Main function outputs diffs and modifies files correctly"""
     monkeypatch.chdir(git_repo.root)
     paths = git_repo.add({"a.py": newline, "b.py": newline}, commit="Initial commit")
-    paths["a.py"].write(newline.join(A_PY))
-    paths["b.py"].write("print(42 ){newline}")
+    paths["a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
+    paths["b.py"].write_bytes("print(42 ){newline}".encode("ascii"))
 
     retval = darker.__main__.main(arguments + ['a.py'])
 
     stdout = capsys.readouterr().out.replace(str(git_repo.root), '')
     assert stdout.split("\n") == expect_stdout
-    assert paths["a.py"].read("br").decode("ascii") == newline.join(expect_a_py)
-    assert paths["b.py"].read("br").decode("ascii") == "print(42 ){newline}"
+    assert paths["a.py"].read_bytes().decode("ascii") == newline.join(expect_a_py)
+    assert paths["b.py"].read_bytes().decode("ascii") == "print(42 ){newline}"
     assert retval == expect_retval
 
 
@@ -236,14 +236,14 @@ def test_main(
 @pytest.mark.parametrize("newline", [b"\n", b"\r\n"])
 def test_main_encoding(git_repo, encoding, text, newline):
     """Encoding and newline of the file is kept unchanged after reformatting"""
-    paths = git_repo.add({"a.py": newline}, commit="Initial commit")
+    paths = git_repo.add({"a.py": newline.decode("ascii")}, commit="Initial commit")
     edited = [b"# coding: ", encoding, newline, b's="', text, b'"', newline]
     expect = [b"# coding: ", encoding, newline, b's = "', text, b'"', newline]
-    paths["a.py"].write(b"".join(edited), "wb")
+    paths["a.py"].write_bytes(b"".join(edited))
 
     retval = darker.__main__.main(["a.py"])
 
-    result = paths["a.py"].read("br")
+    result = paths["a.py"].read_bytes()
     assert retval == 0
     assert result == b"".join(expect)
 

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -248,8 +248,10 @@ def test_main_encoding(git_repo, encoding, text, newline):
     assert result == b"".join(expect)
 
 
-def test_output_diff(capsys):
+def test_output_diff(tmp_path, monkeypatch, capsys):
     """output_diff() prints Black-style diff output"""
+    monkeypatch.chdir(tmp_path)
+    Path("a.py").write_text("dummy\n")
     darker.__main__.print_diff(
         Path('a.py'),
         TextDocument.from_lines(

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -42,20 +42,24 @@ from darker.tests.helpers import raises_if_exception
 @pytest.mark.parametrize(
     "revision, worktree_content, expect",
     [
-        ("", "USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("", "ORIGINAL=1\n", ["+1M0", "+2-1", "+2M1-0", "+2M1"]),
-        ("", "MODIFIED=1\n", ["+1", "+2-1", "+2", "+2M1-0"]),
-        ("HEAD", "USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("HEAD", "ORIGINAL=1\n", ["+1M0", "+2-1", "+2M1-0", "+2M1"],),
-        ("HEAD", "MODIFIED=1\n", ["+1", "+2-1", "+2", "+2M1-0"]),
-        ("HEAD^", "USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("HEAD^", "USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("HEAD^", "ORIGINAL=1\n", ["+2-1", "+2M1-0", "+2M1"]),
-        ("HEAD^", "MODIFIED=1\n", ["+1", "+1M0", "+2-1", "+2"]),
-        ("HEAD~2", "USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("HEAD~2", "ORIGINAL=1\n", ["+1", "+1M0"]),
-        ("HEAD~2", "MODIFIED=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
-        ("HEAD~3", "USERMOD=1\n", SystemExit),
+        ("", b"USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        ("", b"ORIGINAL=1\n", ["+1M0", "+2-1", "+2M1-0", "+2M1"]),
+        ("", b"MODIFIED=1\n", ["+1", "+2-1", "+2", "+2M1-0"]),
+        ("HEAD", b"USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        (
+            "HEAD",
+            b"ORIGINAL=1\n",
+            ["+1M0", "+2-1", "+2M1-0", "+2M1"],
+        ),
+        ("HEAD", b"MODIFIED=1\n", ["+1", "+2-1", "+2", "+2M1-0"]),
+        ("HEAD^", b"USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        ("HEAD^", b"USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        ("HEAD^", b"ORIGINAL=1\n", ["+2-1", "+2M1-0", "+2M1"]),
+        ("HEAD^", b"MODIFIED=1\n", ["+1", "+1M0", "+2-1", "+2"]),
+        ("HEAD~2", b"USERMOD=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        ("HEAD~2", b"ORIGINAL=1\n", ["+1", "+1M0"]),
+        ("HEAD~2", b"MODIFIED=1\n", ["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"]),
+        ("HEAD~3", b"USERMOD=1\n", SystemExit),
     ],
 )
 def test_revision(git_repo, monkeypatch, capsys, revision, worktree_content, expect):
@@ -89,7 +93,7 @@ def test_revision(git_repo, monkeypatch, capsys, revision, worktree_content, exp
     )
     # Working tree:
     for path in paths.values():
-        path.write(worktree_content)
+        path.write_bytes(worktree_content)
     arguments = ["--diff", "--revision", revision, "."]
 
     with raises_if_exception(expect):

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -173,12 +173,12 @@ def test_textdocument_from_file_detect_encoding(tmp_path, content, expect):
 
 
 @pytest.mark.parametrize(
-    "content, expect", [('print("unix")\n', "\n"), ('print("windows")\r\n', "\r\n")]
+    "content, expect", [(b'print("unix")\n', "\n"), (b'print("windows")\r\n', "\r\n")]
 )
 def test_textdocument_from_file_detect_newline(tmp_path, content, expect):
     """TextDocument.from_file() detects the newline character sequence correctly"""
     path = tmp_path / "test.py"
-    path.write_text(content)
+    path.write_bytes(content)
 
     textdocument = TextDocument.from_file(path)
 

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -294,7 +294,7 @@ def test_textdocument_mtime(document, expect):
 def test_textdocument_from_file(tmp_path):
     """TextDocument.from_file()"""
     dummy_txt = tmp_path / "dummy.txt"
-    dummy_txt.write_text("# coding: iso-8859-1\r\ndummy\r\ncontent\r\n")
+    dummy_txt.write_bytes(b"# coding: iso-8859-1\r\ndummy\r\ncontent\r\n")
     os.utime(dummy_txt, (1_000_000_000, 1_000_000_000))
 
     document = TextDocument.from_file(dummy_txt)


### PR DESCRIPTION
- [x] write source code files in binary in unit tests to prevent newline conversion on Windows
- [x] use a dummy `Path` object instead of `Mock` so a doctest passes correctly on Windows
- [x] also prefer `Path` objects in tests so path separators are correct also on Windows
- [x] use a real file in test when `Path.relative_to()` needs to work – it checks file existence on Windows

This branch sits on top of #120 since we want to see the test result of Windows. Once we see that this fix works, let's rebase this on `master` and merge before merging #120.