### PR TITLE
Handle files not encoded with UTF-8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Added
 Fixed
 -----
 - Avoid memory leak from using ``@lru_cache`` on a method.
+- Handle files encoded with an encoding other than UTF-8 without an exception.
 
 
 1.4.2_ - 2022-03-12

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -25,6 +25,7 @@
 - Eric Riddoch (@phitoduck)
 - Filippos Giannakos (@philipgian)
 - Fox_white (@foxwhite25)
+- Georges Discry (@gdiscry)
 - Giel van Schijndel (@muggenhor)
 - Hugo Dupras (@jabesq)
 - Iryna (@irynahryshanovich)

--- a/README.rst
+++ b/README.rst
@@ -978,6 +978,17 @@ Thanks goes to these wonderful people (`emoji key`_):
          <a href="https://github.com/akaihola/darker/search?q=foxwhite25" title="Bug reports">🐛</a>
        </td>
        <td align="center">
+         <a href="https://github.com/gdiscry">
+           <img src="https://avatars.githubusercontent.com/u/476823?v=3" width="100px;" alt="@gdiscry" />
+           <br />
+           <sub>
+             <b>Georges Discry</b>
+           </sub>
+         </a>
+         <br />
+         <a href="https://github.com/akaihola/darker/pulls?q=is%3Apr+author%3Agdiscry" title="Code">💻</a>
+       </td>
+       <td align="center">
          <a href="https://github.com/muggenhor">
            <img src="https://avatars.githubusercontent.com/u/484066?v=3" width="100px;" alt="@muggenhor" />
            <br />
@@ -1011,6 +1022,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Airynahryshanovich" title="Bug reports">🐛</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/jasleen19">
            <img src="https://avatars.githubusercontent.com/u/30443449?v=3" width="100px;" alt="@jasleen19" />
@@ -1023,8 +1036,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          <a href="https://github.com/akaihola/darker/issues?q=author%3Ajasleen19" title="Bug reports">🐛</a>
          <a href="https://github.com/akaihola/darker/pulls?q=is%3Apr+reviewed-by%3Ajasleen19" title="Reviewed Pull Requests">👀</a>
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/jedie">
            <img src="https://avatars.githubusercontent.com/u/71315?v=3" width="100px;" alt="@jedie" />
@@ -1080,6 +1091,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Amagnunm" title="Bug reports">🐛</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/markddavidoff">
            <img src="https://avatars.githubusercontent.com/u/1360543?v=3" width="100px;" alt="@markddavidoff" />
@@ -1091,8 +1104,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Amarkddavidoff" title="Bug reports">🐛</a>
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/matclayton">
            <img src="https://avatars.githubusercontent.com/u/126218?v=3" width="100px;" alt="@matclayton" />
@@ -1153,6 +1164,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <a href="https://github.com/akaihola/darker/issues?q=author%3Anjhuffman" title="Bug reports">🐛</a>
          <a href="https://github.com/akaihola/darker/commits?author=njhuffman" title="Code">💻</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/CircleOnCircles">
            <img src="https://avatars.githubusercontent.com/u/8089231?v=3" width="100px;" alt="@CircleOnCircles" />
@@ -1164,8 +1177,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3ACircleOnCircles" title="Bug reports">🐛</a>
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/Pacu2">
            <img src="https://avatars.githubusercontent.com/u/21290461?v=3" width="100px;" alt="@Pacu2" />
@@ -1224,6 +1235,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Aroniemartinez" title="Bug reports">🐛</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/rossbar">
            <img src="https://avatars.githubusercontent.com/u/1268991?v=3" width="100px;" alt="@rossbar" />
@@ -1235,8 +1248,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Arossbar" title="Bug reports">🐛</a>
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/sherbie">
            <img src="https://avatars.githubusercontent.com/u/15087653?v=3" width="100px;" alt="@sherbie" />
@@ -1292,6 +1303,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Aguettli" title="Bug reports">🐛</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/tobiasdiez">
            <img src="https://avatars.githubusercontent.com/u/5037600?v=3" width="100px;" alt="@tobiasdiez" />
@@ -1302,8 +1315,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          </a>
          <br />
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/yoursvivek">
            <img src="https://avatars.githubusercontent.com/u/163296?v=3" width="100px;" alt="@yoursvivek" />
@@ -1362,6 +1373,8 @@ Thanks goes to these wonderful people (`emoji key`_):
          <a href="https://github.com/conda-forge/staged-recipes/search?q=darker&type=issues&author=martinRenou" title="Code">💻</a>
          <a href="https://github.com/akaihola/darker/pulls?q=is%3Apr+reviewed-by%3AmartinRenou" title="Reviewed Pull Requests">👀</a>
        </td>
+     </tr>
+     <tr>
        <td align="center">
          <a href="https://github.com/mayk0gan">
            <img src="https://avatars.githubusercontent.com/u/96263702?v=3" width="100px;" alt="@mayk0gan" />
@@ -1373,8 +1386,6 @@ Thanks goes to these wonderful people (`emoji key`_):
          <br />
          <a href="https://github.com/akaihola/darker/issues?q=author%3Amayk0gan" title="Bug reports">🐛</a>
        </td>
-     </tr>
-     <tr>
        <td align="center">
          <a href="https://github.com/overratedpro">
            <img src="https://avatars.githubusercontent.com/u/1379994?v=3" width="100px;" alt="@overratedpro" />

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -58,6 +58,8 @@ flying-sheep:
   - {link_type: issues, type: Bug reports}
 foxwhite25:
   - {link_type: search, type: Bug reports}
+gdiscry:
+  - {link_type: pulls-author, type: Code}
 guettli:
   - {link_type: issues, type: Bug reports}
 hauntsaninja:

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -3,7 +3,7 @@
 import os
 from pathlib import Path
 from subprocess import check_call  # nosec
-from typing import Dict, Optional
+from typing import Dict, Union
 
 import pytest
 from black import find_project_root as black_find_project_root
@@ -39,7 +39,7 @@ class GitRepoFixture:
         return _git_check_output_lines(list(args), Path(self.root))[0]
 
     def add(
-        self, paths_and_contents: Dict[str, Optional[str]], commit: str = None
+        self, paths_and_contents: Dict[str, Union[str, bytes, None]], commit: str = None
     ) -> Dict[str, Path]:
         """Add/remove/modify files and optionally commit the changes
 
@@ -58,10 +58,12 @@ class GitRepoFixture:
             path = absolute_paths[relative_path]
             if content is None:
                 self._run("rm", "--", relative_path)
-            else:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_bytes(content.encode("utf-8"))
-                self._run("add", "--", relative_path)
+                continue
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+            self._run("add", "--", relative_path)
         if commit:
             self._run("commit", "-m", commit)
         return absolute_paths

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -25,7 +25,7 @@ class GitRepoFixture:
         env = {"HOME": str(root), "LC_ALL": "C", "PATH": os.environ["PATH"]}
         instance = cls(root, env)
         # pylint: disable=protected-access
-        instance._run("init")
+        instance._run("init", "--initial-branch=master")
         instance._run("config", "user.email", "ci@example.com")
         instance._run("config", "user.name", "CI system")
         return instance


### PR DESCRIPTION
Black can format files encoded with an encoding other than UTF-8, based on the encoding cookie present in the first two lines. Darker is also supposed to format those files, but an exception is raised instead.

The exception happens because all the output from git is decoded with UTF-8, including calls to `git show <revision>:<path>` that returns the binary content of a file from the history. If a file used an encoding other than UTF-8, the decoding fails.

I introduce `TextDocument.from_bytes()` to create a `TextDocument` from the raw binary content of a file, automatically detecting the encoding used, and use this new factory when loading a file from disk or from a revision in the git history.