### PR TITLE
Always run Git in English

### DIFF
--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -150,7 +150,11 @@ def _git_check_output_lines(
     logger.debug("[%s]$ %s", cwd, " ".join(cmd))
     try:
         return check_output(
-            ["git"] + cmd, cwd=str(cwd), encoding="utf-8", stderr=PIPE
+            ["git"] + cmd,
+            cwd=str(cwd),
+            encoding="utf-8",
+            stderr=PIPE,
+            env={"LC_ALL": "C"},
         ).splitlines()
     except CalledProcessError as exc_info:
         if not exit_on_error:
@@ -178,7 +182,7 @@ def _git_exists_in_revision(path: Path, rev2: str) -> bool:
     # Surprise: On Windows, `git cat-file` doesn't work with backslash directory
     # separators in paths. We need to use Posix paths and forward slashes instead.
     cmd = ["git", "cat-file", "-e", f"{rev2}:{path.as_posix()}"]
-    result = run(cmd, check=False, stderr=DEVNULL)
+    result = run(cmd, check=False, stderr=DEVNULL, env={"LC_ALL": "C"})
     return result.returncode == 0
 
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -153,7 +153,11 @@ def test_git_get_content_at_revision_git_calls(revision, expect):
         assert check_output.call_count == len(expect)
         for expect_call in expect:
             check_output.assert_any_call(
-                expect_call.split(), cwd="cwd", encoding="utf-8", stderr=PIPE
+                expect_call.split(),
+                cwd="cwd",
+                encoding="utf-8",
+                stderr=PIPE,
+                env={"LC_ALL": "C"},
             )
 
 
@@ -318,7 +322,10 @@ def test_git_exists_in_revision_git_call(retval, expect):
         result = git._git_exists_in_revision(Path("path.py"), "rev2")
 
     run.assert_called_once_with(
-        ["git", "cat-file", "-e", "rev2:path.py"], check=False, stderr=DEVNULL
+        ["git", "cat-file", "-e", "rev2:path.py"],
+        check=False,
+        stderr=DEVNULL,
+        env={"LC_ALL": "C"},
     )
     assert result == expect
 


### PR DESCRIPTION
This is important since we parse the output to hide expected fatal errors.