### PR TITLE
Increase delay tolerance in Git test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Added
   file provided on the command line.
 - Terminate with an error if non-existing files or directories are passed on the command
   line. This also improves the error from misquoted parameters like ``"--lint pylint"``.
+- Allow Git test case to run slower when checking file timestamps. CI can be slow.
 
 Fixed
 -----

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -91,7 +91,7 @@ def test_git_get_content_at_revision(git_repo, revision, expect_lines, expect_mt
     if expect_mtime:
         mtime_then = datetime.strptime(result.mtime, GIT_DATEFORMAT)
         difference = expect_mtime() - mtime_then
-        assert timedelta(0) <= difference < timedelta(seconds=2)
+        assert timedelta(0) <= difference < timedelta(seconds=3)
     else:
         assert result.mtime == ""
     assert result.encoding == "utf-8"


### PR DESCRIPTION
File timestamp age exceeded two seconds in [this #172 check](https://github.com/akaihola/darker/pull/172/checks?check_run_id=3218212179).