### PR TITLE
Format docstrings as complete chunks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Fixed
   the virtualenv.
 - Allow more time to pass when checking file modification times in a unit test.
   Windows tests on GitHub are sometimes really slow.
+- Multiline strings are now always reformatted completely even if just a part
+  was modified by the user and reformatted by Black. This prevents the
+  "back-and-forth indent" symptom.
 
 
 1.4.1_ - 2022-02-17

--- a/src/darker/multiline_strings.py
+++ b/src/darker/multiline_strings.py
@@ -1,0 +1,37 @@
+"""Helper functions for dealing with reformatting multi-line strings"""
+
+from tokenize import STRING, tokenize
+from typing import List, Optional, Sequence, Tuple
+
+from darker.utils import TextDocument
+
+
+def get_multiline_string_ranges(content: TextDocument) -> List[Tuple[int, int]]:
+    """Return the line ranges of multi-line strings found in the given Python source
+
+    Each item is a 1-based ``(start, end)`` tuple, ``end`` being the line number
+    following the last line of the multi-line string.
+
+    :return: Line number ranges of multi-line strings
+
+    """
+    readline = (f"{line}\n".encode(content.encoding) for line in content.lines).__next__
+    return [
+        (t.start[0], t.end[0] + 1)
+        for t in tokenize(readline)
+        if t.type == STRING and t.end[0] > t.start[0]
+    ]
+
+
+def find_overlap(
+    start: int, end: int, ranges: Sequence[Tuple[int, int]]
+) -> Optional[Tuple[int, int]]:
+    """Return the first of the given ranges which overlaps with given start and end
+
+    :return: The first overlapping range
+
+    """
+    for range_start, range_end in ranges:
+        if start < range_end and end > range_start:
+            return range_start, range_end
+    return None

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -203,7 +203,7 @@ EXAMPLE_OPCODES = [
     dict(context_lines=2, expect=[[1, 7], [11, 28]]),
 )
 def test_opcodes_to_edit_linenums(context_lines, expect):
-    edit_linenums = list(opcodes_to_edit_linenums(EXAMPLE_OPCODES, context_lines))
+    edit_linenums = list(opcodes_to_edit_linenums(EXAMPLE_OPCODES, context_lines, []))
     expect_ranges = [[n, n] if isinstance(n, int) else n for n in expect]
     expect_linenums = list(chain(*(range(n[0], n[1] + 1) for n in expect_ranges)))
 
@@ -211,6 +211,8 @@ def test_opcodes_to_edit_linenums(context_lines, expect):
 
 
 def test_opcodes_to_edit_linenums_empty_opcodes():
-    result = list(opcodes_to_edit_linenums([], context_lines=0))
+    result = list(
+        opcodes_to_edit_linenums([], context_lines=0, multiline_string_ranges=[])
+    )
 
     assert result == []

--- a/src/darker/tests/test_multiline_strings.py
+++ b/src/darker/tests/test_multiline_strings.py
@@ -1,0 +1,124 @@
+"""Tests for `darker.multiline_strings`"""
+
+import pytest
+
+from darker import multiline_strings
+from darker.utils import TextDocument
+
+
+def test_get_multiline_string_ranges():
+    """`get_multiline_string_ranges()` identifies multi-line strings correctly"""
+    content = TextDocument.from_lines(
+        [
+            "'single-quoted string'",  # (line 1)
+            "f'single-quoted f-string'",
+            "r'single-quoted raw string'",
+            "rf'single-quoted raw f-string'",
+            "b'single-quoted bytestring'",  # (line 5)
+            "rb'single-quoted raw bytestring'",
+            "'''triple-single-quoted one-line string'''",
+            "f'''triple-single-quoted one-line f-string'''",
+            "r'''triple-single-quoted one-line raw string'''",
+            "rf'''triple-single-quoted one-line raw f-string'''",  # (line 10)
+            "b'''triple-single-quoted one-line bytestring'''",
+            "rb'''triple-single-quoted one-line raw bytestring'''",
+            "'''triple-single-quoted",  # line 13
+            "   two-line string'''",
+            "f'''triple-single-quoted",  # line 15
+            "    two-line f-string'''",
+            "r'''triple-single-quoted",  # line 17
+            "    two-line raw string'''",
+            "rf'''triple-single-quoted",  # line 19
+            "     two-line raw f-string'''",
+            "b'''triple-single-quoted",  # line 21
+            "    two-line bytestring'''",
+            "rb'''triple-single-quoted",  # line 23
+            "     two-line raw bytestring'''",
+            '"double-quoted string"',  # (line 25)
+            'f"double-quoted f-string"',
+            'r"double-quoted raw string"',
+            'rf"double-quoted raw f-string"',
+            'b"double-quoted bytestring"',
+            'rb"double-quoted raw bytestring"',  # (line 30)
+            '"""triple-double-quoted one-line string"""',
+            'f"""triple-double-quoted one-line f-string"""',
+            'r"""triple-double-quoted one-line raw string"""',
+            'rf"""triple-double-quoted one-line raw f-string"""',
+            'b"""triple-double-quoted one-line bytestring"""',  # (line 35)
+            'rb"""triple-double-quoted one-line raw bytestring"""',
+            '"""triple-double-quoted',  # line 37
+            '   two-line string"""',
+            'f"""triple-double-quoted',  # line 39
+            '    two-line f-string"""',
+            'r"""triple-double-quoted',  # line 41
+            '    two-line raw string"""',
+            'rf"""triple-double-quoted',  # line 43
+            '     two-line raw f-string"""',
+            'b"""triple-double-quoted',  # line 45
+            '    two-line bytestring"""',
+            'rb"""triple-double-quoted',  # line 47
+            '     two-line raw bytestring"""',
+            '"""triple-',  # line 49
+            "   double-",
+            "   quoted",
+            "   six-",
+            "   line",
+            '   string"""',  # line 54
+        ]
+    )
+
+    result = multiline_strings.get_multiline_string_ranges(content)
+
+    assert result == [
+        # 1-based, end-exclusive
+        (13, 15),
+        (15, 17),
+        (17, 19),
+        (19, 21),
+        (21, 23),
+        (23, 25),
+        (37, 39),
+        (39, 41),
+        (41, 43),
+        (43, 45),
+        (45, 47),
+        (47, 49),
+        (49, 55),
+    ]
+
+
+# End-exclusive
+TEST_RANGES = [(2, 2), (5, 6), (9, 11), (14, 17)]
+
+
+@pytest.mark.kwparametrize(
+    # `(start, end)` and `ranges` are end-exclusive
+    dict(start=0, end=0, ranges=[], expect=None),
+    dict(start=0, end=42, ranges=[], expect=None),
+    dict(start=0, end=0, ranges=TEST_RANGES, expect=None),
+    dict(start=1, end=2, ranges=TEST_RANGES, expect=None),
+    dict(start=2, end=2, ranges=TEST_RANGES, expect=None),
+    dict(start=1, end=3, ranges=TEST_RANGES, expect=(2, 2)),
+    dict(start=2, end=3, ranges=TEST_RANGES, expect=None),
+    dict(start=3, end=3, ranges=TEST_RANGES, expect=None),
+    dict(start=4, end=5, ranges=TEST_RANGES, expect=None),
+    dict(start=5, end=5, ranges=TEST_RANGES, expect=None),
+    dict(start=4, end=6, ranges=TEST_RANGES, expect=(5, 6)),
+    dict(start=5, end=6, ranges=TEST_RANGES, expect=(5, 6)),
+    dict(start=6, end=6, ranges=TEST_RANGES, expect=None),
+    dict(start=4, end=7, ranges=TEST_RANGES, expect=(5, 6)),
+    dict(start=5, end=7, ranges=TEST_RANGES, expect=(5, 6)),
+    dict(start=6, end=7, ranges=TEST_RANGES, expect=None),
+    dict(start=10, end=10, ranges=TEST_RANGES, expect=(9, 11)),
+    dict(start=10, end=11, ranges=TEST_RANGES, expect=(9, 11)),
+    dict(start=10, end=12, ranges=TEST_RANGES, expect=(9, 11)),
+    dict(start=11, end=11, ranges=TEST_RANGES, expect=None),
+    dict(start=11, end=12, ranges=TEST_RANGES, expect=None),
+    dict(start=12, end=12, ranges=TEST_RANGES, expect=None),
+    dict(start=10, end=19, ranges=TEST_RANGES, expect=(9, 17)),
+)
+def test_find_overlap(start, end, ranges, expect):
+    """`find_overlap()` finds the enclosing range for overlapping ranges"""
+    result = multiline_strings.find_overlap(start, end, ranges)
+
+    assert result == expect

--- a/src/darker/tests/test_multiline_strings.py
+++ b/src/darker/tests/test_multiline_strings.py
@@ -9,61 +9,63 @@ from darker.utils import TextDocument
 def test_get_multiline_string_ranges():
     """`get_multiline_string_ranges()` identifies multi-line strings correctly"""
     content = TextDocument.from_lines(
-        [
-            "'single-quoted string'",  # (line 1)
-            "f'single-quoted f-string'",
-            "r'single-quoted raw string'",
-            "rf'single-quoted raw f-string'",
-            "b'single-quoted bytestring'",  # (line 5)
-            "rb'single-quoted raw bytestring'",
-            "'''triple-single-quoted one-line string'''",
-            "f'''triple-single-quoted one-line f-string'''",
-            "r'''triple-single-quoted one-line raw string'''",
-            "rf'''triple-single-quoted one-line raw f-string'''",  # (line 10)
-            "b'''triple-single-quoted one-line bytestring'''",
-            "rb'''triple-single-quoted one-line raw bytestring'''",
-            "'''triple-single-quoted",  # line 13
-            "   two-line string'''",
-            "f'''triple-single-quoted",  # line 15
-            "    two-line f-string'''",
-            "r'''triple-single-quoted",  # line 17
-            "    two-line raw string'''",
-            "rf'''triple-single-quoted",  # line 19
-            "     two-line raw f-string'''",
-            "b'''triple-single-quoted",  # line 21
-            "    two-line bytestring'''",
-            "rb'''triple-single-quoted",  # line 23
-            "     two-line raw bytestring'''",
-            '"double-quoted string"',  # (line 25)
-            'f"double-quoted f-string"',
-            'r"double-quoted raw string"',
-            'rf"double-quoted raw f-string"',
-            'b"double-quoted bytestring"',
-            'rb"double-quoted raw bytestring"',  # (line 30)
-            '"""triple-double-quoted one-line string"""',
-            'f"""triple-double-quoted one-line f-string"""',
-            'r"""triple-double-quoted one-line raw string"""',
-            'rf"""triple-double-quoted one-line raw f-string"""',
-            'b"""triple-double-quoted one-line bytestring"""',  # (line 35)
-            'rb"""triple-double-quoted one-line raw bytestring"""',
-            '"""triple-double-quoted',  # line 37
-            '   two-line string"""',
-            'f"""triple-double-quoted',  # line 39
-            '    two-line f-string"""',
-            'r"""triple-double-quoted',  # line 41
-            '    two-line raw string"""',
-            'rf"""triple-double-quoted',  # line 43
-            '     two-line raw f-string"""',
-            'b"""triple-double-quoted',  # line 45
-            '    two-line bytestring"""',
-            'rb"""triple-double-quoted',  # line 47
-            '     two-line raw bytestring"""',
-            '"""triple-',  # line 49
-            "   double-",
-            "   quoted",
-            "   six-",
-            "   line",
-            '   string"""',  # line 54
+        line
+        for _, line in [
+            # Dummy line numbers added to ease debugging of failures
+            (1, "'single-quoted string'"),
+            (2, "f'single-quoted f-string'"),
+            (3, "r'single-quoted raw string'"),
+            (4, "rf'single-quoted raw f-string'"),
+            (5, "b'single-quoted bytestring'"),
+            (6, "rb'single-quoted raw bytestring'"),
+            (7, "'''triple-single-quoted one-line string'''"),
+            (8, "f'''triple-single-quoted one-line f-string'''"),
+            (9, "r'''triple-single-quoted one-line raw string'''"),
+            (10, "rf'''triple-single-quoted one-line raw f-string'''"),
+            (11, "b'''triple-single-quoted one-line bytestring'''"),
+            (12, "rb'''triple-single-quoted one-line raw bytestring'''"),
+            (13, "'''triple-single-quoted"),
+            (14, "   two-line string'''"),
+            (15, "f'''triple-single-quoted"),
+            (16, "    two-line f-string'''"),
+            (17, "r'''triple-single-quoted"),
+            (18, "    two-line raw string'''"),
+            (19, "rf'''triple-single-quoted"),
+            (20, "     two-line raw f-string'''"),
+            (21, "b'''triple-single-quoted"),
+            (22, "    two-line bytestring'''"),
+            (23, "rb'''triple-single-quoted"),
+            (24, "     two-line raw bytestring'''"),
+            (25, '"double-quoted string"'),
+            (26, 'f"double-quoted f-string"'),
+            (27, 'r"double-quoted raw string"'),
+            (28, 'rf"double-quoted raw f-string"'),
+            (29, 'b"double-quoted bytestring"'),
+            (30, 'rb"double-quoted raw bytestring"'),
+            (31, '"""triple-double-quoted one-line string"""'),
+            (32, 'f"""triple-double-quoted one-line f-string"""'),
+            (33, 'r"""triple-double-quoted one-line raw string"""'),
+            (34, 'rf"""triple-double-quoted one-line raw f-string"""'),
+            (35, 'b"""triple-double-quoted one-line bytestring"""'),
+            (36, 'rb"""triple-double-quoted one-line raw bytestring"""'),
+            (37, '"""triple-double-quoted'),
+            (38, '   two-line string"""'),
+            (39, 'f"""triple-double-quoted'),
+            (40, '    two-line f-string"""'),
+            (41, 'r"""triple-double-quoted'),
+            (42, '    two-line raw string"""'),
+            (43, 'rf"""triple-double-quoted'),
+            (44, '     two-line raw f-string"""'),
+            (45, 'b"""triple-double-quoted'),
+            (46, '    two-line bytestring"""'),
+            (47, 'rb"""triple-double-quoted'),
+            (48, '     two-line raw bytestring"""'),
+            (49, '"""triple-'),
+            (50, "   double-"),
+            (51, "   quoted"),
+            (52, "   six-"),
+            (53, "   line"),
+            (54, '   string"""'),
         ]
     )
 


### PR DESCRIPTION
Treating large docstrings as separate chunks can cause to weird behavior, e.g. "reformat loops" in which some lines are repeatedly indented and unindented by Darker.

Fixes #240.

- [x] add failing test case
- [x] find multi-line using AST parsing, using e.g.:
  ```python
  from pathlib import Path
  from tokenize import tokenize, STRING
  from darker.utils import TextDocument

  src = TextDocument.from_file(Path("setup.py"))
  readline = (f"{line}\n".encode(src.encoding) for line in src.lines).__next__
  multiline_string_linespans = [
      (t.start[0], t.end[0]) for t in tokenize(readline)
      if t.type == STRING and t.end[0] > t.start[0]
  ]
  ```
- [x] if any line in a multi-line string was edited by the user, mark all of the lines edited
- [x] change log
- [x] tests for added functions