### PR TITLE
Respect black exclude

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -75,3 +75,6 @@ ignore_missing_imports = True
 
 [mypy-pygments.lexers.*]
 ignore_missing_imports = True
+
+[mypy-regex]
+ignore_missing_imports = True

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 def format_edited_parts(
     git_root: Path,
-    changed_files: Collection[Path],
+    changed_files: Collection[Path],  # pylint: disable=unsubscriptable-object
     revrange: RevisionRange,
     enable_isort: bool,
     black_config: BlackConfig,

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -118,7 +118,9 @@ def read_black_config(src: Tuple[str, ...], value: Optional[str]) -> BlackConfig
 
 
 def apply_black_excludes(
-    paths: Collection[Path], root: Path, black_config: BlackConfig
+    paths: Collection[Path],  # pylint: disable=unsubscriptable-object
+    root: Path,
+    black_config: BlackConfig,
 ) -> Set[Path]:
     """Get the subset of files which are not excluded by Black's configuration
 

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -110,17 +110,17 @@ A_PY_DIFF_BLACK_ISORT = [
 
 
 @pytest.mark.kwparametrize(
-    dict(enable_isort=False, black_args={}, expect=A_PY_BLACK),
-    dict(enable_isort=True, black_args={}, expect=A_PY_BLACK_ISORT),
+    dict(enable_isort=False, black_config={}, expect=A_PY_BLACK),
+    dict(enable_isort=True, black_config={}, expect=A_PY_BLACK_ISORT),
     dict(
         enable_isort=False,
-        black_args={"skip_string_normalization": True},
+        black_config={"skip_string_normalization": True},
         expect=A_PY_BLACK_UNNORMALIZE,
     ),
     ids=["black", "black_isort", "black_unnormalize"],
 )
 @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["unix", "windows"])
-def test_format_edited_parts(git_repo, enable_isort, black_args, newline, expect):
+def test_format_edited_parts(git_repo, enable_isort, black_config, newline, expect):
     """Correct reformatting and import sorting changes are produced"""
     paths = git_repo.add({"a.py": newline, "b.py": newline}, commit="Initial commit")
     paths["a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
@@ -131,7 +131,7 @@ def test_format_edited_parts(git_repo, enable_isort, black_args, newline, expect
         [Path("a.py")],
         RevisionRange("HEAD"),
         enable_isort,
-        black_args,
+        black_config,
         report_unmodified=False,
     )
 
@@ -182,7 +182,7 @@ def test_format_edited_parts_ast_changed(git_repo, caplog):
                 [Path("a.py")],
                 RevisionRange("HEAD"),
                 enable_isort=False,
-                black_args={},
+                black_config={},
                 report_unmodified=False,
             )
         )
@@ -226,7 +226,7 @@ def test_format_edited_parts_isort_on_already_formatted(git_repo):
         {Path("a.py")},
         RevisionRange("HEAD"),
         enable_isort=True,
-        black_args={},
+        black_config={},
         report_unmodified=False,
     )
 
@@ -281,7 +281,7 @@ def test_format_edited_parts_historical(git_repo, rev1, rev2, expect):
         {Path("a.py")},
         RevisionRange(rev1, rev2),
         enable_isort=True,
-        black_args={},
+        black_config={},
         report_unmodified=False,
     )
 


### PR DESCRIPTION
Skip Black reformatting for files matching the `exclude`, `extend-exclude` or `force-exclude` Black configuration options. Fixes #146.