### PR TITLE
Validate that paths given on command line do exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Added
 - ``darker --diff`` output is now identical to that of ``black --diff``
 - The ``-d`` / ``--stdout`` option outputs the reformatted contents of the single Python
   file provided on the command line.
+- Disallow file paths starting with a hyphen. This improves the error from misquoted
+  parameters like ``"--lint pylint"``.
 
 Fixed
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,8 @@ Added
 - ``darker --diff`` output is now identical to that of ``black --diff``
 - The ``-d`` / ``--stdout`` option outputs the reformatted contents of the single Python
   file provided on the command line.
-- Disallow file paths starting with a hyphen. This improves the error from misquoted
-  parameters like ``"--lint pylint"``.
+- Terminate with an error if non-existing files or directories are passed on the command
+  line. This also improves the error from misquoted parameters like ``"--lint pylint"``.
 
 Fixed
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ where = src
 
 [options.entry_points]
 console_scripts =
-    darker = darker.__main__:main
+    darker = darker.__main__:main_with_error_handling
 
 [options.extras_require]
 isort =

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -279,10 +279,7 @@ def main(argv: List[str] = None) -> int:
     """
     if argv is None:
         argv = sys.argv[1:]
-    try:
-        args, config, config_nondefault = parse_command_line(argv)
-    except ArgumentError as exc_info:
-        sys.exit(exc_info)
+    args, config, config_nondefault = parse_command_line(argv)
     logging.basicConfig(level=args.log_level)
     if args.log_level == logging.INFO:
         formatter = logging.Formatter("%(levelname)s: %(message)s")

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -278,7 +278,10 @@ def main(argv: List[str] = None) -> int:
     """
     if argv is None:
         argv = sys.argv[1:]
-    args, config, config_nondefault = parse_command_line(argv)
+    try:
+        args, config, config_nondefault = parse_command_line(argv)
+    except ArgumentError as exc_info:
+        sys.exit(exc_info)
     logging.basicConfig(level=args.log_level)
     if args.log_level == logging.INFO:
         formatter = logging.Formatter("%(levelname)s: %(message)s")

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -22,6 +22,7 @@ from darker.git import (
     WORKTREE,
     EditedLinenumsDiffer,
     RevisionRange,
+    get_missing_at_revision,
     git_get_content_at_revision,
     git_get_modified_files,
 )
@@ -324,6 +325,16 @@ def main(argv: List[str] = None) -> int:
             f"Can't write reformatted files for revision '{revrange.rev2}'."
             " Either --diff or --check must be used.",
         )
+
+    missing = get_missing_at_revision(paths, revrange.rev2)
+    if missing:
+        missing_reprs = " ".join(repr(str(path)) for path in missing)
+        rev2_repr = "the working tree" if revrange.rev2 == WORKTREE else revrange.rev2
+        raise ArgumentError(
+            Action(["PATH"], "path"),
+            f"Error: Path(s) {missing_reprs} do not exist in {rev2_repr}",
+        )
+
     if output_mode == OutputMode.CONTENT:
         # With `-d` / `--stdout`, process the file whether modified or not. Paths have
         # previously been validated to contain exactly one existing file.

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -351,6 +351,14 @@ def main(argv: List[str] = None) -> int:
     return 1 if args.check and failures_on_modified_lines else 0
 
 
+def main_with_error_handling() -> int:
+    """Entry point for console script"""
+    try:
+        return main()
+    except ArgumentError as exc_info:
+        sys.exit(str(exc_info))
+
+
 if __name__ == "__main__":
-    RETVAL = main()
+    RETVAL = main_with_error_handling()
     sys.exit(RETVAL)

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -1,4 +1,6 @@
-from argparse import ArgumentParser, Namespace
+"""Command line parsing for the ``darker`` binary"""
+
+from argparse import Action, ArgumentError, ArgumentParser, Namespace
 from typing import Any, List, Optional, Text, Tuple
 
 from darker import help as hlp
@@ -105,6 +107,14 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     #    This is used to find out differences between the effective configuration and
     #    default configuration values, and print them out in verbose mode.
     parser_with_original_defaults = make_argument_parser(require_src=True)
+    invalid_src_paths = [src for src in args.src if src.startswith("-")]
+    if invalid_src_paths:
+        invalid_path_reprs = " ".join(repr(path) for path in invalid_src_paths)
+        raise ArgumentError(
+            Action(["src"], dest="src", metavar="PATH"),
+            f"PATH can't begin with a hyphen: {invalid_path_reprs}\n"
+            "Maybe check your shell quoting?",
+        )
     return (
         args,
         get_effective_config(args),

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -1,6 +1,6 @@
 """Command line parsing for the ``darker`` binary"""
 
-from argparse import Action, ArgumentError, ArgumentParser, Namespace
+from argparse import ArgumentParser, Namespace
 from typing import Any, List, Optional, Text, Tuple
 
 from darker import help as hlp
@@ -107,14 +107,6 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     #    This is used to find out differences between the effective configuration and
     #    default configuration values, and print them out in verbose mode.
     parser_with_original_defaults = make_argument_parser(require_src=True)
-    invalid_src_paths = [src for src in args.src if src.startswith("-")]
-    if invalid_src_paths:
-        invalid_path_reprs = " ".join(repr(path) for path in invalid_src_paths)
-        raise ArgumentError(
-            Action(["src"], dest="src", metavar="PATH"),
-            f"PATH can't begin with a hyphen: {invalid_path_reprs}\n"
-            "Maybe check your shell quoting?",
-        )
     return (
         args,
         get_effective_config(args),

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -175,7 +175,9 @@ def _git_exists_in_revision(path: Path, rev2: str) -> bool:
              it doesn't.
 
     """
-    cmd = ["git", "cat-file", "-e", f"{rev2}:{path}"]
+    # Surprise: On Windows, `git cat-file` doesn't work with backslash directory
+    # separators in paths. We need to use Posix paths and forward slashes instead.
+    cmd = ["git", "cat-file", "-e", f"{rev2}:{path.as_posix()}"]
     result = run(cmd, check=False, stderr=DEVNULL)
     return result.returncode == 0
 

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from subprocess import PIPE, CalledProcessError, check_output
+from subprocess import DEVNULL, PIPE, CalledProcessError, check_output, run
 from typing import Iterable, List, Set
 
 from darker.diff import diff_and_get_opcodes, opcodes_to_edit_linenums
@@ -164,6 +164,36 @@ def _git_check_output_lines(
         for error_line in exc_info.stderr.splitlines():
             logger.error(error_line)
         sys.exit(123)
+
+
+def _git_exists_in_revision(path: Path, rev2: str) -> bool:
+    """Return ``True`` if the given path exists in the given Git revision
+
+    :param path: The path of the file or directory to check
+    :param rev2: The Git revision to look at
+    :return: ``True`` if the file or directory exists at the revision, or ``False`` if
+             it doesn't.
+
+    """
+    cmd = ["git", "cat-file", "-e", f"{rev2}:{path}"]
+    result = run(cmd, check=False, stderr=DEVNULL)
+    return result.returncode == 0
+
+
+def get_missing_at_revision(paths: Iterable[Path], rev2: str) -> Set[Path]:
+    """Return paths missing in the given revision
+
+    In case of ``WORKTREE``, just check if the files exist on the filesystem instead of
+    asking Git.
+
+    :param paths: Paths to check
+    :param rev2: The Git revision to look at, or ``WORKTREE`` for the working tree
+    :return: The set of file or directory paths which are missing in the revision
+
+    """
+    if rev2 == WORKTREE:
+        return {path for path in paths if not path.exists()}
+    return {path for path in paths if not _git_exists_in_revision(path, rev2)}
 
 
 def git_get_modified_files(

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -3,6 +3,7 @@
 """Unit tests for :mod:`darker.command_line` and :mod:`darker.__main__`"""
 
 import re
+from argparse import Action, ArgumentError
 from importlib import reload
 from pathlib import Path
 from textwrap import dedent
@@ -287,6 +288,22 @@ def test_parse_command_line_config_src(
         expect_value=("line_length", 99),
         expect_config=("line_length", 99),
         expect_modified=("line_length", 99),
+    ),
+    dict(
+        argv=["--invalid PATH"],
+        expect_value=ArgumentError(
+            Action(["src"], dest="src"),
+            "PATH can't begin with a hyphen: '--invalid PATH'\n"
+            "Maybe check your shell quoting?",
+        ),
+        expect_config=(),
+        expect_modified=(),
+    ),
+    dict(
+        argv=["valid/path", "another/valid/path"],
+        expect_value=("src", ["valid/path", "another/valid/path"]),
+        expect_config=("src", ["valid/path", "another/valid/path"]),
+        expect_modified=("src", ["valid/path", "another/valid/path"]),
     ),
 )
 def test_parse_command_line(

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -310,11 +310,11 @@ def test_parse_command_line(
     """``parse_command_line()`` parses options correctly"""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "dummy.py").touch()
-
-    with raises_if_exception(expect_value):
+    with raises_if_exception(expect_value) as expect_exception:
 
         args, effective_cfg, modified_cfg = parse_command_line(argv)
 
+    if not expect_exception:
         arg_name, expect_arg_value = expect_value
         assert getattr(args, arg_name) == expect_arg_value
 

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -1,9 +1,9 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,too-many-locals
 
 """Unit tests for :mod:`darker.command_line` and :mod:`darker.__main__`"""
 
 import re
-from argparse import Action, ArgumentError
+from argparse import ArgumentError
 from importlib import reload
 from pathlib import Path
 from textwrap import dedent
@@ -290,14 +290,12 @@ def test_parse_command_line_config_src(
         expect_modified=("line_length", 99),
     ),
     dict(
-        argv=["--invalid PATH"],
-        expect_value=ArgumentError(
-            Action(["src"], dest="src"),
-            "PATH can't begin with a hyphen: '--invalid PATH'\n"
-            "Maybe check your shell quoting?",
-        ),
-        expect_config=(),
-        expect_modified=(),
+        # this is accepted as a path, but would later fail if a file or directory with
+        # that funky name doesn't exist
+        argv=["--suspicious path"],
+        expect_value=("src", ["--suspicious path"]),
+        expect_config=("src", ["--suspicious path"]),
+        expect_modified=("src", ["--suspicious path"]),
     ),
     dict(
         argv=["valid/path", "another/valid/path"],
@@ -578,8 +576,9 @@ def test_options(git_repo, options, expect):
     dict(check=True, changes=True, expect_retval=1),
     expect_retval=0,
 )
-def test_main_retval(check, changes, expect_retval):
+def test_main_retval(git_repo, check, changes, expect_retval):
     """main() return value is correct based on --check and the need to reformat files"""
+    git_repo.add({"a.py": ""}, commit="Initial commit")
     format_edited_parts = Mock()
     format_edited_parts.return_value = (
         [
@@ -600,3 +599,32 @@ def test_main_retval(check, changes, expect_retval):
         retval = main(check_arg_maybe + ["a.py"])
 
     assert retval == expect_retval
+
+
+def test_main_missing_in_worktree(git_repo):
+    """An ``ArgumentError`` is raised if given file is not found on disk"""
+    paths = git_repo.add({"a.py": ""}, commit="Add a.py")
+    paths["a.py"].unlink()
+
+    with pytest.raises(
+        ArgumentError,
+        match=re.escape(
+            "argument PATH: Error: Path(s) 'a.py' do not exist in the working tree"
+        ),
+    ):
+
+        main(["a.py"])
+
+
+def test_main_missing_in_revision(git_repo):
+    """An ``ArgumentError`` is raised if given file didn't exist in rev2"""
+    paths = git_repo.add({"a.py": ""}, commit="Add a.py")
+    git_repo.add({"a.py": None}, commit="Delete a.py")
+    paths["a.py"].touch()
+
+    with pytest.raises(
+        ArgumentError,
+        match=re.escape("argument PATH: Error: Path(s) 'a.py' do not exist in HEAD"),
+    ):
+
+        main(["--diff", "--revision", "..HEAD", "a.py"])

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -339,7 +339,7 @@ def test_git_exists_in_revision_git_call(retval, expect):
 )
 def test_git_exists_in_revision(git_repo, rev2, path, expect):
     """``_get_exists_in_revision()`` detects file/dir existence correctly"""
-    git_repo.add({"dir/a.py": "foo", "dir/b.py": "bar"}, commit="Add dir/*.py")
+    git_repo.add({"dir/a.py": "", "dir/b.py": ""}, commit="Add dir/*.py")
     add = git_repo.get_hash()
     git_repo.add({"dir/a.py": None}, commit="Delete dir/a.py")
     del_a = git_repo.get_hash()
@@ -357,7 +357,7 @@ def test_git_exists_in_revision(git_repo, rev2, path, expect):
 )
 def test_get_missing_at_revision(git_repo, rev2, expect):
     """``get_missing_at_revision()`` returns missing files/directories correctly"""
-    git_repo.add({"dir/a.py": "foo", "dir/b.py": "bar"}, commit="Add dir/*.py")
+    git_repo.add({"dir/a.py": "", "dir/b.py": ""}, commit="Add dir/*.py")
     add = git_repo.get_hash()
     git_repo.add({"dir/a.py": None}, commit="Delete dir/a.py")
     del_a = git_repo.get_hash()
@@ -369,6 +369,19 @@ def test_get_missing_at_revision(git_repo, rev2, expect):
     )
 
     assert result == expect
+
+
+def test_get_missing_at_revision_worktree(git_repo):
+    """``get_missing_at_revision()`` returns missing work tree files/dirs correctly"""
+    paths = git_repo.add({"dir/a.py": "", "dir/b.py": ""}, commit="Add dir/*.py")
+    paths["dir/a.py"].unlink()
+    paths["dir/b.py"].unlink()
+
+    result = git.get_missing_at_revision(
+        {Path("dir"), Path("dir/a.py"), Path("dir/b.py")}, git.WORKTREE
+    )
+
+    assert result == {Path("dir/a.py"), Path("dir/b.py")}
 
 
 @pytest.mark.kwparametrize(

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -351,6 +351,27 @@ def test_git_exists_in_revision(git_repo, rev2, path, expect):
 
 
 @pytest.mark.kwparametrize(
+    dict(rev2="{add}", expect=set()),
+    dict(rev2="{del_a}", expect={Path("dir/a.py")}),
+    dict(rev2="HEAD", expect={Path("dir"), Path("dir/a.py"), Path("dir/b.py")}),
+)
+def test_get_missing_at_revision(git_repo, rev2, expect):
+    """``get_missing_at_revision()`` returns missing files/directories correctly"""
+    git_repo.add({"dir/a.py": "foo", "dir/b.py": "bar"}, commit="Add dir/*.py")
+    add = git_repo.get_hash()
+    git_repo.add({"dir/a.py": None}, commit="Delete dir/a.py")
+    del_a = git_repo.get_hash()
+    git_repo.add({"dir/b.py": None}, commit="Delete dir/b.py")
+
+    result = git.get_missing_at_revision(
+        {Path("dir"), Path("dir/a.py"), Path("dir/b.py")},
+        rev2.format(add=add, del_a=del_a),
+    )
+
+    assert result == expect
+
+
+@pytest.mark.kwparametrize(
     dict(paths=["a.py"], expect=[]),
     dict(expect=[]),
     dict(modify_paths={"a.py": "new"}, expect=["a.py"]),

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -324,6 +324,33 @@ def test_git_exists_in_revision_git_call(retval, expect):
 
 
 @pytest.mark.kwparametrize(
+    dict(rev2="{add}", path="dir/a.py", expect=True),
+    dict(rev2="{add}", path="dir/b.py", expect=True),
+    dict(rev2="{add}", path="dir/", expect=True),
+    dict(rev2="{add}", path="dir", expect=True),
+    dict(rev2="{del_a}", path="dir/a.py", expect=False),
+    dict(rev2="{del_a}", path="dir/b.py", expect=True),
+    dict(rev2="{del_a}", path="dir/", expect=True),
+    dict(rev2="{del_a}", path="dir", expect=True),
+    dict(rev2="HEAD", path="dir/a.py", expect=False),
+    dict(rev2="HEAD", path="dir/b.py", expect=False),
+    dict(rev2="HEAD", path="dir/", expect=False),
+    dict(rev2="HEAD", path="dir", expect=False),
+)
+def test_git_exists_in_revision(git_repo, rev2, path, expect):
+    """``_get_exists_in_revision()`` detects file/dir existence correctly"""
+    git_repo.add({"dir/a.py": "foo", "dir/b.py": "bar"}, commit="Add dir/*.py")
+    add = git_repo.get_hash()
+    git_repo.add({"dir/a.py": None}, commit="Delete dir/a.py")
+    del_a = git_repo.get_hash()
+    git_repo.add({"dir/b.py": None}, commit="Delete dir/b.py")
+
+    result = git._git_exists_in_revision(Path(path), rev2.format(add=add, del_a=del_a))
+
+    assert result == expect
+
+
+@pytest.mark.kwparametrize(
     dict(paths=["a.py"], expect=[]),
     dict(expect=[]),
     dict(modify_paths={"a.py": "new"}, expect=["a.py"]),

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -477,11 +477,11 @@ def test_main_encoding(
     assert result == b"".join(expect)
 
 
-def test_main_historical():
+def test_main_historical(git_repo):
     """Stop if rev2 isn't the working tree and no ``--diff`` or ``--check`` provided"""
     with pytest.raises(ArgumentError):
 
-        darker.__main__.main(["--revision=foo..bar"])
+        darker.__main__.main(["--revision=foo..bar", "."])
 
 
 def test_print_diff(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
~Disallow paths starting with a hyphen – those are probably due to quoting multiple arguments like `"--lint pylint"`.~
Disallow paths which don't exist as files or directories on disk (if rev2 is `WORKTREE`) or in a past revision (if rev2 points to a commit). Fixes #147 and #102.

- [x] unit tests for `darker.git.get_missing_at_revision()` for commits
- [x] solve Windows test failure for `darker.git.get_missing_at_revision()` unit test
- [x] unit tests for `darker.git.get_missing_at_revision()` for `WORKTREE`
- [x] unit tests for `darker.git._git_exists_in_revision()`
- [x] unit tests for `darker.__main__.main()` failing for non-existing files in a revision or the working tree
- [x] change log