### PR TITLE
Re-enable Win and Python 3.6/3.7/3.8/3.9 builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,13 +42,13 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        #- windows-latest
+        - windows-latest
         - macos-latest
         python-version:
-        #- '3.6'
-        #- '3.7'
-        #- '3.8'
-        #- '3.9'
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
         - '3.10'
         constraints: ['']
         include:


### PR DESCRIPTION
I accidentally left these disabled in #248.