### PR TITLE
Ignore ~/.gitconfig when running git tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Git-related commands in the test suite now ignore the user's ``~/.gitconfig``.
 
 
 1.2.3_ - 2021-05-02

--- a/README.rst
+++ b/README.rst
@@ -276,10 +276,6 @@ For example:
 
 *New in version 1.2.2:* Support for ``-r :PRE-COMMIT:`` / ``--revision=:PRE_COMMIT:``
 
-*New in version 1.3.0:*
-
-- git-related commands in the test suite now ignore the user's ~/.gitconfig
-
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/
 .. _command line arguments: https://black.readthedocs.io/en/stable/installation_and_usage.html#command-line-options

--- a/README.rst
+++ b/README.rst
@@ -276,6 +276,10 @@ For example:
 
 *New in version 1.2.2:* Support for ``-r :PRE-COMMIT:`` / ``--revision=:PRE_COMMIT:``
 
+*New in version 1.3.0:*
+
+- git-related commands in the test suite now ignore the user's ~/.gitconfig
+
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/
 .. _command line arguments: https://black.readthedocs.io/en/stable/installation_and_usage.html#command-line-options

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -37,10 +37,11 @@ class GitRepoFixture:
         env = os.environ.copy()
         # for testing, ignore ~/.gitconfig settings like templateDir and defaultBranch
         env["HOME"] = str(root)
-        check_call(["git", "init"], cwd=root, env=env)
-        check_call(["git", "config", "user.email", "ci@example.com"], cwd=root, env=env)
-        check_call(["git", "config", "user.name", "CI system"], cwd=root, env=env)
-        return cls(root, env)
+        instance = cls(root, env)
+        instance._run("init")
+        instance._run("config", "user.email", "ci@example.com")
+        instance._run("config", "user.name", "CI system")
+        return instance
 
     def _run(self, *args: str) -> None:
         """Helper method to run a Git command line in the repository root"""

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -27,23 +27,24 @@ def with_isort():
 
 
 class GitRepoFixture:
-    def __init__(self, root: Path):
+    def __init__(self, root: Path, env: Dict[str, str]):
         self.root = root
+        self.env = env
 
     @classmethod
     def create_repository(cls, root: Path) -> "GitRepoFixture":
         """Fixture method for creating a Git repository in the given directory"""
         env = os.environ.copy()
-        # for testsing, ignore ~/.gitconfig settings like templateDir and defaultBranch
-        env['HOME'] = root
+        # for testing, ignore ~/.gitconfig settings like templateDir and defaultBranch
+        env["HOME"] = str(root)
         check_call(["git", "init"], cwd=root, env=env)
-        check_call(["git", "config", "user.email", "ci@example.com"], cwd=root)
-        check_call(["git", "config", "user.name", "CI system"], cwd=root)
-        return cls(root)
+        check_call(["git", "config", "user.email", "ci@example.com"], cwd=root, env=env)
+        check_call(["git", "config", "user.name", "CI system"], cwd=root, env=env)
+        return cls(root, env)
 
     def _run(self, *args: str) -> None:
         """Helper method to run a Git command line in the repository root"""
-        check_call(["git"] + list(args), cwd=self.root)
+        check_call(["git"] + list(args), cwd=self.root, env=self.env)
 
     def _run_and_get_first_line(self, *args: str) -> str:
         """Helper method to run Git in repo root and return first line of output"""

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -38,6 +38,7 @@ class GitRepoFixture:
         # for testing, ignore ~/.gitconfig settings like templateDir and defaultBranch
         env["HOME"] = str(root)
         instance = cls(root, env)
+        # pylint: disable=protected-access
         instance._run("init")
         instance._run("config", "user.email", "ci@example.com")
         instance._run("config", "user.name", "CI system")

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -1,5 +1,6 @@
 """Configuration and fixtures for the Pytest based test suite"""
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -32,7 +33,10 @@ class GitRepoFixture:
     @classmethod
     def create_repository(cls, root: Path) -> "GitRepoFixture":
         """Fixture method for creating a Git repository in the given directory"""
-        check_call(["git", "init"], cwd=root)
+        env = os.environ.copy()
+        # for testsing, ignore ~/.gitconfig settings like templateDir and defaultBranch
+        env['HOME'] = root
+        check_call(["git", "init"], cwd=root, env=env)
         check_call(["git", "config", "user.email", "ci@example.com"], cwd=root)
         check_call(["git", "config", "user.name", "CI system"], cwd=root)
         return cls(root)

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -83,6 +83,10 @@ class GitRepoFixture:
         """Return the commit hash at the given revision in the Git repository"""
         return self._run_and_get_first_line("rev-parse", revision)
 
+    def get_branch(self) -> str:
+        """Return the active branch name in the Git repository"""
+        return self._run_and_get_first_line("symbolic-ref", "--short", "HEAD")
+
     def create_branch(self, new_branch: str, start_point: str) -> None:
         """Fixture method to create and check out new branch at given starting point"""
         self._run("checkout", "-b", new_branch, start_point)

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -459,7 +459,7 @@ def test_local_gitconfig_ignored_by_gitrepofixture(tmp_path):
         # Note: once we decide to drop support for git < 2.28, the HEAD file
         # creation above can be removed, and setup can simplify to
         # check_call("git config --global init.defaultBranch main".split())
-        check_call("git config --global init.templateDir".split() + [tmp_path])
+        check_call("git config --global init.templateDir".split() + [str(tmp_path)])
         root = tmp_path / "repo"
         root.mkdir()
         git_repo = GitRepoFixture.create_repository(root)

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -453,8 +453,7 @@ def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expec
 
 def test_local_gitconfig_ignored_by_gitrepofixture(tmp_path):
     """Tests that ~/.gitconfig is ignored when running darker's git tests"""
-    with open(tmp_path / "HEAD", "w") as head_file:
-        head_file.write("ref: refs/heads/main")
+    (tmp_path / "HEAD").write_text("ref: refs/heads/main")
 
     with patch.dict(os.environ, {"HOME": str(tmp_path)}):
         # Note: once we decide to drop support for git < 2.28, the HEAD file

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, check_call
 from typing import List, Union
 from unittest.mock import patch
 
@@ -449,3 +449,19 @@ def test_edited_linenums_differ_revision_vs_lines(git_repo, context_lines, expec
     result = differ.revision_vs_lines(Path("a.py"), content, context_lines)
 
     assert result == expect
+
+
+def test_local_gitconfig_ignored_by_gitrepofixture(tmp_path):
+    """Tests that ~/.gitconfig is ignored when running darker's git tests"""
+    with open(tmp_path / "HEAD", "w") as head_file:
+        head_file.write("ref: refs/heads/main")
+
+    with patch.dict(os.environ, {"HOME": str(tmp_path)}):
+        # Note: once we decide to drop support for git < 2.28, the HEAD file
+        # creation above can be removed, and setup can simplify to
+        # check_call("git config --global init.defaultBranch main".split())
+        check_call("git config --global init.templateDir".split() + [tmp_path])
+        root = tmp_path / "repo"
+        root.mkdir()
+        git_repo = GitRepoFixture.create_repository(root)
+        assert git_repo.get_branch() == "master"

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -13,16 +13,16 @@ from black import find_project_root
 import darker.__main__
 import darker.import_sorting
 from darker.git import RevisionRange
-from darker.tests.conftest import GitRepoFixture
 from darker.utils import TextDocument
 from darker.verification import NotEquivalentError
 
 
-def test_isort_option_without_isort(tmpdir, without_isort, caplog):
-    GitRepoFixture.create_repository(tmpdir)
+def test_isort_option_without_isort(git_repo, without_isort, caplog):
+    """Without isort, provide isort install instructions and error"""
+    # pylint: disable=unused-argument
     with patch.object(darker.__main__, "isort", None), pytest.raises(SystemExit):
 
-        darker.__main__.main(["--isort", str(tmpdir)])
+        darker.__main__.main(["--isort", "."])
 
     assert (
         "Please run `pip install 'darker[isort]'` to use the `--isort` option."

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 from pathlib import Path
-from subprocess import check_call
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -14,12 +13,13 @@ from black import find_project_root
 import darker.__main__
 import darker.import_sorting
 from darker.git import RevisionRange
+from darker.tests.conftest import GitRepoFixture
 from darker.utils import TextDocument
 from darker.verification import NotEquivalentError
 
 
 def test_isort_option_without_isort(tmpdir, without_isort, caplog):
-    check_call(["git", "init"], cwd=tmpdir)
+    GitRepoFixture.create_repository(tmpdir)
     with patch.object(darker.__main__, "isort", None), pytest.raises(SystemExit):
 
         darker.__main__.main(["--isort", str(tmpdir)])


### PR DESCRIPTION
Set HOME environment variable to the temporary directory the tests will
run in, avoiding any ~/.gitconfig settings that may interfere with
assumptions in the tests, particularly init.defaultBranch and
init.templateDir

Context: 
There are two settings that I'm aware of that can violate the assumption that the default branch will be called "master" when running `git init`. The older way is via the templateDir setting, which if pointed to a directory with a HEAD file containing `ref: refs/heads/main` will cause `git init` to default to `main` branch. Additionally, starting with version 2.28, git introduced a defaultBranch setting, that also allows developers to change the name of the initial branch name in a brand new repository.

This PR contains a minimal change to make the git-related tests pass locally (I use the templateDir method to change my default branch name).

Thank you for making and maintaining darker!

---

- [x] review #135 
- [x] merge #135 
- [x] rebase this one on `master`