### PR TITLE
VSCode `.py.tmp` file should be reformatted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- Consider ``.py.tmp`` as files which should be reformatted.
+  This enables VSCode Format On Save.
 
 
 1.4.0_ - 2022-02-08

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -26,6 +26,7 @@ from darker.git import (
     EditedLinenumsDiffer,
     RevisionRange,
     get_missing_at_revision,
+    get_rev1_path,
     git_get_content_at_revision,
     git_get_modified_python_files,
     git_is_repository,
@@ -127,7 +128,7 @@ def _reformat_single_file(  # pylint: disable=too-many-arguments,too-many-locals
 
     """
     src = root / relative_path
-    rev1_relative_path = _get_rev1_path(relative_path)
+    rev1_relative_path = get_rev1_path(relative_path)
     edited_linenums_differ = EditedLinenumsDiffer(root, revrange)
 
     # 4. run black
@@ -198,23 +199,6 @@ def _reformat_single_file(  # pylint: disable=too-many-arguments,too-many-locals
     if not last_successful_reformat:
         raise NotEquivalentError(relative_path)
     return last_successful_reformat
-
-
-def _get_rev1_path(path: Path) -> Path:
-    """Return the relative path to the file in the old revision
-
-    This is usually the same as the relative path on the command line. But in the
-    special case of VSCode temporary files (like ``file.py.12345.tmp``), we actually
-    want to diff against the corresponding ``.py`` file instead.
-
-    """
-    if path.suffixes[-3::2] != [".py", ".tmp"]:
-        # The file name is not like `*.py.<HASH>.tmp`. Return it as such.
-        return path
-    # This is a VSCode temporary file. Drop the hash and the `.tmp` suffix to get the
-    # original file name for retrieving the previous revision to diff against.
-    path_with_hash = path.with_suffix("")
-    return path_with_hash.with_suffix("")
 
 
 def modify_file(path: Path, new_content: TextDocument) -> None:

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -239,6 +239,23 @@ def test_revisionrange_parse_with_common_ancestor(git_repo, revrange, expect):
 
 
 @pytest.mark.kwparametrize(
+    dict(path="file.py", expect="file.py"),
+    dict(path="subdir/file.py", expect="subdir/file.py"),
+    dict(path="file.py.12345.tmp", expect="file.py"),
+    dict(path="subdir/file.py.12345.tmp", expect="subdir/file.py"),
+    dict(path="file.py.tmp", expect="file.py.tmp"),
+    dict(path="subdir/file.py.tmp", expect="subdir/file.py.tmp"),
+    dict(path="file.12345.tmp", expect="file.12345.tmp"),
+    dict(path="subdir/file.12345.tmp", expect="subdir/file.12345.tmp"),
+)
+def test_get_rev1_path(path, expect):
+    """``get_rev1_path`` drops two suffixes from ``.py.<HASH>.tmp``"""
+    result = git.get_rev1_path(Path(path))
+
+    assert result == Path(expect)
+
+
+@pytest.mark.kwparametrize(
     dict(path=".", create=False, expect=False),
     dict(path="main", create=True, expect=False),
     dict(path="main.c", create=True, expect=False),

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -398,23 +398,6 @@ def test_reformat_single_file(
 
 
 @pytest.mark.kwparametrize(
-    dict(path="file.py", expect="file.py"),
-    dict(path="subdir/file.py", expect="subdir/file.py"),
-    dict(path="file.py.12345.tmp", expect="file.py"),
-    dict(path="subdir/file.py.12345.tmp", expect="subdir/file.py"),
-    dict(path="file.py.tmp", expect="file.py.tmp"),
-    dict(path="subdir/file.py.tmp", expect="subdir/file.py.tmp"),
-    dict(path="file.12345.tmp", expect="file.12345.tmp"),
-    dict(path="subdir/file.12345.tmp", expect="subdir/file.12345.tmp"),
-)
-def test_get_rev1_path(path, expect):
-    """``_get_rev1_path`` drops two suffixes from ``.py.<HASH>.tmp``"""
-    result = darker.__main__._get_rev1_path(Path(path))
-
-    assert result == Path(expect)
-
-
-@pytest.mark.kwparametrize(
     dict(arguments=["--diff"], expect_stdout=A_PY_DIFF_BLACK),
     dict(arguments=["--isort"], expect_a_py=A_PY_BLACK_ISORT),
     dict(


### PR DESCRIPTION
Fixes #249 and #255

- [x] rebase on `master` after #270 has been merged
- [x] failing test
- [x] fix
- [x] change log