### PR TITLE
Fix gen_python_files usage for black>=21.7b1.dev9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Added
 - Terminate with an error if non-existing files or directories are passed on the command
   line. This also improves the error from misquoted parameters like ``"--lint pylint"``.
 - Allow Git test case to run slower when checking file timestamps. CI can be slow.
+- Fix compatibility with Black >= 21.7b1.dev9
 
 Fixed
 -----

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -133,7 +133,7 @@ def apply_black_excludes(
     """
     sig = inspect.signature(gen_python_files)
     # those two exist and are required in black>=21.7b1.dev9
-    kwa = dict(verbose=False, quiet=False) if "verbose" in sig.parameters else {}
+    kwargs = dict(verbose=False, quiet=False) if "verbose" in sig.parameters else {}
     return set(
         gen_python_files(
             (root / path for path in paths),
@@ -144,7 +144,7 @@ def apply_black_excludes(
             force_exclude=black_config.get("force_exclude"),
             report=Report(),
             gitignore=None,
-            **kwa,
+            **kwargs,
         )
     )
 

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -32,7 +32,7 @@ for how this result is further processed with:
   based on whether reformats touch user-edited lines
 
 """
-
+import inspect
 import logging
 import sys
 from pathlib import Path
@@ -131,6 +131,9 @@ def apply_black_excludes(
     :return: Absolute paths of files which should be reformatted using Black
 
     """
+    sig = inspect.signature(gen_python_files)
+    # those two exist and are required in black>=21.8b0
+    kwa = dict(verbose=False, quiet=False) if "verbose" in sig.parameters else {}
     return set(
         gen_python_files(
             (root / path for path in paths),
@@ -141,6 +144,7 @@ def apply_black_excludes(
             force_exclude=black_config.get("force_exclude"),
             report=Report(),
             gitignore=None,
+            **kwa,
         )
     )
 

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -132,7 +132,7 @@ def apply_black_excludes(
 
     """
     sig = inspect.signature(gen_python_files)
-    # those two exist and are required in black>=21.8b0
+    # those two exist and are required in black>=21.7b1.dev9
     kwa = dict(verbose=False, quiet=False) if "verbose" in sig.parameters else {}
     return set(
         gen_python_files(


### PR DESCRIPTION
This should fix the tests and be backwards compatible