### PR TITLE
Keep `$PATH` intact so Git is found on NixOS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Added
 Fixed
 -----
 - ``regex`` module now always available for unit tests
+- Compatibility with NixOS. Keep ``$PATH`` intact so Git can be called.
 
 
 1.3.2_ - 2021-10-28

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -1,5 +1,6 @@
 """Configuration and fixtures for the Pytest based test suite"""
 
+import os
 from pathlib import Path
 from subprocess import check_call
 from typing import Dict, Optional
@@ -21,7 +22,7 @@ class GitRepoFixture:
         # For testing, ignore ~/.gitconfig settings like templateDir and defaultBranch.
         # Also, this makes sure GIT_DIR or other GIT_* variables are not set, and that
         # Git's messages are in English.
-        env = {"HOME": str(root), "LC_ALL": "C"}
+        env = {"HOME": str(root), "LC_ALL": "C", "PATH": os.environ["PATH"]}
         instance = cls(root, env)
         # pylint: disable=protected-access
         instance._run("init")

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -195,7 +195,7 @@ def test_git_get_content_at_revision_obtain_file_content(
                 cwd=str(Path("/path")),
                 encoding="utf-8",
                 stderr=PIPE,
-                env={"LC_ALL": "C"},
+                env={"LC_ALL": "C", "PATH": os.environ["PATH"]},
             )
             for expected_call in expect_git_calls
         ]
@@ -403,7 +403,7 @@ def test_git_exists_in_revision_git_call(retval, expect):
         cwd=".",
         check=False,
         stderr=DEVNULL,
-        env={"LC_ALL": "C"},
+        env={"LC_ALL": "C", "PATH": os.environ["PATH"]},
     )
     assert result == expect
 
@@ -790,12 +790,14 @@ def test_local_gitconfig_ignored_by_gitrepofixture(tmp_path):
     """Tests that ~/.gitconfig is ignored when running darker's git tests"""
     (tmp_path / "HEAD").write_text("ref: refs/heads/main")
 
-    with patch.dict(os.environ, {"HOME": str(tmp_path)}):
-        # Note: once we decide to drop support for git < 2.28, the HEAD file
-        # creation above can be removed, and setup can simplify to
-        # check_call("git config --global init.defaultBranch main".split())
-        check_call("git config --global init.templateDir".split() + [str(tmp_path)])
-        root = tmp_path / "repo"
-        root.mkdir()
-        git_repo = GitRepoFixture.create_repository(root)
-        assert git_repo.get_branch() == "master"
+    # Note: once we decide to drop support for git < 2.28, the HEAD file
+    # creation above can be removed, and setup can simplify to
+    # check_call("git config --global init.defaultBranch main".split())
+    check_call(
+        "git config --global init.templateDir".split() + [str(tmp_path)],
+        env={"HOME": str(tmp_path), "PATH": os.environ["PATH"]},
+    )
+    root = tmp_path / "repo"
+    root.mkdir()
+    git_repo = GitRepoFixture.create_repository(root)
+    assert git_repo.get_branch() == "master"


### PR DESCRIPTION
On NixOS systems Git is in a funky non-standard directory which isn't included in the system default `$PATH`. So we need to pass through `$PATH` when invoking Git subprocesses.

Fixes #245.