### PR TITLE
fix: always give git_get_content_at_revision a relative path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Added
 
 Fixed
 -----
+- Ensure a full revision range ``--revision <COMMIT_A>..<COMMIT_B>`` where
+  COMMIT_B is *not* ``:WORKTREE:`` works too.
 
 
 1.2.4_ - 2021-06-27

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -51,7 +51,9 @@ def format_edited_parts(
 
     for path_in_repo in sorted(changed_files):
         src = git_root / path_in_repo
-        rev2_content = git_get_content_at_revision(src, revrange.rev2, git_root)
+        rev2_content = git_get_content_at_revision(
+            path_in_repo, revrange.rev2, git_root
+        )
 
         # 1. run isort
         if enable_isort:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -40,6 +40,10 @@ def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDoc
     :param cwd: The root of the Git repository
 
     """
+    assert (
+        not path.is_absolute()
+    ), f"the 'path' parameter must receive a relative path, got {path!r} instead"
+
     if revision == WORKTREE:
         abspath = cwd / path
         return TextDocument.from_file(abspath)


### PR DESCRIPTION
Instead of passing an absolute path to `git show COMMITISH:{path}` and being surprised that git isn't able to deal with absolute paths there.

This triggers when using `--revision <COMMIT_A>..<COMMIT_B>` where `COMMIT_B` is _not_ `:WORKTREE:`. That is what we want to use in our CI system to validate every single commit in a PR.

For C++ we've already been using this for years with `clang-format` for the purpose of ensuring that `git blame` always returns the commit that changed the logic of the code, not some follow up commit that reformatted it (by basically forbidding such follow up commits).