### PR TITLE
`stdin` mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Added
   ``rev2`` to get the current situation. Old linter messages which fall on unmodified
   lines are hidden, so effectively the user gets new linter messages introduced by
   latest changes, as well as persistent linter messages on modified lines.
+- ``--stdin-filename=PATH`` now allows reading contents of a single file from standard
+  input. This also makes ``:STDIN:``, a new magic value, the default ``rev2`` for
+  ``--revision``.
 - Add configuration for ``darglint`` and ``flake8-docstrings``, preparing for enabling
   those linters in CI builds.
 

--- a/README.rst
+++ b/README.rst
@@ -315,13 +315,14 @@ For more details, see:
 The following `command line arguments`_ can also be used to modify the defaults:
 
 -r REV, --revision REV
-       Git revision against which to compare the working tree. Tags, branch names,
-       commit hashes, and other expressions like ``HEAD~5`` work here. Also a range like
-       ``master...HEAD`` or ``master...`` can be used to compare the best common
-       ancestor. With the magic value ``:PRE-COMMIT:``, Darker works in pre-commit
-       compatible mode. Darker expects the revision range from the
-       ``PRE_COMMIT_FROM_REF`` and ``PRE_COMMIT_TO_REF`` environment variables. If those
-       are not found, Darker works against ``HEAD``.
+       Revisions to compare. The default is ``HEAD..:WORKTREE:`` which compares the
+       latest commit to the working tree. Tags, branch names, commit hashes, and other
+       expressions like ``HEAD~5`` work here. Also a range like ``main...HEAD`` or
+       ``main...`` can be used to compare the best common ancestor. With the magic value
+       ``:PRE-COMMIT:``, Darker works in pre-commit compatible mode. Darker expects the
+       revision range from the ``PRE_COMMIT_FROM_REF`` and ``PRE_COMMIT_TO_REF``
+       environment variables. If those are not found, Darker works against ``HEAD``.
+       Also see ``--stdin-filename=`` for the ``:STDIN:`` special value.
 --diff
        Don't write the files back, just output a diff for each file on stdout. Highlight
        syntax if on a terminal and the ``pygments`` package is available, or if enabled
@@ -330,6 +331,10 @@ The following `command line arguments`_ can also be used to modify the defaults:
        Force complete reformatted output to stdout, instead of in-place. Only valid if
        there's just one file to reformat. Highlight syntax if on a terminal and the
        ``pygments`` package is available, or if enabled by configuration.
+--stdin-filename PATH
+       The path to the file when passing it through stdin. Useful so Darker can find the
+       previous version from Git. Only valid with ``--revision=<rev1>..:STDIN:``
+       (``HEAD..:STDIN:`` being the default if ``--stdin-filename`` is enabled).
 --check
        Don't write the files back, just return the status. Return code 0 means nothing
        would change. Return code 1 means some files would be reformatted.

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -18,6 +18,7 @@ from darker.config import (
     get_modified_config,
     load_config,
     override_color_with_environment,
+    validate_stdin_src,
 )
 from darker.version import __version__
 
@@ -115,7 +116,8 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     Finally, also return the set of configuration options which differ from defaults.
 
     """
-    # 1. Parse the paths of files/directories to process into `args.src`.
+    # 1. Parse the paths of files/directories to process into `args.src`, and the config
+    #    file path into `args.config`.
     parser_for_srcs = make_argument_parser(require_src=False)
     args = parser_for_srcs.parse_args(argv)
 
@@ -123,23 +125,36 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     #    if it's not provided, based on the paths to process, or in the current
     #    directory if no paths were given. Load Darker configuration from it.
     pyproject_config = load_config(args.config, args.src)
+
+    # 3. The PY_COLORS, NO_COLOR and FORCE_COLOR environment variables override the
+    #    `--color` command line option.
     config = override_color_with_environment(pyproject_config)
 
-    # 3. Use configuration as defaults for re-parsing command line arguments, and don't
-    #    require file/directory paths if they are specified in configuration.
-    parser = make_argument_parser(require_src=not config.get("src"))
-    parser.set_defaults(**config)
-    args = parser.parse_args(argv)
+    # 4. Re-run the parser with configuration defaults. This way we get combined values
+    #    based on the configuration file and the command line options for all options
+    #    except `src` (the list of files to process).
+    parser_for_srcs.set_defaults(**config)
+    args = parser_for_srcs.parse_args(argv)
 
-    # 4. Make sure there aren't invalid option combinations after merging configuration
+    # 5. Make sure an error for missing file/directory paths is thrown if we're not
+    #    running in stdin mode and no file/directory is configured in `pyproject.toml`.
+    if args.stdin_filename is None and not config.get("src"):
+        parser = make_argument_parser(require_src=True)
+        parser.set_defaults(**config)
+        args = parser.parse_args(argv)
+
+    # 6. Make sure there aren't invalid option combinations after merging configuration
     #    and command line options.
     OutputMode.validate_diff_stdout(args.diff, args.stdout)
-    OutputMode.validate_stdout_src(args.stdout, args.src)
+    OutputMode.validate_stdout_src(args.stdout, args.src, args.stdin_filename)
+    validate_stdin_src(args.stdin_filename, args.src)
 
-    # 5. Also create a parser which uses the original default configuration values.
+    # 7. Also create a parser which uses the original default configuration values.
     #    This is used to find out differences between the effective configuration and
     #    default configuration values, and print them out in verbose mode.
-    parser_with_original_defaults = make_argument_parser(require_src=True)
+    parser_with_original_defaults = make_argument_parser(
+        require_src=args.stdin_filename is None
+    )
     return (
         args,
         get_effective_config(args),

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -42,6 +42,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
     add_arg(hlp.REVISION, "-r", "--revision", default="HEAD", metavar="REV")
     add_arg(hlp.DIFF, "--diff", action="store_true")
     add_arg(hlp.STDOUT, "-d", "--stdout", action="store_true")
+    add_arg(hlp.STDIN_FILENAME, "--stdin-filename", metavar="PATH")
     add_arg(hlp.CHECK, "--check", action="store_true")
     add_arg(hlp.FLYNT, "-f", "--flynt", action="store_true")
     add_arg(hlp.ISORT, "-i", "--isort", action="store_true")

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -72,15 +72,19 @@ class OutputMode:
             )
 
     @staticmethod
-    def validate_stdout_src(stdout: bool, src: List[str]) -> None:
-        """Raise an exception in ``stdout`` mode if not exactly one path is provided"""
+    def validate_stdout_src(
+        stdout: bool, src: List[str], stdin_filename: Optional[str]
+    ) -> None:
+        """Raise an exception in ``stdout`` mode if not exactly one input is provided"""
         if not stdout:
             return
-        if len(src) == 1 and Path(src[0]).is_file():
+        if stdin_filename is None and len(src) == 1 and Path(src[0]).is_file():
+            return
+        if stdin_filename is not None and len(src) == 0:
             return
         raise ConfigurationError(
-            "Exactly one Python source file which exists on disk must be provided when"
-            " using the `stdout` option"
+            "Either --stdin-filename=<path> or exactly one Python source file which"
+            " exists on disk must be provided when using the `stdout` option"
         )
 
 
@@ -98,6 +102,17 @@ def validate_config_output_mode(config: DarkerConfig) -> None:
     """Make sure both ``diff`` and ``stdout`` aren't enabled in configuration"""
     OutputMode.validate_diff_stdout(
         config.get("diff", False), config.get("stdout", False)
+    )
+
+
+def validate_stdin_src(stdin_filename: Optional[str], src: List[str]) -> None:
+    """Make sure both ``stdin`` mode and paths/directories are specified"""
+    if stdin_filename is None:
+        return
+    if len(src) == 0:
+        return
+    raise ConfigurationError(
+        "No Python source files are allowed when using the `stdin-filename` option"
     )
 
 

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -56,6 +56,7 @@ COMMIT_RANGE_RE = re.compile(r"(.*?)(\.{2,3})(.*)$")
 # - referring to the `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF` environment variables
 #   for determining the revision range
 WORKTREE = ":WORKTREE:"
+STDIN = ":STDIN:"
 PRE_COMMIT_FROM_TO_REFS = ":PRE-COMMIT:"
 
 
@@ -175,34 +176,55 @@ class RevisionRange:
 
     @classmethod
     def parse_with_common_ancestor(
-        cls, revision_range: str, cwd: Path
+        cls, revision_range: str, cwd: Path, stdin_mode: bool
     ) -> "RevisionRange":
         """Convert a range expression to a ``RevisionRange`` object
 
         If the expression contains triple dots (e.g. ``master...HEAD``), finds the
         common ancestor of the two revisions and uses that as the first revision.
 
+        :param revision_range: The revision range as a string to parse
+        :param cwd: The working directory to use if invoking Git
+        :param stdin_mode: If `True`, the default for ``rev2`` is ``:STDIN:``
+        :return: The range parsed into a `RevisionRange` object
+
         """
-        rev1, rev2, use_common_ancestor = cls._parse(revision_range)
+        rev1, rev2, use_common_ancestor = cls._parse(revision_range, stdin_mode)
         if use_common_ancestor:
             return cls._with_common_ancestor(rev1, rev2, cwd)
         return cls(rev1, rev2)
 
     @staticmethod
-    def _parse(revision_range: str) -> Tuple[str, str, bool]:
+    def _parse(revision_range: str, stdin_mode: bool) -> Tuple[str, str, bool]:
         """Convert a range expression to revisions, using common ancestor if appropriate
 
-        >>> RevisionRange._parse("a..b")
+        A `ValueError` is raised if ``--stdin-filename`` is used by the revision range
+        is ``:PRE-COMMIT:`` or the end of the range is not ``:STDIN:``.
+
+        :param revision_range: The revision range as a string to parse
+        :param stdin_mode: If `True`, the default for ``rev2`` is ``:STDIN:``
+        :raises ValueError: for an invalid revision when ``--stdin-filename`` is used
+        :return: The range parsed into a `RevisionRange` object
+
+        >>> RevisionRange._parse("a..b", stdin_mode=False)
         ('a', 'b', False)
-        >>> RevisionRange._parse("a...b")
+        >>> RevisionRange._parse("a...b", stdin_mode=False)
         ('a', 'b', True)
-        >>> RevisionRange._parse("a..")
+        >>> RevisionRange._parse("a..", stdin_mode=False)
         ('a', ':WORKTREE:', False)
-        >>> RevisionRange._parse("a...")
+        >>> RevisionRange._parse("a...", stdin_mode=False)
         ('a', ':WORKTREE:', True)
+        >>> RevisionRange._parse("a..", stdin_mode=True)
+        ('a', ':STDIN:', False)
+        >>> RevisionRange._parse("a...", stdin_mode=True)
+        ('a', ':STDIN:', True)
 
         """
         if revision_range == PRE_COMMIT_FROM_TO_REFS:
+            if stdin_mode:
+                raise ValueError(
+                    f"With --stdin-filename, revision {revision_range!r} is not allowed"
+                )
             try:
                 return (
                     os.environ["PRE_COMMIT_FROM_REF"],
@@ -213,16 +235,27 @@ class RevisionRange:
                 # Fallback to running against HEAD
                 revision_range = "HEAD"
         match = COMMIT_RANGE_RE.match(revision_range)
+        default_rev2 = STDIN if stdin_mode else WORKTREE
         if match:
             rev1, range_dots, rev2 = match.groups()
             use_common_ancestor = range_dots == "..."
-            return (rev1 or "HEAD", rev2 or WORKTREE, use_common_ancestor)
-        return (revision_range or "HEAD", WORKTREE, revision_range not in ["", "HEAD"])
+            effective_rev2 = rev2 or default_rev2
+            if stdin_mode and effective_rev2 != STDIN:
+                raise ValueError(
+                    f"With --stdin-filename, rev2 in {revision_range} must be"
+                    f" {STDIN!r}, not {effective_rev2!r}"
+                )
+            return (rev1 or "HEAD", rev2 or default_rev2, use_common_ancestor)
+        return (
+            revision_range or "HEAD",
+            default_rev2,
+            revision_range not in ["", "HEAD"],
+        )
 
     @classmethod
     def _with_common_ancestor(cls, rev1: str, rev2: str, cwd: Path) -> "RevisionRange":
         """Find common ancestor for revisions and return a ``RevisionRange`` object"""
-        rev2_for_merge_base = "HEAD" if rev2 == WORKTREE else rev2
+        rev2_for_merge_base = "HEAD" if rev2 in [WORKTREE, STDIN] else rev2
         merge_base_cmd = ["merge-base", rev1, rev2_for_merge_base]
         common_ancestor = _git_check_output_lines(merge_base_cmd, cwd)[0]
         rev1_hash = _git_check_output_lines(["show", "-s", "--pretty=%H", rev1], cwd)[0]

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -50,13 +50,14 @@ DESCRIPTION = "".join(DESCRIPTION_PARTS)
 SRC = "Path(s) to the Python source file(s) to reformat"
 
 REVISION = (
-    "Git revision against which to compare the working tree. Tags, branch names, commit"
-    " hashes, and other expressions like `HEAD~5` work here. Also a range like"
-    " `master...HEAD` or `master...` can be used to compare the best common ancestor."
-    " With the magic value `:PRE-COMMIT:`, Darker works in pre-commit compatible mode."
-    " Darker expects the revision range from the `PRE_COMMIT_FROM_REF` and"
-    " `PRE_COMMIT_TO_REF` environment variables. If those are not found, Darker works"
-    " against `HEAD`."
+    "Revisions to compare. The default is `HEAD..:WORKTREE:` which compares the latest"
+    " commit to the working tree. Tags, branch names, commit hashes, and other"
+    " expressions like `HEAD~5` work here. Also a range like `main...HEAD` or `main...`"
+    " can be used to compare the best common ancestor. With the magic value"
+    " `:PRE-COMMIT:`, Darker works in pre-commit compatible mode. Darker expects the"
+    " revision range from the `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF` environment"
+    " variables. If those are not found, Darker works against `HEAD`. Also see"
+    " `--stdin-filename=` for the `:STDIN:` special value."
 )
 
 DIFF = (
@@ -75,6 +76,12 @@ STDOUT = (
     "Force complete reformatted output to stdout, instead of in-place. Only valid if"
     " there's just one file to reformat. Highlight syntax if on a terminal and the"
     " `pygments` package is available, or if enabled by configuration."
+)
+
+STDIN_FILENAME = (
+    "The path to the file when passing it through stdin. Useful so Darker can find the"
+    " previous version from Git. Only valid with `--revision=<rev1>..:STDIN:`"
+    " (`HEAD..:STDIN:` being the default if `--stdin-filename` is enabled)."
 )
 
 FLYNT_PARTS = [

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -44,6 +44,7 @@ from typing import (
 
 from darker.diff import map_unmodified_lines
 from darker.git import (
+    STDIN,
     WORKTREE,
     RevisionRange,
     git_clone_local,
@@ -382,11 +383,16 @@ def run_linters(
     :param paths: The files and directories to check, relative to ``root``
     :param revrange: The Git revisions to compare
     :param use_color: ``True`` to use syntax highlighting for linter output
+    :raises NotImplementedError: if ``--stdin-filename`` is used
     :return: Total number of linting errors found on modified lines
 
     """
     if not linter_cmdlines:
         return 0
+    if revrange.rev2 == STDIN:
+        raise NotImplementedError(
+            "The -l/--lint option isn't yet available with --stdin-filename"
+        )
     _require_rev2_worktree(revrange.rev2)
     git_root = git_get_root(root)
     if not git_root:

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -96,29 +96,80 @@ def test_output_mode_validate_diff_stdout(diff, stdout, expect):
 
 
 @pytest.mark.kwparametrize(
-    dict(stdout=False, src=[], expect=None),
-    dict(stdout=False, src=["first.py"], expect=None),
-    dict(stdout=False, src=["first.py", "second.py"], expect=None),
-    dict(stdout=False, src=["first.py", "missing.py"], expect=None),
-    dict(stdout=False, src=["missing.py"], expect=None),
-    dict(stdout=False, src=["missing.py", "another_missing.py"], expect=None),
-    dict(stdout=False, src=["directory"], expect=None),
-    dict(stdout=True, src=[], expect=ConfigurationError),
-    dict(stdout=True, src=["first.py"], expect=None),
+    dict(stdout=False),
+    dict(stdout=False, src=["first.py"]),
+    dict(stdout=False, src=["first.py", "second.py"]),
+    dict(stdout=False, src=["first.py", "missing.py"]),
+    dict(stdout=False, src=["missing.py"]),
+    dict(stdout=False, src=["missing.py", "another_missing.py"]),
+    dict(stdout=False, src=["directory"]),
+    dict(stdout=True, expect=ConfigurationError),
+    dict(stdout=True, src=["first.py"]),
     dict(stdout=True, src=["first.py", "second.py"], expect=ConfigurationError),
     dict(stdout=True, src=["first.py", "missing.py"], expect=ConfigurationError),
     dict(stdout=True, src=["missing.py"], expect=ConfigurationError),
     dict(stdout=True, src=["missing.py", "another.py"], expect=ConfigurationError),
     dict(stdout=True, src=["directory"], expect=ConfigurationError),
+    dict(stdout=False, stdin_filename="path.py"),
+    dict(stdout=False, src=["first.py"], stdin_filename="path.py"),
+    dict(stdout=False, src=["first.py", "second.py"], stdin_filename="path.py"),
+    dict(stdout=False, src=["first.py", "missing.py"], stdin_filename="path.py"),
+    dict(stdout=False, src=["missing.py"], stdin_filename="path.py"),
+    dict(
+        stdout=False, src=["missing.py", "another_missing.py"], stdin_filename="path.py"
+    ),
+    dict(stdout=False, src=["directory"], stdin_filename="path.py"),
+    dict(stdout=True, stdin_filename="path.py"),
+    dict(
+        stdout=True,
+        src=["first.py"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    dict(
+        stdout=True,
+        src=["first.py", "second.py"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    dict(
+        stdout=True,
+        src=["first.py", "missing.py"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    dict(
+        stdout=True,
+        src=["missing.py"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    dict(
+        stdout=True,
+        src=["missing.py", "another.py"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    dict(
+        stdout=True,
+        src=["directory"],
+        stdin_filename="path.py",
+        expect=ConfigurationError,
+    ),
+    src=[],
+    stdin_filename=None,
+    expect=None,
 )
-def test_output_mode_validate_stdout_src(tmp_path, monkeypatch, stdout, expect, src):
+def test_output_mode_validate_stdout_src(
+    tmp_path, monkeypatch, stdout, src, stdin_filename, expect
+):
     """Validation fails only if exactly one file isn't provided for ``--stdout``"""
     monkeypatch.chdir(tmp_path)
     Path("first.py").touch()
     Path("second.py").touch()
     with raises_if_exception(expect):
 
-        OutputMode.validate_stdout_src(stdout, src)
+        OutputMode.validate_stdout_src(stdout, src, stdin_filename)
 
 
 @pytest.mark.kwparametrize(

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -103,13 +103,23 @@ def test_output_mode_validate_diff_stdout(diff, stdout, expect):
     dict(stdout=False, src=["missing.py"]),
     dict(stdout=False, src=["missing.py", "another_missing.py"]),
     dict(stdout=False, src=["directory"]),
-    dict(stdout=True, expect=ConfigurationError),
+    dict(stdout=True, expect=ConfigurationError),  # input file missing
     dict(stdout=True, src=["first.py"]),
-    dict(stdout=True, src=["first.py", "second.py"], expect=ConfigurationError),
-    dict(stdout=True, src=["first.py", "missing.py"], expect=ConfigurationError),
-    dict(stdout=True, src=["missing.py"], expect=ConfigurationError),
-    dict(stdout=True, src=["missing.py", "another.py"], expect=ConfigurationError),
-    dict(stdout=True, src=["directory"], expect=ConfigurationError),
+    dict(  # too many input files
+        stdout=True, src=["first.py", "second.py"], expect=ConfigurationError
+    ),
+    dict(  # too many input files (even if all but one missing)
+        stdout=True, src=["first.py", "missing.py"], expect=ConfigurationError
+    ),
+    dict(  # input file doesn't exist
+        stdout=True, src=["missing.py"], expect=ConfigurationError
+    ),
+    dict(  # too many input files (even if all but one missing)
+        stdout=True, src=["missing.py", "another.py"], expect=ConfigurationError
+    ),
+    dict(  # input file required, not a directory
+        stdout=True, src=["directory"], expect=ConfigurationError
+    ),
     dict(stdout=False, stdin_filename="path.py"),
     dict(stdout=False, src=["first.py"], stdin_filename="path.py"),
     dict(stdout=False, src=["first.py", "second.py"], stdin_filename="path.py"),
@@ -120,37 +130,37 @@ def test_output_mode_validate_diff_stdout(diff, stdout, expect):
     ),
     dict(stdout=False, src=["directory"], stdin_filename="path.py"),
     dict(stdout=True, stdin_filename="path.py"),
-    dict(
+    dict(  # too many input files, here from two different command line arguments
         stdout=True,
         src=["first.py"],
         stdin_filename="path.py",
         expect=ConfigurationError,
     ),
-    dict(
+    dict(  # too many input files, here from two different command line arguments
         stdout=True,
         src=["first.py", "second.py"],
         stdin_filename="path.py",
         expect=ConfigurationError,
     ),
-    dict(
+    dict(  # too many input files, here from two different command line arguments
         stdout=True,
         src=["first.py", "missing.py"],
         stdin_filename="path.py",
         expect=ConfigurationError,
     ),
-    dict(
+    dict(  # too many input files (even if positional file is missing)
         stdout=True,
         src=["missing.py"],
         stdin_filename="path.py",
         expect=ConfigurationError,
     ),
-    dict(
+    dict(  # too many input files, here from two different command line arguments
         stdout=True,
         src=["missing.py", "another.py"],
         stdin_filename="path.py",
         expect=ConfigurationError,
     ),
-    dict(
+    dict(  # too many input files, here from two different command line arguments
         stdout=True,
         src=["directory"],
         stdin_filename="path.py",

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -338,7 +338,9 @@ def test_run_linters_non_worktree():
             ["dummy-linter"],
             Path("/dummy"),
             {Path("dummy.py")},
-            RevisionRange.parse_with_common_ancestor("..HEAD", Path("dummy cwd")),
+            RevisionRange.parse_with_common_ancestor(
+                "..HEAD", Path("dummy cwd"), stdin_mode=False
+            ),
             use_color=False,
         )
 

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -433,6 +433,23 @@ def test_run_linters_line_separation(git_repo, capsys):
     )
 
 
+def test_run_linters_stdin():
+    """`linting.run_linters` raises a `NotImplementeError` on ``--stdin-filename``"""
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^The -l/--lint option isn't yet available with --stdin-filename$",
+    ):
+        # end of test setup
+
+        _ = linting.run_linters(
+            ["dummy-linter-command"],
+            Path("/dummy-dir"),
+            {Path("dummy.py")},
+            RevisionRange("HEAD", ":STDIN:"),
+            use_color=False,
+        )
+
+
 def _build_messages(
     lines_and_messages: Iterable[Union[Tuple[int, str], Tuple[int, str, str]]],
 ) -> Dict[MessageLocation, List[LinterMessage]]:

--- a/src/darker/tests/test_main_blacken_and_flynt_single_file.py
+++ b/src/darker/tests/test_main_blacken_and_flynt_single_file.py
@@ -128,16 +128,16 @@ def test_blacken_and_flynt_single_file_common_ancestor(git_repo):
     git_repo.create_branch("feature", initial)
     git_repo.add({"a.py": a_py_feature}, commit="on feature")
     worktree = TextDocument.from_str(a_py_worktree)
+    revrange = RevisionRange.parse_with_common_ancestor(
+        "master...", git_repo.root, stdin_mode=False
+    )
 
     result = _blacken_and_flynt_single_file(
         git_repo.root,
         Path("a.py"),
         Path("a.py"),
         Exclusions(),
-        EditedLinenumsDiffer(
-            git_repo.root,
-            RevisionRange.parse_with_common_ancestor("master...", git_repo.root),
-        ),
+        EditedLinenumsDiffer(git_repo.root, revrange),
         rev2_content=worktree,
         rev2_isorted=worktree,
         has_isort_changes=False,
@@ -187,16 +187,16 @@ def test_reformat_single_file_docstring(git_repo):
     )
     paths = git_repo.add({"a.py": initial}, commit="Initial commit")
     paths["a.py"].write_text(modified)
+    revrange = RevisionRange.parse_with_common_ancestor(
+        "HEAD..", git_repo.root, stdin_mode=False
+    )
 
     result = _blacken_and_flynt_single_file(
         git_repo.root,
         Path("a.py"),
         Path("a.py"),
         Exclusions(),
-        EditedLinenumsDiffer(
-            git_repo.root,
-            RevisionRange.parse_with_common_ancestor("HEAD..", git_repo.root),
-        ),
+        EditedLinenumsDiffer(git_repo.root, revrange),
         rev2_content=TextDocument.from_str(modified),
         rev2_isorted=TextDocument.from_str(modified),
         has_isort_changes=False,

--- a/src/darker/tests/test_main_stdin_filename.py
+++ b/src/darker/tests/test_main_stdin_filename.py
@@ -1,0 +1,164 @@
+"""Tests for `darker.__main__.main` and the ``--stdin-filename`` option"""
+
+# pylint: disable=too-many-arguments,use-dict-literal
+
+from io import BytesIO
+from typing import List, Optional
+from unittest.mock import Mock, patch
+
+import pytest
+import toml
+
+import darker.__main__
+from darker.config import ConfigurationError
+from darker.tests.conftest import GitRepoFixture
+from darker.tests.helpers import raises_if_exception
+
+pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
+
+
+@pytest.mark.kwparametrize(
+    dict(expect=SystemExit(2)),
+    dict(config_src=["a.py"], expect_a_py='modified = "a.py worktree"\n'),
+    dict(config_src=["b.py"], src=["a.py"], expect_a_py='modified = "a.py worktree"\n'),
+    dict(
+        config_src=["b.py"],
+        stdin_filename=["a.py"],
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(config_src=["a.py"], revision="..:STDIN:", expect_a_py='modified = "stdin"\n'),
+    dict(
+        config_src=["a.py"],
+        revision="..:WORKTREE:",
+        expect_a_py='modified = "a.py worktree"\n',
+    ),
+    dict(
+        config_src=["b.py"],
+        src=["a.py"],
+        stdin_filename="a.py",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(
+        config_src=["b.py"],
+        src=["a.py"],
+        revision="..:STDIN:",
+        expect_a_py='modified = "stdin"\n',
+    ),
+    dict(
+        config_src=["b.py"],
+        src=["a.py"],
+        revision="..:WORKTREE:",
+        expect_a_py='modified = "a.py worktree"\n',
+    ),
+    dict(
+        config_src=["b.py"],
+        src=["a.py"],
+        stdin_filename="a.py",
+        revision="..:STDIN:",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(
+        config_src=["b.py"],
+        src=["a.py"],
+        stdin_filename="a.py",
+        revision="..:WORKTREE:",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(src=["a.py"], expect_a_py='modified = "a.py worktree"\n'),
+    dict(
+        src=["a.py"],
+        stdin_filename="a.py",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(
+        src=["a.py"],
+        revision="..:STDIN:",
+        expect_a_py='modified = "stdin"\n',
+    ),
+    dict(
+        src=["a.py"],
+        revision="..:WORKTREE:",
+        expect_a_py='modified = "a.py worktree"\n',
+    ),
+    dict(
+        src=["a.py"],
+        stdin_filename="a.py",
+        revision="..:STDIN:",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(
+        src=["a.py"],
+        stdin_filename="a.py",
+        revision="..:WORKTREE:",
+        expect=ConfigurationError(
+            "No Python source files are allowed when using the `stdin-filename` option"
+        ),
+    ),
+    dict(stdin_filename="a.py", expect_a_py='modified = "stdin"\n'),
+    dict(
+        stdin_filename="a.py", revision="..:STDIN:", expect_a_py='modified = "stdin"\n'
+    ),
+    dict(
+        stdin_filename="a.py",
+        revision="..:WORKTREE:",
+        expect=ValueError(
+            "With --stdin-filename, rev2 in ..:WORKTREE: must be ':STDIN:', not"
+            " ':WORKTREE:'"
+        ),
+    ),
+    dict(revision="..:STDIN:", expect=SystemExit(2)),
+    dict(revision="..:WORKTREE:", expect=SystemExit(2)),
+    config_src=None,
+    src=[],
+    stdin_filename=None,
+    revision=None,
+    expect=0,
+    expect_a_py="original\n",
+)
+def test_main_stdin_filename(
+    git_repo: GitRepoFixture,
+    config_src: Optional[List[str]],
+    src: List[str],
+    stdin_filename: Optional[str],
+    revision: Optional[str],
+    expect: int,
+    expect_a_py: str,
+) -> None:
+    """Tests for `darker.__main__.main` and the ``--stdin-filename`` option"""
+    if config_src is not None:
+        configuration = {"tool": {"darker": {"src": config_src}}}
+        git_repo.add({"pyproject.toml": toml.dumps(configuration)})
+    paths = git_repo.add(
+        {"a.py": "original\n", "b.py": "original\n"}, commit="Initial commit"
+    )
+    paths["a.py"].write_text("modified  = 'a.py worktree'")
+    paths["b.py"].write_text("modified  = 'b.py worktree'")
+    arguments = src[:]
+    if stdin_filename is not None:
+        arguments.insert(0, f"--stdin-filename={stdin_filename}")
+    if revision is not None:
+        arguments.insert(0, f"--revision={revision}")
+    with patch.object(
+        darker.__main__.sys,  # type: ignore[attr-defined]
+        "stdin",
+        Mock(buffer=BytesIO(b"modified  = 'stdin'")),
+    ), raises_if_exception(expect):
+        # end of test setup
+
+        retval = darker.__main__.main(arguments)
+
+        assert retval == expect
+        assert paths["a.py"].read_text() == expect_a_py
+        assert paths["b.py"].read_text() == "modified  = 'b.py worktree'"


### PR DESCRIPTION
Fixes #239.

- [x] Design decision: `--stdin-filename` vs. ~~unique file in the `src` argument with an `--stdin` option~~ (see [discussion in #239](https://github.com/akaihola/darker/issues/239#issuecomment-1049739494))
  - [x] Add `--stdin-filename` command line argument, or
  - [x] ~~Ensure unique file in `src`~~
- [x] Ensure `rev2 == ":WORKTREE:"`
- [x] Ensure no positional file arguments
- [x] Read `stdin` instead of file
- [x] Raise `NotImplementedError` if both `--stdin-filename` and `--lint` are used (we may fix this later)
- [x] Make `HEAD..:STDIN:` the default if `--stdin-filename` is used
- [x] Merge #393
- [x] Improve `--revision` description in `--help`
- [x] Update `--help` in `README.rst`
- [x] Change log
- [x] Tests
  - [x] all 8 combinations of existence of `src =` config option, path/directory on command line, and `--stdin-filename`