### PR TITLE
isort only if imports at the top of the module were edited

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,9 @@ Added
 - The ``--workers``/``-W`` option now specifies how many Darker jobs are used to
   process files in parallel to complete reformatting/linting faster.
 - Linters can now be installed and run in the GitHub Action using the ``lint:`` option.
-  
+- Sort imports only if the range of modified lines overlaps with changes resulting from
+  sorting the imports.
+
 Fixed
 -----
 - Avoid memory leak from using ``@lru_cache`` on a method.

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -125,7 +125,7 @@ def _isort_and_blacken_single_file(  # pylint: disable=too-many-arguments
 
     """
     # With VSCode, `relative_path_in_rev2` may be a `.py.<HASH>.tmp` file in the
-    # working tree insted of a `.py` file.
+    # working tree instead of a `.py` file.
     absolute_path_in_rev2 = root / relative_path_in_rev2
     rev2_content = git_get_content_at_revision(
         relative_path_in_rev2, revrange.rev2, root

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -136,7 +136,7 @@ def _isort_and_blacken_single_file(  # pylint: disable=too-many-arguments
         content_after_reformatting = _blacken_single_file(
             root,
             relative_path,
-            revrange,
+            EditedLinenumsDiffer(root, revrange),
             rev2_content,
             rev2_isorted,
             enable_isort,
@@ -151,7 +151,7 @@ def _isort_and_blacken_single_file(  # pylint: disable=too-many-arguments
 def _blacken_single_file(  # pylint: disable=too-many-arguments,too-many-locals
     root: Path,
     relative_path: Path,
-    revrange: RevisionRange,
+    edited_linenums_differ: EditedLinenumsDiffer,
     rev2_content: TextDocument,
     rev2_isorted: TextDocument,
     enable_isort: bool,
@@ -161,7 +161,7 @@ def _blacken_single_file(  # pylint: disable=too-many-arguments,too-many-locals
 
     :param root: Root directory for the relative path
     :param relative_path: Relative path to a Python source code file
-    :param revrange: The Git revisions to compare
+    :param edited_linenums_differ: Helper for finding out which lines were edited
     :param rev2_content: Contents of the file at ``revrange.rev2``
     :param rev2_isorted: Contents of the file after optional import sorting
     :param enable_isort: ``True`` if ``isort`` was already run for the file
@@ -172,7 +172,6 @@ def _blacken_single_file(  # pylint: disable=too-many-arguments,too-many-locals
     """
     src = root / relative_path
     rev1_relative_path = get_rev1_path(relative_path)
-    edited_linenums_differ = EditedLinenumsDiffer(root, revrange)
 
     # 4. run black
     formatted = run_black(rev2_isorted, black_config)

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -28,6 +28,7 @@ from darker.git import (
     EditedLinenumsDiffer,
     RevisionRange,
     get_missing_at_revision,
+    get_path_in_repo,
     git_get_content_at_revision,
     git_get_modified_python_files,
     git_is_repository,
@@ -148,7 +149,7 @@ def _isort_and_blacken_single_file(  # pylint: disable=too-many-arguments
         content_after_reformatting = _blacken_single_file(
             root,
             relative_path_in_rev2,
-            _get_path_in_repo(relative_path_in_rev2),
+            get_path_in_repo(relative_path_in_rev2),
             edited_linenums_differ,
             rev2_content,
             rev2_isorted,
@@ -259,23 +260,6 @@ def _blacken_single_file(  # pylint: disable=too-many-arguments,too-many-locals
     if not last_successful_reformat:
         raise NotEquivalentError(relative_path_in_rev2)
     return last_successful_reformat
-
-
-def _get_path_in_repo(path: Path) -> Path:
-    """Return the relative path to the file in the old revision
-
-    This is usually the same as the relative path on the command line. But in the
-    special case of VSCode temporary files (like ``file.py.12345.tmp``), we actually
-    want to diff against the corresponding ``.py`` file instead.
-
-    """
-    if path.suffixes[-3::2] != [".py", ".tmp"]:
-        # The file name is not like `*.py.<HASH>.tmp`. Return it as such.
-        return path
-    # This is a VSCode temporary file. Drop the hash and the `.tmp` suffix to get the
-    # original file name for retrieving the previous revision to diff against.
-    path_with_hash = path.with_suffix("")
-    return path_with_hash.with_suffix("")
 
 
 def modify_file(path: Path, new_content: TextDocument) -> None:

--- a/src/darker/diff.py
+++ b/src/darker/diff.py
@@ -177,3 +177,29 @@ def opcodes_to_chunks(
     _validate_opcodes(opcodes)
     for _tag, src_start, src_end, dst_start, dst_end in opcodes:
         yield src_start + 1, src.lines[src_start:src_end], dst.lines[dst_start:dst_end]
+
+
+def diff_chunks(src: TextDocument, dst: TextDocument) -> List[DiffChunk]:
+    """Diff two documents and return the list of chunks in the diff
+
+    Each chunk is a 3-tuple::
+
+        (
+            linenum: int,
+            old_lines: List[str],
+            new_lines: List[str],
+        )
+
+    ``old_lines`` and ``new_lines`` may be
+
+    - identical to indicate a chunk with no changes,
+    - of the same length but different items to indicate some modified lines, or
+    - of different lengths to indicate removed or inserted lines.
+
+    For the return value ``retval``, the following always holds::
+
+        retval[n + 1][0] == retval[n][0] + len(retval[n][old_lines])
+
+    """
+    opcodes = diff_and_get_opcodes(src, dst)
+    return list(opcodes_to_chunks(opcodes, src, dst))

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -170,7 +170,7 @@ class RevisionRange:
         return cls(rev1 if common_ancestor == rev1_hash else common_ancestor, rev2)
 
 
-def get_rev1_path(path: Path) -> Path:
+def get_path_in_repo(path: Path) -> Path:
     """Return the relative path to the file in the old revision
 
     This is usually the same as the relative path on the command line. But in the
@@ -188,7 +188,7 @@ def get_rev1_path(path: Path) -> Path:
 
 
 def should_reformat_file(path: Path) -> bool:
-    return path.exists() and get_rev1_path(path).suffix == ".py"
+    return path.exists() and get_path_in_repo(path).suffix == ".py"
 
 
 @lru_cache(maxsize=1)

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -1,11 +1,13 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from darker.black_compat import find_project_root
+from darker.diff import diff_chunks
 from darker.exceptions import IncompatiblePackageError, MissingPackageError
-from darker.utils import TextDocument
+from darker.git import EditedLinenumsDiffer
+from darker.utils import DiffChunk, TextDocument
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -55,31 +57,113 @@ class IsortArgs(TypedDict, total=False):
 def apply_isort(
     content: TextDocument,
     src: Path,
+    edited_linenums_differ: EditedLinenumsDiffer,
     config: Optional[str] = None,
     line_length: Optional[int] = None,
 ) -> TextDocument:
-    isort_args = IsortArgs()
+    """Run isort on the given Python source file content
+
+    :param content: The contents of the Python source code file to sort imports in
+    :param src: The relative path to the file. This must be the actual path in the
+                repository, which may differ from the path given on the command line in
+                case of VSCode temporary files.
+    :param edited_linenums_differ: Helper for finding out which lines were edited
+    :param config: Path to configuration file
+    :param line_length: Maximum line length to use
+
+    """
+    edited_linenums = edited_linenums_differ.revision_vs_lines(
+        src,
+        content,
+        context_lines=0,
+    )
+    if not edited_linenums:
+        return content
+    isort_args = _build_isort_args(src, config, line_length)
+    rev2_isorted = _call_isort_code(content, isort_args)
+    # Get the chunks in the diff between the edited and import-sorted file
+    isort_chunks = diff_chunks(content, rev2_isorted)
+    if not isort_chunks:
+        # No imports were sorted. Return original content.
+        return content
+    if not _diff_overlaps_with_edits(edited_linenums, isort_chunks):
+        # No lines had been modified in the range of modified import lines. Return
+        # original content.
+        return content
+    # The range lines modified by sorted imports overlaps with user modifications in the
+    # code. Return the import-sorted file.
+    return rev2_isorted
+
+
+def _build_isort_args(
+    src: Path,
+    config: Optional[str] = None,
+    line_length: Optional[int] = None,
+) -> IsortArgs:
+    """Build ``isort.code()`` keyword arguments
+
+    :param src: The relative path to the file. This must be the actual path in the
+                repository, which may differ from the path given on the command line in
+                case of VSCode temporary files.
+    :param config: Path to configuration file
+    :param line_length: Maximum line length to use
+
+    """
+    isort_args: IsortArgs = {}
     if config:
         isort_args["settings_file"] = config
     else:
         isort_args["settings_path"] = str(find_project_root((str(src),)))
     if line_length:
         isort_args["line_length"] = line_length
+    return isort_args
 
-    logger.debug(
-        "isort.code(code=..., {})".format(
-            ", ".join(f"{k}={v!r}" for k, v in isort_args.items())
-        )
-    )
 
+def _call_isort_code(content: TextDocument, isort_args: IsortArgs) -> TextDocument:
+    """Call ``isort.code()`` and return the result as a `TextDocument` object
+
+    :param content: The contents of the Python source code file to sort imports in
+    :param isort_args: Keyword arguments for ``isort.code()``
+
+    """
     code = content.string
+    logger.debug(
+        "isort.code(code=..., %s)",
+        ", ".join(f"{k}={v!r}" for k, v in isort_args.items()),
+    )
     try:
         code = isort_code(code=code, **isort_args)
     except isort.exceptions.FileSkipComment:
         pass
-
     return TextDocument.from_str(
         code,
         encoding=content.encoding,
         mtime=content.mtime,
+    )
+
+
+def _diff_overlaps_with_edits(
+    edited_linenums: List[int], isort_chunks: List[DiffChunk]
+) -> bool:
+    """Return ``True`` if the complete diff overlaps the range of edited lines
+
+    :param edited_linenums: The line numbers of all edited lines
+    :param isort_chunks: The diff chunks
+    :return: ``True`` if the two overlap
+
+    """
+    if not edited_linenums:
+        return False
+    first_edited_linenum, last_edited_linenum = edited_linenums[0], edited_linenums[-1]
+    modified_chunks = [
+        (linenum, old, new) for linenum, old, new in isort_chunks if old != new
+    ]
+    if not modified_chunks:
+        return False
+    (first_isort_line, _, _) = modified_chunks[0]
+    (last_isort_chunk_start, last_isort_chunk_original_lines, _) = modified_chunks[-1]
+    last_isort_line = last_isort_chunk_start + len(last_isort_chunk_original_lines)
+    return (
+        first_edited_linenum < last_isort_line
+        and last_edited_linenum >= first_isort_line
     )

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -250,9 +250,9 @@ def test_revisionrange_parse_with_common_ancestor(git_repo, revrange, expect):
     dict(path="file.12345.tmp", expect="file.12345.tmp"),
     dict(path="subdir/file.12345.tmp", expect="subdir/file.12345.tmp"),
 )
-def test_get_rev1_path(path, expect):
-    """``get_rev1_path`` drops two suffixes from ``.py.<HASH>.tmp``"""
-    result = git.get_rev1_path(Path(path))
+def test_get_path_in_repo(path, expect):
+    """``get_path_in_repo`` drops two suffixes from ``.py.<HASH>.tmp``"""
+    result = git.get_path_in_repo(Path(path))
 
     assert result == Path(expect)
 

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -1,6 +1,6 @@
 """Tests for :mod:`darker.import_sorting`"""
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument,protected-access
 
 from importlib import reload
 from pathlib import Path
@@ -9,11 +9,12 @@ from textwrap import dedent
 import pytest
 
 import darker.import_sorting
+from darker.git import EditedLinenumsDiffer, RevisionRange
 from darker.tests.helpers import isort_present
-from darker.utils import TextDocument
+from darker.utils import TextDocument, joinlines
 
-ORIGINAL_SOURCE = ("import sys", "import os")
-ISORTED_SOURCE = ("import os", "import sys")
+ORIGINAL_SOURCE = ("import sys", "import os", "", "print(42)")
+ISORTED_SOURCE = ("import os", "import sys", "", "print(42)")
 
 
 @pytest.mark.parametrize("present", [True, False])
@@ -31,14 +32,32 @@ def test_import_sorting_importable_with_and_without_isort(present):
 
 @pytest.mark.parametrize("encoding", ["utf-8", "iso-8859-1"])
 @pytest.mark.parametrize("newline", ["\n", "\r\n"])
-def test_apply_isort(encoding, newline):
-    """Import sorting is applied correctly, with encoding and newline intact"""
-    result = darker.import_sorting.apply_isort(
-        TextDocument.from_lines(ORIGINAL_SOURCE, encoding=encoding, newline=newline),
-        Path("test1.py"),
+@pytest.mark.kwparametrize(
+    dict(content=ORIGINAL_SOURCE, expect=ORIGINAL_SOURCE),
+    dict(content=("import sys", "import os"), expect=("import sys", "import os")),
+    dict(
+        content=("import sys", "import os", "# foo", "print(42)"),
+        expect=("import sys", "import os", "# foo", "print(42)"),
+    ),
+    dict(
+        content=("import sys", "import os", "", "print(43)"),
+        expect=("import sys", "import os", "", "print(43)"),
+    ),
+    dict(content=("import   sys", "import os", "", "print(42)"), expect=ISORTED_SOURCE),
+    dict(content=("import sys", "import   os", "", "print(42)"), expect=ISORTED_SOURCE),
+)
+def test_apply_isort(git_repo, encoding, newline, content, expect):
+    """Imports are sorted if edits overlap them, with encoding and newline intact"""
+    git_repo.add({"test1.py": joinlines(ORIGINAL_SOURCE, newline)}, commit="Initial")
+    edited_linenums_differ = EditedLinenumsDiffer(
+        git_repo.root, RevisionRange("HEAD", ":WORKTREE:")
     )
+    src = Path("test1.py")
+    content_ = TextDocument.from_lines(content, encoding=encoding, newline=newline)
 
-    assert result.lines == ISORTED_SOURCE
+    result = darker.import_sorting.apply_isort(content_, src, edited_linenums_differ)
+
+    assert result.lines == expect
     assert result.encoding == encoding
     assert result.newline == newline
 
@@ -100,9 +119,32 @@ def test_isort_config(
     config = str(tmpdir / settings_file) if settings_file else None
 
     actual = darker.import_sorting.apply_isort(
-        TextDocument.from_str(content), Path("test1.py"), config
+        TextDocument.from_str(content),
+        Path("test1.py"),
+        EditedLinenumsDiffer(Path("."), RevisionRange("master", "HEAD")),
+        config,
     )
     assert actual.string == expect
+
+
+@pytest.mark.kwparametrize(
+    dict(src=Path("file.py"), expect={"settings_path": "{cwd}"}),
+    dict(
+        config="myconfig.toml",
+        expect={"settings_file": "myconfig.toml"},
+    ),
+    dict(line_length=42, expect={"settings_path": "{cwd}", "line_length": 42}),
+    src=Path("file.py"),
+    config=None,
+    line_length=None,
+)
+def test_build_isort_args(src, config, line_length, expect):
+    """``_build_isort_args`` returns correct arguments for isort"""
+    result = darker.import_sorting._build_isort_args(src, config, line_length)
+
+    if "settings_path" in expect:
+        expect["settings_path"] = str(expect["settings_path"].format(cwd=Path.cwd()))
+    assert result == expect
 
 
 def test_isort_file_skip_comment():
@@ -111,7 +153,66 @@ def test_isort_file_skip_comment():
     content = "# iso" + "rt:skip_file"
 
     actual = darker.import_sorting.apply_isort(
-        TextDocument.from_str(content), Path("test1.py")
+        TextDocument.from_str(content),
+        Path("test1.py"),
+        EditedLinenumsDiffer(Path("."), RevisionRange("master", "HEAD")),
     )
 
     assert actual.string == content
+
+
+@pytest.mark.kwparametrize(
+    dict(edited_linenums=[], isort_chunks=[], expect=False),
+    dict(edited_linenums=[1, 2, 3, 4, 5, 6, 7, 8, 9], isort_chunks=[], expect=False),
+    dict(edited_linenums=[], isort_chunks=[(1, ("a", "b"), ("A", "B"))], expect=False),
+    dict(edited_linenums=[1], isort_chunks=[(1, ("a", "b"), ("A", "B"))], expect=True),
+    dict(edited_linenums=[2], isort_chunks=[(1, ("a", "b"), ("A", "B"))], expect=True),
+    dict(edited_linenums=[3], isort_chunks=[(1, ("a", "b"), ("A", "B"))], expect=False),
+    dict(edited_linenums=[], isort_chunks=[(1, ("A", "B"), ("A", "B"))], expect=False),
+    dict(edited_linenums=[1], isort_chunks=[(1, ("A", "B"), ("A", "B"))], expect=False),
+    dict(edited_linenums=[2], isort_chunks=[(1, ("A", "B"), ("A", "B"))], expect=False),
+    dict(edited_linenums=[3], isort_chunks=[(1, ("A", "B"), ("A", "B"))], expect=False),
+    dict(
+        edited_linenums=[3, 9],
+        isort_chunks=[
+            (1, ("a", "b"), ("A", "B")),
+            (3, ("c", "d", "e", "f", "g"), ("c", "d", "e", "f", "g")),
+            (8, ("h", "i", "j"), ("h", "i", "j")),
+        ],
+        expect=False,
+    ),
+    dict(
+        edited_linenums=[3, 9],
+        isort_chunks=[
+            (1, ("a", "b", "c"), ("A", "B", "C")),
+            (4, ("d", "e", "f", "g"), ("d", "e", "f", "g")),
+            (8, ("h", "i", "j"), ("h", "i", "j")),
+        ],
+        expect=True,
+    ),
+    dict(
+        edited_linenums=[3, 9],
+        isort_chunks=[
+            (1, ("a", "b", "c"), ("a", "b", "c")),
+            (4, ("d", "e", "f", "g"), ("d", "e", "f", "g")),
+            (8, ("h", "i", "j"), ("H", "I", "J")),
+        ],
+        expect=True,
+    ),
+    dict(
+        edited_linenums=[3, 9],
+        isort_chunks=[
+            (1, ("a", "b", "c", "d"), ("a", "b", "c", "d")),
+            (5, ("e", "f", "g", "h", "i"), ("e", "f", "g", "h", "i")),
+            (10, ("j"), ("J")),
+        ],
+        expect=False,
+    ),
+)
+def test_diff_overlaps_with_edits(edited_linenums, isort_chunks, expect):
+    """Overlapping edits and import sortings are detected correctly"""
+    result = darker.import_sorting._diff_overlaps_with_edits(
+        edited_linenums, isort_chunks
+    )
+
+    assert result == expect

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -210,7 +210,7 @@ def test_isort_file_skip_comment():
     ),
 )
 def test_diff_overlaps_with_edits(edited_linenums, isort_chunks, expect):
-    """Overlapping edits and import sortings are detected correctly"""
+    """Overlapping edits and sorting of imports are detected correctly"""
     result = darker.import_sorting._diff_overlaps_with_edits(
         edited_linenums, isort_chunks
     )

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -16,7 +16,7 @@ import darker.__main__
 import darker.import_sorting
 import darker.linting
 from darker.exceptions import MissingPackageError
-from darker.git import WORKTREE, RevisionRange
+from darker.git import WORKTREE, EditedLinenumsDiffer, RevisionRange
 from darker.tests.helpers import isort_present
 from darker.utils import TextDocument, joinlines
 from darker.verification import NotEquivalentError
@@ -391,7 +391,7 @@ def test_blacken_single_file(
     result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path(relative_path),
-        RevisionRange(rev1, rev2),
+        EditedLinenumsDiffer(git_repo.root, RevisionRange(rev1, rev2)),
         TextDocument(rev2_content),
         TextDocument(rev2_isorted),
         enable_isort,

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -391,6 +391,7 @@ def test_blacken_single_file(
     result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path(relative_path),
+        Path("file.py"),
         EditedLinenumsDiffer(git_repo.root, RevisionRange(rev1, rev2)),
         TextDocument(rev2_content),
         TextDocument(rev2_isorted),
@@ -399,6 +400,23 @@ def test_blacken_single_file(
     )
 
     assert result.string == expect
+
+
+@pytest.mark.kwparametrize(
+    dict(path="file.py", expect="file.py"),
+    dict(path="subdir/file.py", expect="subdir/file.py"),
+    dict(path="file.py.12345.tmp", expect="file.py"),
+    dict(path="subdir/file.py.12345.tmp", expect="subdir/file.py"),
+    dict(path="file.py.tmp", expect="file.py.tmp"),
+    dict(path="subdir/file.py.tmp", expect="subdir/file.py.tmp"),
+    dict(path="file.12345.tmp", expect="file.12345.tmp"),
+    dict(path="subdir/file.12345.tmp", expect="subdir/file.12345.tmp"),
+)
+def test_get_path_in_repo(path, expect):
+    """``_get_path_in_repo`` drops two suffixes from ``.py.<HASH>.tmp``"""
+    result = darker.__main__._get_path_in_repo(Path(path))
+
+    assert result == Path(expect)
 
 
 @pytest.mark.kwparametrize(

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -403,23 +403,6 @@ def test_blacken_single_file(
 
 
 @pytest.mark.kwparametrize(
-    dict(path="file.py", expect="file.py"),
-    dict(path="subdir/file.py", expect="subdir/file.py"),
-    dict(path="file.py.12345.tmp", expect="file.py"),
-    dict(path="subdir/file.py.12345.tmp", expect="subdir/file.py"),
-    dict(path="file.py.tmp", expect="file.py.tmp"),
-    dict(path="subdir/file.py.tmp", expect="subdir/file.py.tmp"),
-    dict(path="file.12345.tmp", expect="file.12345.tmp"),
-    dict(path="subdir/file.12345.tmp", expect="subdir/file.12345.tmp"),
-)
-def test_get_path_in_repo(path, expect):
-    """``_get_path_in_repo`` drops two suffixes from ``.py.<HASH>.tmp``"""
-    result = darker.__main__._get_path_in_repo(Path(path))
-
-    assert result == Path(expect)
-
-
-@pytest.mark.kwparametrize(
     dict(arguments=["--diff"], expect_stdout=A_PY_DIFF_BLACK),
     dict(arguments=["--isort"], expect_a_py=A_PY_BLACK_ISORT),
     dict(

--- a/src/darker/tests/test_main_blacken_single_file.py
+++ b/src/darker/tests/test_main_blacken_single_file.py
@@ -58,6 +58,7 @@ def test_blacken_single_file_common_ancestor(git_repo):
     result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path("a.py"),
+        Path("a.py"),
         EditedLinenumsDiffer(
             git_repo.root,
             RevisionRange.parse_with_common_ancestor("master...", git_repo.root),
@@ -114,6 +115,7 @@ def test_reformat_single_file_docstring(git_repo):
 
     result = darker.__main__._blacken_single_file(
         git_repo.root,
+        Path("a.py"),
         Path("a.py"),
         EditedLinenumsDiffer(
             git_repo.root,

--- a/src/darker/tests/test_main_blacken_single_file.py
+++ b/src/darker/tests/test_main_blacken_single_file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import darker.__main__
-from darker.git import RevisionRange
+from darker.git import EditedLinenumsDiffer, RevisionRange
 from darker.utils import TextDocument
 
 
@@ -58,7 +58,10 @@ def test_blacken_single_file_common_ancestor(git_repo):
     result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path("a.py"),
-        RevisionRange.parse_with_common_ancestor("master...", git_repo.root),
+        EditedLinenumsDiffer(
+            git_repo.root,
+            RevisionRange.parse_with_common_ancestor("master...", git_repo.root),
+        ),
         rev2_content=worktree,
         rev2_isorted=worktree,
         enable_isort=False,
@@ -112,7 +115,10 @@ def test_reformat_single_file_docstring(git_repo):
     result = darker.__main__._blacken_single_file(
         git_repo.root,
         Path("a.py"),
-        RevisionRange("HEAD", ":WORKTREE:"),
+        EditedLinenumsDiffer(
+            git_repo.root,
+            RevisionRange.parse_with_common_ancestor("HEAD..", git_repo.root),
+        ),
         rev2_content=TextDocument.from_str(modified),
         rev2_isorted=TextDocument.from_str(modified),
         enable_isort=False,


### PR DESCRIPTION
Fixes #72:

>The problem with applying isort modifications "surgically" is in the fact that isort may (and often does) change the order of lines.
>
>Could we consider all changes by isort as one contiguous diff chunk, and apply it if any line in `edited_linenums` falls inside that chunk? Is there an edge case where isort only modifies part of the import lines, and a user edit happens to an import outside that part? I can't see a problem there. The important thing is that either all or none of the isort modifications are applied.

The changes are pretty involved. Here's a summary for reviewers:

### src/darker/\_\_main\_\_.py:
- some variable renames for clarity:
  - `path_in_repo` -> `relative_path_in_rev2`
  - `src` -> `absolute_path_in_rev2`
  - `relative_path` -> `relative_path_in_rev2`
- `_isort_and_blacken_single_file()` and `_isort_and_blacken_single_file()` now accept
  - a pre-created `EditedLinenumsDiffer` object instead of creating its own
  - a list of files to skip when reformatting using Black, instead of just a boolean for the single file

### src/darker/git.py:
- rename `get_rev1_path()` to `get_path_in_repo()`

### src/darker/import_sorting.py:
- `apply_isort()` now
  - accepts a pre-created `EditedLinenumsDiffer` object instead of creating its own
  - calls into helper functions refactored out of it:
    - `isort` arguments are created in `_build_isort_args()`
    - `isort` is invoked in `_call_isort_code()`
  - generates a diff for the result of `isort`
- `_diff_overlaps_with_edits()` does the meat of the new functionality: it checks whether the range of user edits touches the range of reformatted imports

### src/darker/diff.py:
- `diff_chunks()` now combines `diff_and_get_opcodes()` and `opcodes_to_chunks()` behind one call