### PR TITLE
Document VSCode / `--lint` incompatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Added
 -----
 - Document ``isort``'s requirement to be run in the same environment as
   the modules which are processed.
+- Document VSCode and ``--lint``/``-L`` incompatibility in the README.
 
 Fixed
 -----

--- a/README.rst
+++ b/README.rst
@@ -639,7 +639,7 @@ Here's an example of `cov_to_lint.py`_ output::
 +=======================================================================+
 | Don't enable linting on the command line or in the configuration when | 
 | running Darker as a reformatter in VSCode. You will confuse VSCode    |
-| with unexpected output from Darker.                                   |
+| with unexpected output from Darker, as it only expect black's output                                  |
 +-----------------------------------------------------------------------+
 
 .. _Mypy: https://pypi.org/project/mypy

--- a/README.rst
+++ b/README.rst
@@ -311,6 +311,10 @@ For example:
    ]
    log_level = "INFO"
 
+Be careful to not use options which generate output which is unexpected for
+other tools. For example, VSCode only expects the reformat diff, so
+``lint = [ ... ]`` can't be used with it.
+
 *New in version 1.0.0:*
 
 - The ``-c``, ``-S`` and ``-l`` command line options.
@@ -413,6 +417,7 @@ PyCharm/IntelliJ IDEA
 
 __ https://plugins.jetbrains.com/plugin/7177-file-watchers
 
+
 Visual Studio Code
 ------------------
 
@@ -440,6 +445,8 @@ Visual Studio Code
 
 You can pass additional arguments to ``darker`` in the ``blackArgs`` option
 (e.g. ``["--diff", "--isort"]``), but make sure at least ``--diff`` is included.
+Also, this won't work if you have any linters enabled on the command line
+or in ``pyproject.toml``.
 
 Note that VSCode first copies the file to reformat into a temporary
 ``<filename>.py.<hash>.tmp`` file, then calls Black (or Darker in this case) on that
@@ -626,6 +633,14 @@ Here's an example of `cov_to_lint.py`_ output::
     src/darker/__main__.py:130: no coverage:             if context_lines == max_context_lines:
     src/darker/__main__.py:131: no coverage:                 raise
     src/darker/__main__.py:132: no coverage:             logger.debug(
+
++-----------------------------------------------------------------------+
+|                               ⚠ NOTE ⚠                                |
++=======================================================================+
+| Don't enable linting on the command line or in the configuration when | 
+| running Darker as a reformatter in VSCode. You will confuse VSCode    |
+| with unexpected output from Darker.                                   |
++-----------------------------------------------------------------------+
 
 .. _Mypy: https://pypi.org/project/mypy
 .. _Pylint: https://pypi.org/project/pylint

--- a/README.rst
+++ b/README.rst
@@ -441,12 +441,13 @@ Visual Studio Code
 
     "python.formatting.provider": "black",
     "python.formatting.blackPath": "<install_location_from_step_2>",
-    "python.formatting.blackArgs": ["--diff"],
+    "python.formatting.blackArgs": [],
 
-You can pass additional arguments to ``darker`` in the ``blackArgs`` option
-(e.g. ``["--diff", "--isort"]``), but make sure at least ``--diff`` is included.
-Also, this won't work if you have any linters enabled on the command line
-or in ``pyproject.toml``.
+VSCode will always add ``--diff --quiet`` as arguments to Darker,
+but you can also pass additional arguments in the ``blackArgs`` option
+(e.g. ``["--isort", "--revision=master..."]``).
+Be sure to *not* enable any linters here or in ``pyproject.toml``
+since VSCode won't be able to understand output from them.
 
 Note that VSCode first copies the file to reformat into a temporary
 ``<filename>.py.<hash>.tmp`` file, then calls Black (or Darker in this case) on that

--- a/README.rst
+++ b/README.rst
@@ -640,7 +640,7 @@ Here's an example of `cov_to_lint.py`_ output::
 +=======================================================================+
 | Don't enable linting on the command line or in the configuration when | 
 | running Darker as a reformatter in VSCode. You will confuse VSCode    |
-| with unexpected output from Darker, as it only expect black's output                                  |
+| with unexpected output from Darker, as it only expect black's output  |
 +-----------------------------------------------------------------------+
 
 .. _Mypy: https://pypi.org/project/mypy


### PR DESCRIPTION
Fixes #297 partially.

