### PR TITLE
Update black required versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ console_scripts =
 isort =
     isort>=5.0.1
 test =
+    black>=21.7b1  # to prevent Mypy error about `gen_python_files`, see issue #189
     mypy>=0.910
     pylint
     pytest>=6.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    black>=20.8b1
+    black>=21.5b1
     toml
     typing-extensions ; python_version < "3.8"
     dataclasses ; python_version < "3.7"

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -145,7 +145,7 @@ def apply_black_excludes(
             report=Report(),
             gitignore=None,
             **kwargs,
-        )  # type: ignore[call-arg]
+        )
     )
 
 


### PR DESCRIPTION
There were two issues with Black versions:

1. with current Black, Mypy *shouldn't* ignore extra call arguments for `black.files.gen_python_files()` (see #189), but we have to make sure a recent enough Black is used when running tests
2. Black < 21.5b1 are incompatible with at least to recently added features, so the minimum required Black version had to be bumped