### PR TITLE
NixOS build failed when `pytest-darker` called `pylint`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,8 +31,9 @@ jobs:
         run: |
           nix-shell --pure --run '
             python -m venv venv
-            venv/bin/pip install -e '.[isort,test]'
-            venv/bin/pytest
+            source venv/bin/activate
+            pip install -e '.[isort,test]'
+            pytest
           ' ./default.nix
 
   build:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Added
 
 Fixed
 -----
+- Fix NixOS builds when ``pytest-darker`` calls ``pylint``. Needed to activate
+  the virtualenv.
 
 
 1.4.1_ - 2022-02-17


### PR DESCRIPTION
This happened first in the [ubuntu-latest](https://github.com/akaihola/darker/runs/5274554724?check_suite_focus=true) and [macos-latest](https://github.com/akaihola/darker/runs/5274554796?check_suite_focus=true) NixOS builds for #300. And it wasn't a transient problem, since they failed again (see build \#860 for [ubuntu-latest](https://github.com/akaihola/darker/runs/5277753959?check_suite_focus=true) and [macos-latest](https://github.com/akaihola/darker/runs/5277754008?check_suite_focus=true).

But for this PR, strangely, the [ubuntu-latest nixos build](https://github.com/akaihola/darker/runs/5277677163?check_suite_focus=true) succeeds. It's hard for me to believe that the code changes in #300 would have caused the failure.

I'll still use this PR to find a fix..