### PR TITLE
Upgrade to `mypy==0.940`

### DIFF
--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -11,7 +11,7 @@ defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11
 flake8-comprehensions==3.7.0
-mypy==0.931
+mypy==0.940
 pytest==6.1.0
 pytest-flake8==1.0.6
 pytest-isort==1.1.0

--- a/release_tools/update_contributors.py
+++ b/release_tools/update_contributors.py
@@ -135,7 +135,7 @@ def verify() -> None:
                 raise AssertionError((username, path, contribution_type))
             contributions.append({"type": contribution_type, "link_type": link_type})
         users[username] = contributions
-    click.echo(yaml.dump(users))  # type: ignore[attr-defined]
+    click.echo(yaml.dump(users))
 
 
 CONTRIBUTION_SYMBOLS = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ test =
     flake8-2020>=1.6.1
     flake8-bugbear>=22.1.11
     flake8-comprehensions>=3.7.0
-    mypy>=0.931
+    mypy>=0.940
     pygments
     pylint
     pytest>=6.1.0


### PR DESCRIPTION
`# type: ignore[attr-defined]` must be removed from `click.echo(yaml.dump(users))` when upgrading.