### PR TITLE
--jobs argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ These features will be included in the next release:
 
 Added
 -----
+- The ``--jobs`` option now specifies how many Darker jobs are used to process files in
+  parallel to complete reformatting/linting faster
 
 Fixed
 -----

--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
        to override ``skip_magic_trailing_comma = true`` from a configuration file.
 -l LENGTH, --line-length LENGTH
        How many characters per line to allow [default: 88]
+-j JOBS, --jobs JOBS
+       How many parallel jobs to allow [default: 1]
 
 To change default values for these options for a given project,
 add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory.
@@ -347,6 +349,8 @@ other tools. For example, VSCode only expects the reformat diff, so
 *New in version 1.3.0:* Support for command line option ``--skip-magic-trailing-comma``
 
 *New in version 1.3.0:* The ``-d`` / ``--stdout`` command line option
+
+*New in version 1.4.0:* The ``-j`` / ``--jobs`` command line option
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/pyproject_toml.html
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/mypy.ini
+++ b/mypy.ini
@@ -47,6 +47,9 @@ disallow_any_explicit = False
 [mypy-darker.command_line]
 disallow_any_explicit = False
 
+[mypy-darker.concurrency]
+disallow_any_explicit = False
+
 [mypy-darker.config]
 disallow_subclassing_any = False
 

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -18,6 +18,7 @@ from darker.black_diff import (
 )
 from darker.chooser import choose_lines
 from darker.command_line import parse_command_line
+from darker.concurrency import get_executor
 from darker.config import OutputMode, dump_config
 from darker.diff import diff_and_get_opcodes, opcodes_to_chunks
 from darker.exceptions import DependencyError, MissingPackageError
@@ -76,7 +77,7 @@ def format_edited_parts(
              be reformatted, and skips unchanged files.
 
     """
-    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs or None) as executor:
+    with get_executor(max_workers=jobs) as executor:
         # pylint: disable=unsubscriptable-object
         futures: List[concurrent.futures.Future[ProcessedDocument]] = []
         for path_in_repo in sorted(changed_files):

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -1,5 +1,6 @@
 """Darker - apply black reformatting to only areas edited since the last commit"""
 
+import concurrent.futures
 import logging
 import sys
 import warnings
@@ -8,7 +9,6 @@ from datetime import datetime
 from difflib import unified_diff
 from pathlib import Path
 from typing import Collection, Generator, List, Tuple
-import concurrent.futures
 
 from darker.black_diff import (
     BlackConfig,
@@ -77,9 +77,8 @@ def format_edited_parts(
 
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs or None) as executor:
-        futures: List[
-            concurrent.futures.Future[ProcessedDocument]
-        ] = []  # pylint: disable=unsubscriptable-object
+        # pylint: disable=unsubscriptable-object
+        futures: List[concurrent.futures.Future[ProcessedDocument]] = []
         for path_in_repo in sorted(changed_files):
             future = executor.submit(
                 _format_single_file,
@@ -98,7 +97,7 @@ def format_edited_parts(
                 yield (src, rev2_content, content_after_reformatting)
 
 
-def _format_single_file(
+def _format_single_file(  # pylint: disable=too-many-arguments
     git_root: Path,
     path_in_repo: Path,
     black_exclude: Collection[Path],  # pylint: disable=unsubscriptable-object

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -425,15 +425,17 @@ def main(argv: List[str] = None) -> int:
         }
 
     formatting_failures_on_modified_lines = False
-    for path, old, new in format_edited_parts(
-        root,
-        changed_files_to_process,
-        black_exclude,
-        revrange,
-        args.isort,
-        black_config,
-        report_unmodified=output_mode == OutputMode.CONTENT,
-        jobs=config["jobs"],
+    for path, old, new in sorted(
+        format_edited_parts(
+            root,
+            changed_files_to_process,
+            black_exclude,
+            revrange,
+            args.isort,
+            black_config,
+            report_unmodified=output_mode == OutputMode.CONTENT,
+            jobs=config["jobs"],
+        ),
     ):
         formatting_failures_on_modified_lines = True
         if output_mode == OutputMode.DIFF:

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -76,7 +76,7 @@ def format_edited_parts(
              be reformatted, and skips unchanged files.
 
     """
-    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs or None) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs or None) as executor:
         # pylint: disable=unsubscriptable-object
         futures: List[concurrent.futures.Future[ProcessedDocument]] = []
         for path_in_repo in sorted(changed_files):

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -82,7 +82,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         dest="line_length",
         metavar="LENGTH",
     )
-    add_arg(hlp.JOBS, "-j", "--jobs", type=int, dest="jobs")
+    add_arg(hlp.JOBS, "-j", "--jobs", type=int, dest="jobs", default=1)
     # A hidden option for printing command lines option in a format suitable for
     # `README.rst`:
     add_arg(SUPPRESS, "--options-for-readme", action=OptionsForReadmeAction)

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -82,6 +82,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         dest="line_length",
         metavar="LENGTH",
     )
+    add_arg(hlp.JOBS, "-j", "--jobs", type=int, dest="jobs")
     # A hidden option for printing command lines option in a format suitable for
     # `README.rst`:
     add_arg(SUPPRESS, "--options-for-readme", action=OptionsForReadmeAction)

--- a/src/darker/concurrency.py
+++ b/src/darker/concurrency.py
@@ -1,0 +1,55 @@
+"""Concurrency helpers for enhancing the performance of Darker"""
+
+from concurrent.futures import Executor, Future, ProcessPoolExecutor
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")  # pylint: disable=invalid-name
+
+
+class DummyExecutor(Executor):
+    """Dummy synchronous executor to use with ``--jobs=1``
+
+    This makes it easier to write test cases for `darker.__main__.main`.
+
+    """
+
+    # pylint: disable=arguments-differ,unsubscriptable-object,broad-except
+    def submit(  # type: ignore[override]
+        self, fn: Callable[..., T], *args: Any, **kwargs: Any
+    ) -> Future[T]:
+        """Submits "a callable to be executed with the given arguments.
+
+        Executes the callable immediately as ``fn(*args, **kwargs)`` and returns a
+        `Future` instance representing the execution of the callable.
+
+        :param fn: The callable to call
+        :param args: Positional arguments for the callable
+        :param kwargs: Keyword arguments for the callable
+        :return: A `Future` representing the given call
+
+        """
+        future = Future[T]()
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as exc_info:
+            future.set_exception(exc_info)
+        else:
+            future.set_result(result)
+        return future
+
+
+def get_executor(max_workers: int) -> Executor:
+    """Return either a dummy executor (if ``max_workers===1`) or a process pool executor
+
+    :param max_workers: The maximum number of processes that can be used to execute the
+                        given calls. If ``0`` then as many worker processes will be
+                        created as the machine has processors. If ``1``, the dummy
+                        executor will be used so calls are executed synchronously.
+    :return: A dummy executor or a process pool executor
+
+    """
+    return (
+        DummyExecutor()
+        if max_workers == 1
+        else ProcessPoolExecutor(max_workers or None)
+    )

--- a/src/darker/concurrency.py
+++ b/src/darker/concurrency.py
@@ -1,9 +1,25 @@
 """Concurrency helpers for enhancing the performance of Darker"""
 
+import sys
 from concurrent.futures import Executor, Future, ProcessPoolExecutor
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Generic, TypeVar, cast
 
 T = TypeVar("T")  # pylint: disable=invalid-name
+
+if sys.version_info < (3, 9):
+
+    class FutureType(Generic[T]):
+        """For Python <3.9 compatibility"""
+
+        def set_exception(self, exc_info: BaseException) -> None:
+            "Dummy method for typing"
+
+        def set_result(self, result: Any) -> None:
+            "Dummy method for typing"
+
+
+else:
+    FutureType = Future
 
 
 class DummyExecutor(Executor):
@@ -16,7 +32,7 @@ class DummyExecutor(Executor):
     # pylint: disable=arguments-differ,unsubscriptable-object,broad-except
     def submit(  # type: ignore[override]
         self, fn: Callable[..., T], *args: Any, **kwargs: Any
-    ) -> Future[T]:
+    ) -> FutureType[T]:
         """Submits "a callable to be executed with the given arguments.
 
         Executes the callable immediately as ``fn(*args, **kwargs)`` and returns a
@@ -28,7 +44,7 @@ class DummyExecutor(Executor):
         :return: A `Future` representing the given call
 
         """
-        future = Future[T]()
+        future = cast(FutureType[T], Future())
         try:
             result = fn(*args, **kwargs)
         except BaseException as exc_info:

--- a/src/darker/concurrency.py
+++ b/src/darker/concurrency.py
@@ -17,7 +17,6 @@ if sys.version_info < (3, 9):
         def set_result(self, result: Any) -> None:
             "Dummy method for typing"
 
-
 else:
     FutureType = Future
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -39,6 +39,7 @@ class DarkerConfig(TypedDict, total=False):
     skip_string_normalization: bool
     skip_magic_trailing_comma: bool
     line_length: int
+    jobs: int
 
 
 class OutputMode:

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -76,3 +76,5 @@ SKIP_MAGIC_TRAILING_COMMA = (
 )
 
 LINE_LENGTH = "How many characters per line to allow [default: 88]"
+
+JOBS = "How many parallel jobs to allow [default: 1]"

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -77,4 +77,4 @@ SKIP_MAGIC_TRAILING_COMMA = (
 
 LINE_LENGTH = "How many characters per line to allow [default: 88]"
 
-JOBS = "How many parallel jobs to allow [default: 1]"
+JOBS = "How many parallel jobs to allow, or `0` for one per core [default: 1]"

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -589,7 +589,9 @@ def test_options(git_repo, options, expect):
         retval = main(options)
 
     expect = (Path(git_repo.root), expect[1]) + expect[2:]
-    format_edited_parts.assert_called_once_with(*expect, report_unmodified=False)
+    format_edited_parts.assert_called_once_with(
+        *expect, report_unmodified=False, jobs=None
+    )
     assert retval == 0
 
 

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -590,7 +590,7 @@ def test_options(git_repo, options, expect):
 
     expect = (Path(git_repo.root), expect[1]) + expect[2:]
     format_edited_parts.assert_called_once_with(
-        *expect, report_unmodified=False, jobs=None
+        *expect, report_unmodified=False, jobs=1
     )
     assert retval == 0
 

--- a/src/darker/tests/test_concurrency.py
+++ b/src/darker/tests/test_concurrency.py
@@ -1,0 +1,46 @@
+"""Tests for `darker.concurrency`"""
+
+from concurrent.futures import Future, ProcessPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+
+from darker import concurrency
+
+
+def test_dummy_executor_submit_success():
+    """Function is executed synchronously and future gives the return value"""
+    executor = concurrency.DummyExecutor()
+    func = Mock(return_value=42)
+
+    future = executor.submit(func, "arg", kwarg="kwarg")
+
+    assert isinstance(future, Future)
+    assert future.result() == 42
+    func.assert_called_once_with("arg", kwarg="kwarg")
+
+
+def test_dummy_executor_submit_exception():
+    """Future raises the exception from the function"""
+    executor = concurrency.DummyExecutor()
+    func = Mock(side_effect=ValueError("my-exception"))
+
+    future = executor.submit(func, "arg", kwarg="kwarg")
+
+    assert isinstance(future, Future)
+    with pytest.raises(ValueError) as exc:
+        assert future.result() == 42
+        assert str(exc.value) == "my-exception"
+
+
+@pytest.mark.kwparametrize(
+    dict(max_workers=0, expect=ProcessPoolExecutor),
+    dict(max_workers=1, expect=concurrency.DummyExecutor),
+    dict(max_workers=2, expect=ProcessPoolExecutor),
+    dict(max_workers=42, expect=ProcessPoolExecutor),
+)
+def test_get_executor(max_workers, expect):
+    """A correct executor object is returned based on ``max_workers``"""
+    result = concurrency.get_executor(max_workers)
+
+    assert isinstance(result, expect)

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -373,7 +373,7 @@ def test_format_edited_parts_historical(git_repo, rev1, rev2, expect):
     black_config={},
     expect="import  original\nprint( original )\n",
 )
-def test_reformat_single_file(
+def test_blacken_single_file(
     git_repo,
     relative_path,
     rev1,
@@ -384,11 +384,11 @@ def test_reformat_single_file(
     black_config,
     expect,
 ):
-    """Test for ``_reformat_single_file``"""
+    """Test for ``_blacken_single_file``"""
     git_repo.add(
         {"file.py": "import  original\nprint( original )\n"}, commit="Initial commit"
     )
-    result = darker.__main__._reformat_single_file(
+    result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path(relative_path),
         RevisionRange(rev1, rev2),

--- a/src/darker/tests/test_main_blacken_single_file.py
+++ b/src/darker/tests/test_main_blacken_single_file.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`darker.__main__._reformat_single_file`"""
+"""Unit tests for :func:`darker.__main__._blacken_single_file`"""
 
 # pylint: disable=protected-access
 
@@ -10,8 +10,8 @@ from darker.git import RevisionRange
 from darker.utils import TextDocument
 
 
-def test_reformat_single_file_common_ancestor(git_repo):
-    """``_reformat_single_file()`` compares to the common ancestor of ``rev1...rev2``"""
+def test_blacken_single_file_common_ancestor(git_repo):
+    """``_blacken_single_file()`` compares to the common ancestor of ``rev1...rev2``"""
     a_py_initial = dedent(
         """\
         a=1
@@ -55,7 +55,7 @@ def test_reformat_single_file_common_ancestor(git_repo):
     git_repo.add({"a.py": a_py_feature}, commit="on feature")
     worktree = TextDocument.from_str(a_py_worktree)
 
-    result = darker.__main__._reformat_single_file(
+    result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path("a.py"),
         RevisionRange.parse_with_common_ancestor("master...", git_repo.root),

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -43,63 +43,63 @@ from darker.tests.helpers import raises_if_exception
     dict(
         revision="",
         worktree_content=b"USERMOD=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="",
         worktree_content=b"ORIGINAL=1\n",
-        expect=["+1M0", "+2-1", "+2M1-0", "+2M1"],
+        expect={"+1M0", "+2-1", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="",
         worktree_content=b"MODIFIED=1\n",
-        expect=["+1", "+2-1", "+2", "+2M1-0"],
+        expect={"+1", "+2-1", "+2", "+2M1-0"},
     ),
     dict(
         revision="HEAD",
         worktree_content=b"USERMOD=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="HEAD",
         worktree_content=b"ORIGINAL=1\n",
-        expect=["+1M0", "+2-1", "+2M1-0", "+2M1"],
+        expect={"+1M0", "+2-1", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="HEAD",
         worktree_content=b"MODIFIED=1\n",
-        expect=["+1", "+2-1", "+2", "+2M1-0"],
+        expect={"+1", "+2-1", "+2", "+2M1-0"},
     ),
     dict(
         revision="HEAD^",
         worktree_content=b"USERMOD=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="HEAD^",
         worktree_content=b"USERMOD=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="HEAD^",
         worktree_content=b"ORIGINAL=1\n",
-        expect=["+2-1", "+2M1-0", "+2M1"],
+        expect={"+2-1", "+2M1-0", "+2M1"},
     ),
     dict(
         revision="HEAD^",
         worktree_content=b"MODIFIED=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2"],
+        expect={"+1", "+1M0", "+2-1", "+2"},
     ),
     dict(
         revision="HEAD~2",
         worktree_content=b"USERMOD=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
-    dict(revision="HEAD~2", worktree_content=b"ORIGINAL=1\n", expect=["+1", "+1M0"]),
+    dict(revision="HEAD~2", worktree_content=b"ORIGINAL=1\n", expect={"+1", "+1M0"}),
     dict(
         revision="HEAD~2",
         worktree_content=b"MODIFIED=1\n",
-        expect=["+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"],
+        expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
     dict(revision="HEAD~3", worktree_content=b"USERMOD=1\n", expect=SystemExit),
 )
@@ -141,9 +141,9 @@ def test_revision(git_repo, monkeypatch, capsys, revision, worktree_content, exp
     with raises_if_exception(expect):
         main(arguments)
 
-        modified_files = [
+        modified_files = {
             line.split("\t")[0][4:-3]
             for line in capsys.readouterr().out.splitlines()
             if line.startswith("+++ ")
-        ]
+        }
         assert modified_files == expect


### PR DESCRIPTION
TBD, closes #178 

- [x] tests
- [x] change log
- [x] documentation
- [x] measure peformance with one job, many jobs using threads, and many jobs using processes
- [x] decide whether to use threads or processes -> **processes**
- [x] use `ProcessPoolExecutor`
- [x] use synchronous calls when `--jobs=1`
- [x] `--jobs=1` as the default
- [x] rebase on `master` to resolve new merge conflicts