### PR TITLE
Use forward slash as the path separator for Git on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Fixed
   COMMIT_B is *not* ``:WORKTREE:`` works too.
 - Hide fatal error from Git on stderr when ``git show`` doesn't find the file in rev1.
   This isn't fatal from Darker's point of view since it's a newly created file.
+- Use forward slash as the path separator when calling Git in Windows. At least
+  ``git show`` and ``git cat-file`` fail when using backslashes.
 
 
 1.2.4_ - 2021-06-27

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -40,7 +40,7 @@ def git_get_mtime_at_commit(path: Path, revision: str, cwd: Path) -> str:
     :param cwd: The root of the Git repository
 
     """
-    cmd = ["log", "-1", "--format=%ct", revision, "--", str(path)]
+    cmd = ["log", "-1", "--format=%ct", revision, "--", path.as_posix()]
     lines = _git_check_output_lines(cmd, cwd)
     return datetime.utcfromtimestamp(int(lines[0])).strftime(GIT_DATEFORMAT)
 
@@ -61,7 +61,7 @@ def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDoc
     if revision == WORKTREE:
         abspath = cwd / path
         return TextDocument.from_file(abspath)
-    cmd = ["show", f"{revision}:./{path}"]
+    cmd = ["show", f"{revision}:./{path.as_posix()}"]
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:
         return TextDocument.from_lines(
@@ -214,7 +214,7 @@ def git_get_modified_files(
 
     """
     relative_paths = {p.resolve().relative_to(cwd) for p in paths}
-    str_paths = [str(path) for path in relative_paths]
+    str_paths = [path.as_posix() for path in relative_paths]
     if revrange.use_common_ancestor:
         rev2 = "HEAD" if revrange.rev2 == WORKTREE else revrange.rev2
         merge_base_cmd = ["merge-base", revrange.rev1, rev2]


### PR DESCRIPTION
This was found and worked around in #163.

Git behavior reported in git-for-windows/git/issues/3344.