### PR TITLE
Mypy & Black 21.x compatibility

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -52,6 +52,7 @@ warn_return_any = False
 
 [mypy-black.*]
 ignore_missing_imports = True
+implicit_reexport = True
 
 [mypy-isort.*]
 ignore_missing_imports = True

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -39,16 +39,16 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional, Set, cast
 
+# `FileMode as Mode` required to satisfy mypy==0.782. Strange.
+from black import FileMode as Mode
+from black import TargetVersion, find_pyproject_toml, format_str, parse_pyproject_toml
+
 from darker.utils import TextDocument
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
-
-# `FileMode as Mode` required to satisfy mypy==0.782. Strange.
-from black import FileMode as Mode
-from black import TargetVersion, find_pyproject_toml, format_str, parse_pyproject_toml
 
 __all__ = ["BlackArgs", "Mode", "run_black"]
 


### PR DESCRIPTION
Enable implicit re-export from Black

Black 21.x split the code base into modules. Symbols are not re-exported in the main package, so we need this Mypy directive in order to pass Mypy checks when Darker imports from Black.

We can't yet import directly from the Black submodules since we want to keep supporting Black 20.x at least for some time still.