### PR TITLE
Fix assumption of root being CWD in print_diff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- ``/foo $ darker --diff /bar/my-repo`` now works: the current working directory can be
+   in a different part of the directory hierarchy
 
 
 1.3.0_ - 2021-09-04

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -6,7 +6,7 @@ from argparse import Action, ArgumentError
 from datetime import datetime
 from difflib import unified_diff
 from pathlib import Path
-from typing import Collection, Generator, List, Optional, Tuple
+from typing import Collection, Generator, List, Tuple
 
 from darker.black_diff import (
     BlackConfig,
@@ -197,7 +197,7 @@ def modify_file(path: Path, new_content: TextDocument) -> None:
 
 
 def print_diff(
-    path: Path, old: TextDocument, new: TextDocument, root: Optional[Path] = None
+    path: Path, old: TextDocument, new: TextDocument, root: Path = None
 ) -> None:
     """Print ``black --diff`` style output for the changes
 

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -440,10 +440,10 @@ def test_main(
     """Main function outputs diffs and modifies files correctly"""
     if root_as_cwd:
         cwd = git_repo.root
-        pwd = ""
+        pwd = Path("")
     else:
         cwd = tmp_path_factory.mktemp("not_a_git_repo")
-        pwd = str(git_repo.root) + "/"
+        pwd = git_repo.root
     monkeypatch.chdir(cwd)
     paths = git_repo.add(
         {"pyproject.toml": dedent(pyproject_toml), "a.py": newline, "b.py": newline},
@@ -452,7 +452,7 @@ def test_main(
     paths["a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
     paths["b.py"].write_bytes(f"print(42 ){newline}".encode("ascii"))
 
-    retval = darker.__main__.main(arguments + [pwd + "a.py"])
+    retval = darker.__main__.main(arguments + [str(pwd / "a.py")])
 
     stdout = capsys.readouterr().out.replace(str(git_repo.root), "")
     diff_output = stdout.splitlines(False)

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -409,16 +409,23 @@ def test_format_edited_parts_historical(git_repo, rev1, rev2, expect):
            """,
         expect_stdout=[],
     ),
+    dict(
+        arguments=["--diff"],
+        expect_stdout=A_PY_DIFF_BLACK,
+        root_as_cwd=False,
+    ),
     # for all test cases, by default there's no output, `a.py` stays unmodified, and the
     # return value is a zero:
     pyproject_toml="",
     expect_stdout=[],
     expect_a_py=A_PY,
     expect_retval=0,
+    root_as_cwd=True,
 )
 @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["unix", "windows"])
 def test_main(
     git_repo,
+    monkeypatch,
     capsys,
     find_project_root_cache_clear,
     arguments,
@@ -427,8 +434,17 @@ def test_main(
     expect_stdout,
     expect_a_py,
     expect_retval,
+    root_as_cwd,
+    tmp_path_factory,
 ):  # pylint: disable=too-many-arguments
     """Main function outputs diffs and modifies files correctly"""
+    if root_as_cwd:
+        cwd = git_repo.root
+        pwd = ""
+    else:
+        cwd = tmp_path_factory.mktemp("not_a_git_repo")
+        pwd = str(git_repo.root) + "/"
+    monkeypatch.chdir(cwd)
     paths = git_repo.add(
         {"pyproject.toml": dedent(pyproject_toml), "a.py": newline, "b.py": newline},
         commit="Initial commit",
@@ -436,7 +452,7 @@ def test_main(
     paths["a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
     paths["b.py"].write_bytes(f"print(42 ){newline}".encode("ascii"))
 
-    retval = darker.__main__.main(arguments + ["a.py"])
+    retval = darker.__main__.main(arguments + [pwd + "a.py"])
 
     stdout = capsys.readouterr().out.replace(str(git_repo.root), "")
     diff_output = stdout.splitlines(False)


### PR DESCRIPTION
As currently written, `print_diff` assumes that that current working directory should be used as the relative path, which does not necessarily need to be the case.

Submitting the test first, for that satisfying red X to green check mark, the patch follows.

- [x] write a test that captures current bug
- [x] make it pass
- [x]  document the change