### PR TITLE
Add support for `black` >= 22.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    black>=21.5b1
+    black>=22.1.0
     toml
     typing-extensions ; python_version < "3.8"
     dataclasses ; python_version < "3.7"

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable, List, cast
 
 import toml
-from black import find_project_root
+from black import find_pyproject_toml
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -104,8 +104,8 @@ def load_config(srcs: Iterable[str]) -> DarkerConfig:
                  are used to look for the ``pyproject.toml`` configuration file.
 
     """
-    path = find_project_root(tuple(srcs or ["."])) / "pyproject.toml"
-    if path.is_file():
+    path = find_pyproject_toml(tuple(srcs or ["."]))
+    if path is not None:
         pyproject_toml = toml.load(path)
         config = cast(
             DarkerConfig, pyproject_toml.get("tool", {}).get("darker", {}) or {}

--- a/src/darker/import_sorting.py
+++ b/src/darker/import_sorting.py
@@ -63,7 +63,7 @@ def apply_isort(
     if config:
         isort_args["settings_file"] = config
     else:
-        isort_args["settings_path"] = str(find_project_root((str(src),)))
+        isort_args["settings_path"] = str(find_project_root((str(src),))[0])
     if line_length:
         isort_args["line_length"] = line_length
 


### PR DESCRIPTION
Black changed `find_project_root` behavior. Now it returns a tuple.
Let's use `find_pyproject_toml` instead.