### PR TITLE
Include `isort@main` in `test-future` workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,6 +60,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             constraints: '--constraint constraints-future.txt'
+            upgrade: '--upgrade --upgrade-strategy=eager'
 
     steps:
       - uses: actions/checkout@v2
@@ -71,10 +72,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        env:
+          pip_options: ${{ matrix.upgrade }} ${{ matrix.constraints }}
         run: |
           # strict dependency resolution added in pip 20.3
           python -m pip install --upgrade 'pip>=20.3'
-          pip install -e '.[isort,test]' ${{ matrix.constraints }}
+          pip install ${pip_options} -e '.[isort,test]'
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -23,7 +23,11 @@ jobs:
         run: |
           # strict dependency resolution added in pip 20.3
           python -m pip install --upgrade 'pip>=20.3'
-          pip install -e '.[isort,test]' --constraint constraints-future.txt
+          pip install \
+            --constraint=constraints-future.txt \
+            --upgrade \
+            --upgrade-strategy=eager \
+            -e '.[isort,test]'
       - name: Test with pytest
         run: |
           pytest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 - Document ``isort``'s requirement to be run in the same environment as
   the modules which are processed.
 - Document VSCode and ``--lint``/``-L`` incompatibility in the README.
+- Guard against breaking changes in ``isort`` by testing against its ``main``
+  branch in the ``test-future`` GitHub Workflow.
 
 Fixed
 -----
@@ -27,6 +29,8 @@ Added
 - Add Nix CI builds on Linux and macOS.
 - Add a YAML linting workflow to the Darker repository.
 - Updated Mypy to version 0.931.
+- Guard against breaking changes in Black by testing against its ``main`` branch
+  in the ``test-future`` GitHub Workflow.
 
 Fixed
 -----

--- a/constraints-future.txt
+++ b/constraints-future.txt
@@ -4,3 +4,4 @@
 # up-to-date by adding entries for any packages we want to get early
 # incompatibility warnings for.
 black @ git+https://github.com/psf/black.git@main 
+isort @ git+https://github.com/PyCQA/isort.git@main


### PR DESCRIPTION
Fixes #262.

Also adds use of `--upgrade --upgrade-strategy=eager` for pip when installing packages with `constraints-future.txt`. This way not only Black and `isort` are from their `main` branches, but also we get newest releases for all other dependencies as well.