### PR TITLE
Debug logging for unknown files in lint output

### DIFF
--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -122,11 +122,10 @@ def run_linter(
                 location,
                 description,
             ) = _parse_linter_line(line, root)
-            if (
-                path_in_repo is None
-                or path_in_repo in missing_files
-                or linter_error_linenum == 0
-            ):
+            if path_in_repo is None:
+                logger.debug("Unknown path %s from %s", path_in_repo, cmdline)
+                continue
+            if path_in_repo in missing_files or linter_error_linenum == 0:
                 continue
             try:
                 edited_linenums = edited_linenums_differ.compare_revisions(


### PR DESCRIPTION
The branch name `lint-diff-against-given-revision` is a relic from on original branch. The bulk of changes in that branch were made obsolete by modifications in another branch, and the logging fix is the only thing left here.