### PR TITLE
Fix bandit reporting in GitHub Workflows by using my own branch of the action

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -11,13 +11,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Bandit security check for code
-        uses: ioggstream/bandit-report-artifacts@v0.0.2
+        uses: akaihola/bandit-report-artifacts@use-config
         with:
           project_path: .
           config_file: ./.bandit.code.yaml
 
       - name: Bandit security check for tests
-        uses: ioggstream/bandit-report-artifacts@v0.0.2
+        uses: akaihola/bandit-report-artifacts@use-config
         with:
           project_path: ./src/darker/tests
           config_file: ./.bandit.tests.yaml


### PR DESCRIPTION
In the [akaihola/bandit-report-artifacts@use-config](https://github.com/akaihola/bandit-report-artifacts/commits/use-config) branch (see ioggstream/bandit-report-artifacts#8), the second `bandit` call from inside `main.py` now uses the configuration file as well. Annotations should now match the check status when looking at GitHub Workflow results.