### PR TITLE
Allow running on plain (non-git) directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Added
 - Darker now allows itself to modify files when called with ``pre-commit -o HEAD``, but
   also emits a warning about this being an experimental feature
 - Mention Black's possible new line range formatting support in README
+- Darker can now be used in a plain directory tree in addition to Git repositories
 
 Fixed
 -----

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -24,11 +24,11 @@ from darker.git import (
     PRE_COMMIT_FROM_TO_REFS,
     WORKTREE,
     EditedLinenumsDiffer,
-    NotGitRespository,
     RevisionRange,
     get_missing_at_revision,
     git_get_content_at_revision,
     git_get_modified_python_files,
+    git_is_repository,
 )
 from darker.help import ISORT_INSTRUCTION
 from darker.highlighting import colorize
@@ -370,11 +370,11 @@ def main(argv: List[str] = None) -> int:
         black_exclude = set()
     else:
         # In other modes, only process files which have been modified.
-        try:
+        if git_is_repository(root):
             changed_files_to_process = git_get_modified_python_files(
                 files_to_process, revrange, root
             )
-        except NotGitRespository:
+        else:
             changed_files_to_process = {
                 path.relative_to(root) for path in files_to_process
             }

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -28,7 +28,7 @@ from darker.git import (
     RevisionRange,
     get_missing_at_revision,
     git_get_content_at_revision,
-    git_get_modified_files,
+    git_get_modified_python_files,
 )
 from darker.help import ISORT_INSTRUCTION
 from darker.highlighting import colorize
@@ -371,16 +371,13 @@ def main(argv: List[str] = None) -> int:
     else:
         # In other modes, only process files which have been modified.
         try:
-            changed_files_to_process = git_get_modified_files(
+            changed_files_to_process = git_get_modified_python_files(
                 files_to_process, revrange, root
             )
         except NotGitRespository:
-            changed_files_to_process = set()
-            for path in files_to_process:
-                if path.suffix == ".py":
-                    changed_files_to_process.add(path)
-                else:
-                    changed_files_to_process.update(path.glob("**/*.py"))
+            changed_files_to_process = {
+                path.relative_to(root) for path in files_to_process
+            }
         black_exclude = {
             f for f in changed_files_to_process if root / f not in files_to_blacken
         }

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -1,6 +1,5 @@
 """Darker - apply black reformatting to only areas edited since the last commit"""
 
-import glob
 import logging
 import sys
 import warnings
@@ -378,11 +377,10 @@ def main(argv: List[str] = None) -> int:
         except NotGitRespository:
             changed_files_to_process = set()
             for path in files_to_process:
-                if str(path).endswith(".py"):
-                    changed_files_to_process.add(Path(path))
+                if path.suffix == ".py":
+                    changed_files_to_process.add(path)
                 else:
-                    more_files = glob.glob(str(path) + "/**/*.py", recursive=True)
-                    changed_files_to_process.update({Path(p) for p in more_files})
+                    changed_files_to_process.update(path.glob("**/*.py"))
         black_exclude = {
             f for f in changed_files_to_process if root / f not in files_to_blacken
         }

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from subprocess import DEVNULL, PIPE, CalledProcessError, run
+from subprocess import DEVNULL, PIPE, CalledProcessError, check_output, run
 from typing import Iterable, List, Set, Tuple
 
 from darker.diff import diff_and_get_opcodes, opcodes_to_edit_linenums
@@ -32,8 +32,19 @@ WORKTREE = ":WORKTREE:"
 PRE_COMMIT_FROM_TO_REFS = ":PRE-COMMIT:"
 
 
-class NotGitRespository(Exception):
-    "Raised when git commands are run in a folder that is not a git repository"
+def git_is_repository(path: Path) -> bool:
+    """Return ``True`` if ``path`` is inside a Git working tree"""
+    try:
+        lines = _git_check_output_lines(
+            ["rev-parse", "--is-inside-work-tree"], path, exit_on_error=False
+        )
+        return lines[:1] == ["true"]
+    except CalledProcessError as exc_info:
+        if exc_info.returncode != 128 or not exc_info.stderr.startswith(
+            "fatal: not a git repository"
+        ):
+            raise
+        return False
 
 
 def git_get_mtime_at_commit(path: Path, revision: str, cwd: Path) -> str:
@@ -168,32 +179,23 @@ def _git_check_output_lines(
     """Log command line, run Git, split stdout to lines, exit with 123 on error"""
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:
-        result = run(
+        return check_output(
             ["git"] + cmd,
             cwd=str(cwd),
-            check=True,
             encoding="utf-8",
-            stdout=PIPE,
             stderr=PIPE,
             env={"LC_ALL": "C"},
-        )
-        return result.stdout.splitlines()
+        ).splitlines()
     except CalledProcessError as exc_info:
-        retval = exc_info.returncode
-        msg = exc_info.stderr
-        if (retval == 129 and msg.startswith("Not a git repository")) or (
-            retval == 1 and msg.startswith("error: could not access ")
-        ):
-            raise NotGitRespository(f"{cwd} is not a git repository") from exc_info
         if not exit_on_error:
             raise
-        if retval != 128:
-            sys.stderr.write(msg)
+        if exc_info.returncode != 128:
+            sys.stderr.write(exc_info.stderr)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the
         # error status 123.
-        for error_line in msg.splitlines():
+        for error_line in exc_info.stderr.splitlines():
             logger.error(error_line)
         sys.exit(123)
 

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -173,7 +173,8 @@ def _git_check_output_lines(
             cwd=str(cwd),
             check=True,
             encoding="utf-8",
-            capture_output=True,
+            stdout=PIPE,
+            stderr=PIPE,
             env={"LC_ALL": "C"},
         )
         return result.stdout.splitlines()

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -278,10 +278,10 @@ def _git_ls_files_others(relative_paths: Set[Path], cwd: Path) -> Set[Path]:
     return {Path(line) for line in lines}
 
 
-def git_get_modified_files(
+def git_get_modified_python_files(
     paths: Iterable[Path], revrange: RevisionRange, cwd: Path
 ) -> Set[Path]:
-    """Ask Git for modified and untracked files
+    """Ask Git for modified and untracked ``*.py`` files
 
     - ``git diff --name-only --relative <rev> -- <path(s)>``
     - ``git ls-files --others --exclude-standard -- <path(s)>``

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -179,19 +179,21 @@ def _git_check_output_lines(
         )
         return result.stdout.splitlines()
     except CalledProcessError as exc_info:
-        if exc_info.returncode == 129 and exc_info.stderr.startswith(
-            "Not a git repository"
+        retval = exc_info.returncode
+        msg = exc_info.stderr
+        if (retval == 129 and msg.startswith("Not a git repository")) or (
+            retval == 1 and msg.startswith("error: could not access ")
         ):
             raise NotGitRespository(f"{cwd} is not a git repository") from exc_info
         if not exit_on_error:
             raise
-        if exc_info.returncode != 128:
-            sys.stderr.write(exc_info.stderr)
+        if retval != 128:
+            sys.stderr.write(msg)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the
         # error status 123.
-        for error_line in exc_info.stderr.splitlines():
+        for error_line in msg.splitlines():
             logger.error(error_line)
         sys.exit(123)
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -510,8 +510,8 @@ def test_git_ls_files_others(git_repo):
     modify_paths={},
     paths=[],
 )
-def test_git_get_modified_files(git_repo, modify_paths, paths, expect):
-    """Tests for `darker.git.git_get_modified_files()`"""
+def test_git_get_modified_python_files(git_repo, modify_paths, paths, expect):
+    """Tests for `darker.git.git_get_modified_python_files()`"""
     root = Path(git_repo.root)
     git_repo.add(
         {
@@ -532,7 +532,9 @@ def test_git_get_modified_files(git_repo, modify_paths, paths, expect):
             absolute_path.write_bytes(content.encode("ascii"))
     revrange = git.RevisionRange("HEAD", ":WORKTREE:")
 
-    result = git.git_get_modified_files({root / p for p in paths}, revrange, cwd=root)
+    result = git.git_get_modified_python_files(
+        {root / p for p in paths}, revrange, cwd=root
+    )
 
     assert result == {Path(p) for p in expect}
 
@@ -679,11 +681,11 @@ def branched_repo(tmp_path_factory):
         expect={"mod_both.py", "mod_same.py", "mod_branch.py"},
     ),
 )
-def test_git_get_modified_files_revision_range(
+def test_git_get_modified_python_files_revision_range(
     _description, branched_repo, revrange, expect
 ):
-    """Test for :func:`darker.git.git_get_modified_files` with a revision range"""
-    result = git.git_get_modified_files(
+    """Test for :func:`darker.git.git_get_modified_python_files` with revision range"""
+    result = git.git_get_modified_python_files(
         [Path(branched_repo.root)],
         git.RevisionRange.parse_with_common_ancestor(revrange, branched_repo.root),
         Path(branched_repo.root),

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -161,12 +161,12 @@ def test_git_get_content_at_revision_obtain_file_content(
     revision, expect_git_calls, expect_textdocument_calls
 ):
     """``git_get_content_at_revision`` calls Git or reads files based on revision"""
-    with patch("darker.git.run") as run, patch(
+    with patch("darker.git.check_output") as check_output, patch(
         "darker.git.TextDocument"
     ) as text_document_class:
         # this dummy value acts both as a dummy Unix timestamp for the file as well as
         # the contents of the file:
-        run.return_value.stdout = b"1627107028"
+        check_output.return_value = b"1627107028"
 
         git.git_get_content_at_revision(Path("my.txt"), revision, Path("/path"))
 
@@ -174,15 +174,13 @@ def test_git_get_content_at_revision_obtain_file_content(
             call(
                 expected_call.split(),
                 cwd=str(Path("/path")),
-                check=True,
-                stdout=PIPE,
-                stderr=PIPE,
                 encoding="utf-8",
+                stderr=PIPE,
                 env={"LC_ALL": "C"},
             )
             for expected_call in expect_git_calls
         ]
-        assert run.call_args_list == expected_calls
+        assert check_output.call_args_list == expected_calls
         assert text_document_class.method_calls == expect_textdocument_calls
 
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -175,7 +175,8 @@ def test_git_get_content_at_revision_obtain_file_content(
                 expected_call.split(),
                 cwd=str(Path("/path")),
                 check=True,
-                capture_output=True,
+                stdout=PIPE,
+                stderr=PIPE,
                 encoding="utf-8",
                 env={"LC_ALL": "C"},
             )

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -18,6 +18,25 @@ from darker.tests.helpers import raises_or_matches
 from darker.utils import GIT_DATEFORMAT, TextDocument
 
 
+def test_tmp_path_sanity(tmp_path):
+    """Make sure Pytest temporary directories aren't inside a Git repository"""
+    try:
+        result = git._git_check_output_lines(
+            ["rev-parse", "--absolute-git-dir"], tmp_path, exit_on_error=False
+        )
+    except CalledProcessError as exc_info:
+        if exc_info.returncode != 128 or not exc_info.stderr.startswith(
+            "fatal: not a git repository"
+        ):
+            raise
+    else:
+        output = "\n".join(result)
+        raise AssertionError(
+            f"Temporary directory {tmp_path} for tests is not clean."
+            f" There is a Git directory in {output}"
+        )
+
+
 @pytest.mark.parametrize(
     "revision_range, expect",
     [

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -161,12 +161,12 @@ def test_git_get_content_at_revision_obtain_file_content(
     revision, expect_git_calls, expect_textdocument_calls
 ):
     """``git_get_content_at_revision`` calls Git or reads files based on revision"""
-    with patch("darker.git.check_output") as check_output, patch(
+    with patch("darker.git.run") as run, patch(
         "darker.git.TextDocument"
     ) as text_document_class:
         # this dummy value acts both as a dummy Unix timestamp for the file as well as
         # the contents of the file:
-        check_output.return_value = b"1627107028"
+        run.return_value.stdout = b"1627107028"
 
         git.git_get_content_at_revision(Path("my.txt"), revision, Path("/path"))
 
@@ -174,13 +174,14 @@ def test_git_get_content_at_revision_obtain_file_content(
             call(
                 expected_call.split(),
                 cwd=str(Path("/path")),
+                check=True,
+                capture_output=True,
                 encoding="utf-8",
-                stderr=PIPE,
                 env={"LC_ALL": "C"},
             )
             for expected_call in expect_git_calls
         ]
-        assert check_output.call_args_list == expected_calls
+        assert run.call_args_list == expected_calls
         assert text_document_class.method_calls == expect_textdocument_calls
 
 


### PR DESCRIPTION
I started off writing some code for better messages when running `darker` on a non-git repo, to fix #71, but then ended up writing enough to make it work anyway.

With this PR, you can `mkdir /tmp/test ; cd /tmp/test ; darker .` and no compaints are raised. Same goes for

```diff
$ mkdir -p /tmp/test ; cd /tmp/test ; echo "print   ('hello'  )" > a.py; darker --diff .;
--- a.py
+++ a.py
@@ -1 +1 @@
-print   ('hello'  )
+print("hello")
```

Opening this up for discussion to see if this if @akaihola would be amenable to something like this, before I start adding tests. In particular,  this will conflict with #138, though I also ran into AST verification failing when using `--isort`, my fix is slightly different (perhaps wrong?). 

#139 also came out of the work on this, but I decided to submit that one separately, since it's an independent change.