### PR TITLE
Allow `pre-commit -o HEAD`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ These features will be included in the next release:
 Added
 -----
 - Empty and all-whitespace files are now reformatted properly
+- Darker now allows itself to modify files when called with ``pre-commit -o HEAD``, but
+  also emits a warning about this being an experimental feature
 - Mention Black's possible new line range formatting support in README
 
 Fixed


### PR DESCRIPTION
With this patch, Darker _will_ modify files when called by `pre-commit -o HEAD`, and emit a warning about this being an experimental feature.

With any other values than `HEAD` for `pre-commit -o`, Darker will still refuse to modify files.

Fixes #180. See the issue for detailed discussion.