### PR TITLE
Hide expected Git errors from stderr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Fixed
 -----
 - Ensure a full revision range ``--revision <COMMIT_A>..<COMMIT_B>`` where
   COMMIT_B is *not* ``:WORKTREE:`` works too.
+- Hide fatal error from Git on stderr when ``git show`` doesn't find the file in rev1.
+  This isn't fatal from Darker's point of view since it's a newly created file.
 
 
 1.2.4_ - 2021-06-27

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -156,7 +156,7 @@ def _git_check_output_lines(
         if not exit_on_error:
             raise
         if exc_info.returncode != 128:
-            sys.stderr.buffer.write(exc_info.stderr)
+            sys.stderr.write(exc_info.stderr)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -153,14 +153,14 @@ def _git_check_output_lines(
             ["git"] + cmd, cwd=str(cwd), encoding="utf-8", stderr=PIPE
         ).splitlines()
     except CalledProcessError as exc_info:
-        if exc_info.returncode == 128 and exit_on_error:
-            # Bad revision or another Git failure. Follow Black's example and return the
-            # error status 123.
-            for error_line in exc_info.stderr.splitlines():
-                logger.error(error_line)
-            sys.exit(123)
-        else:
+        if exc_info.returncode != 128 or not exit_on_error:
             raise
+
+        # Bad revision or another Git failure. Follow Black's example and return the
+        # error status 123.
+        for error_line in exc_info.stderr.splitlines():
+            logger.error(error_line)
+        sys.exit(123)
 
 
 def git_get_modified_files(

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -153,7 +153,10 @@ def _git_check_output_lines(
             ["git"] + cmd, cwd=str(cwd), encoding="utf-8", stderr=PIPE
         ).splitlines()
     except CalledProcessError as exc_info:
-        if exc_info.returncode != 128 or not exit_on_error:
+        if not exit_on_error:
+            raise
+        if exc_info.returncode != 128:
+            sys.stderr.buffer.write(exc_info.stderr)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -296,7 +296,7 @@ def test_git_get_content_at_revision_stderr(git_repo, capfd, caplog):
     git_repo.add({"file2": "file2"}, commit="Second commit")
     capfd.readouterr()  # flush captured stdout and stderr
 
-    result = git_get_content_at_revision(Path("file2"), initial, git_repo.root)
+    result = git.git_get_content_at_revision(Path("file2"), initial, git_repo.root)
 
     assert result == TextDocument()
     outerr = capfd.readouterr()

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -5,7 +5,7 @@
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from subprocess import CalledProcessError, check_call
+from subprocess import PIPE, CalledProcessError, check_call
 from typing import List, Union
 from unittest.mock import patch
 
@@ -152,7 +152,7 @@ def test_git_get_content_at_revision_git_calls(revision, expect):
         assert check_output.call_count == len(expect)
         for expect_call in expect:
             check_output.assert_any_call(
-                expect_call.split(), cwd="cwd", encoding="utf-8"
+                expect_call.split(), cwd="cwd", encoding="utf-8", stderr=PIPE
             )
 
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -247,7 +247,7 @@ def test_git_check_output_lines(branched_repo, cmd, exit_on_error, expect_templa
         expect_exc=SystemExit,
         expect_log=(
             r"ERROR    darker\.git:git\.py:\d+ fatal: "
-            r"Path '/\.file2' does not exist in '{initial}'\n$"
+            r"[pP]ath '/\.file2' does not exist in '{initial}'\n$"
         ),
     ),
     dict(

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -289,6 +289,22 @@ def test_git_check_output_lines_stderr_and_log(
     assert re.match(expect_log_re, caplog.text), repr(caplog.text)
 
 
+def test_git_get_content_at_revision_stderr(git_repo, capfd, caplog):
+    """No stderr or log output from ``git_get_content_at_revision`` for missing file"""
+    git_repo.add({"file1": "file1"}, commit="Initial commit")
+    initial = git_repo.get_hash()[:7]
+    git_repo.add({"file2": "file2"}, commit="Second commit")
+    capfd.readouterr()  # flush captured stdout and stderr
+
+    result = git_get_content_at_revision(Path("file2"), initial, git_repo.root)
+
+    assert result == TextDocument()
+    outerr = capfd.readouterr()
+    assert outerr.out == ""
+    assert outerr.err == ""
+    assert caplog.text == ""
+
+
 @pytest.mark.kwparametrize(
     dict(paths=["a.py"], expect=[]),
     dict(expect=[]),


### PR DESCRIPTION
Fixes #85.

With e.g. `darker --revision=master...`, newly created files would cause this Git error to appear on stderr:
```
fatal: Path 'newfile.py' exists on disk, but not in 'master'.
```

We already caught that situation and interpreted it properly as caused by a newly created file. In addition, the Git error messages are now silenced, but other Git errors are still logged with the `ERROR` loglevel.

Unfortunately I couldn't find a way to create a failing test, i.e. one that would be able to catch Git's stderr.