### PR TITLE
Fix slow windows test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Fixed
 -----
 - Fix NixOS builds when ``pytest-darker`` calls ``pylint``. Needed to activate
   the virtualenv.
+- Allow more time to pass when checking file modification times in a unit test.
+  Windows tests on GitHub are sometimes really slow.
 
 
 1.4.1_ - 2022-02-17

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -110,7 +110,7 @@ def test_git_get_content_at_revision(git_repo, revision, expect_lines, expect_mt
     if expect_mtime:
         mtime_then = datetime.strptime(result.mtime, GIT_DATEFORMAT)
         difference = expect_mtime() - mtime_then
-        assert timedelta(0) <= difference < timedelta(seconds=3)
+        assert timedelta(0) <= difference < timedelta(seconds=6)
     else:
         assert result.mtime == ""
     assert result.encoding == "utf-8"


### PR DESCRIPTION
4.5 seconds passed in [a unit test on Windows](https://github.com/akaihola/darker/runs/5306288849?check_suite_focus=true#step:5:105) while only 3 seconds was allowed when checking whether the file modification time falls in the correct ballpark.

- [x] allow more time to pass when checking file modification times
- [x] change log