### PR TITLE
Fix AST verification and historical comparisons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ Fixed
 -----
 - Git-related commands in the test suite now ignore the user's ``~/.gitconfig``.
 - Now works again even if ``isort`` isn't installed
-- AST verification no longer erroneously fails when using ``--isort`` and a modified
-  Python source code file is already properly formatted
+- AST verification no longer erroneously fails when using ``--isort``
+- Historical comparisons like ``darker --diff --revision=v1.0..v1.1`` now actually
+  compare the second revision and not the working tree files on disk.
 
 
 1.2.3_ - 2021-05-02

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Fixed
 -----
 - Git-related commands in the test suite now ignore the user's ``~/.gitconfig``.
 - Now works again even if ``isort`` isn't installed
+- AST verification no longer erroneously fails when using ``--isort`` and a modified
+  Python source code file is already properly formatted
 
 
 1.2.3_ - 2021-05-02

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -74,6 +74,7 @@ def format_edited_parts(
             )
             if enable_isort and not edited_linenums and edited == worktree_content:
                 logger.debug("No changes in %s after isort", src)
+                last_successful_reformat = (src, worktree_content, edited)
                 break
 
             # 4. run black
@@ -124,9 +125,6 @@ def format_edited_parts(
         #    there were any changes to the original
         src, worktree_content, chosen = last_successful_reformat
         if chosen != worktree_content:
-            # `result_str` is just `chosen_lines` concatenated with newlines.
-            # We need both forms when showing diffs or modifying files.
-            # Pass them both on to avoid back-and-forth conversion.
             yield src, worktree_content, chosen
 
 

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -11,7 +11,7 @@ from darker.chooser import choose_lines
 from darker.command_line import parse_command_line
 from darker.config import dump_config
 from darker.diff import diff_and_get_opcodes, opcodes_to_chunks
-from darker.git import EditedLinenumsDiffer, RevisionRange, git_get_modified_files
+from darker.git import EditedLinenumsDiffer, RevisionRange, git_get_content_at_revision, git_get_modified_files
 from darker.help import ISORT_INSTRUCTION
 from darker.import_sorting import apply_isort, isort
 from darker.linting import run_linters
@@ -44,7 +44,7 @@ def format_edited_parts(
 
     for path_in_repo in sorted(changed_files):
         src = git_root / path_in_repo
-        worktree_content = TextDocument.from_file(src)
+        worktree_content = git_get_content_at_revision(src, revrange.rev2, git_root)
 
         # 1. run isort
         if enable_isort:

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -125,7 +125,7 @@ def format_edited_parts(
         #    there were any changes to the original
         src, worktree_content, chosen = last_successful_reformat
         if chosen != worktree_content:
-            yield src, worktree_content, chosen
+            yield (src, worktree_content, chosen)
 
 
 def modify_file(path: Path, new_content: TextDocument) -> None:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
@@ -43,8 +42,7 @@ def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDoc
     """
     if revision == WORKTREE:
         abspath = cwd / path
-        mtime = datetime.utcfromtimestamp(abspath.stat().st_mtime)
-        return TextDocument.from_str(abspath.read_text("utf-8"), f"{mtime} +0000")
+        return TextDocument.from_file(abspath)
     cmd = ["show", f"{revision}:./{path}"]
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import re
+from argparse import ArgumentError
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -14,7 +15,7 @@ from black import find_project_root
 
 import darker.__main__
 import darker.import_sorting
-from darker.git import RevisionRange, WORKTREE
+from darker.git import WORKTREE, RevisionRange
 from darker.tests.helpers import isort_present
 from darker.utils import TextDocument, joinlines
 from darker.verification import NotEquivalentError
@@ -375,6 +376,13 @@ def test_main_encoding(git_repo, encoding, text, newline):
     result = paths["a.py"].read_bytes()
     assert retval == 0
     assert result == b"".join(expect)
+
+
+def test_main_historical():
+    """Stop if rev2 isn't the working tree and no ``--diff`` or ``--check`` provided"""
+    with pytest.raises(ArgumentError):
+
+        darker.__main__.main(["--revision=foo..bar"])
 
 
 def test_output_diff(tmp_path, monkeypatch, capsys):

--- a/src/darker/utils.py
+++ b/src/darker/utils.py
@@ -175,7 +175,7 @@ def debug_dump(black_chunks: List[DiffChunk], edited_linenums: List[int]) -> Non
     print(80 * "-")
 
 
-def joinlines(lines: TextLines, newline: str = "\n") -> str:
+def joinlines(lines: Iterable[str], newline: str = "\n") -> str:
     """Join a list of lines back, adding a linefeed after each line
 
     This is the reverse of ``str.splitlines()``.


### PR DESCRIPTION
This pull request fixes three bugs:

**AST verification** no longer erroneously fails when using `--isort`.

This bug was introduced in #94 and is present in version 1.2.3.

**Historical comparisons**, e.g. comparing two past commits like `darker --diff v1.0..v1.1` would still compare against the file on disk in the working tree, not the second commit. This has been fixed.

**Darker would write historical reformats on disk**, overwriting a newer version in the working tree. Now an exception is raised instead if a historical comparison like `darker --revision=commit1..commit2` is used without `--diff` or `--check`.