### PR TITLE
Allow overwriting the working tree when run as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/akaihola/darker
-    rev: master
+    rev: allow-overwrite-as-pre-commit-hook
     hooks:
     -   id: darker
         args: [--isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,3 @@ src = [
     "src",
 ]
 revision = "origin/master..."
-lint = [
-    "pylint",
-]

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -19,6 +19,7 @@ from darker.command_line import parse_command_line
 from darker.config import OutputMode, dump_config
 from darker.diff import diff_and_get_opcodes, opcodes_to_chunks
 from darker.git import (
+    PRE_COMMIT_FROM_TO_REFS,
     WORKTREE,
     EditedLinenumsDiffer,
     RevisionRange,
@@ -321,7 +322,11 @@ def main(argv: List[str] = None) -> int:
     revrange = RevisionRange.parse(args.revision)
     output_mode = OutputMode.from_args(args)
     write_modified_files = not args.check and output_mode == OutputMode.NOTHING
-    if revrange.rev2 != WORKTREE and write_modified_files:
+    if (
+        args.revision != PRE_COMMIT_FROM_TO_REFS
+        and revrange.rev2 != WORKTREE
+        and write_modified_files
+    ):
         raise ArgumentError(
             Action(["-r", "--revision"], "revision"),
             f"Can't write reformatted files for revision '{revrange.rev2}'."

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -75,6 +75,7 @@ def run_linter(
         return None
     if revrange.rev2 is not WORKTREE:
         raise NotImplementedError(
+            f"{cmdline}: "
             "Linting arbitrary commits is not supported. "
             "Please use -r {<rev>|<rev>..|<rev>...} instead."
         )


### PR DESCRIPTION
Fixes #180

For earlier work on pre-commit support, see #2, #91, #103, #109, #113, and #116. Also a bit related and currently open is #112.
