### PR TITLE
Allow constraining linter versions in GitHub Action configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Added
 -----
 - The ``--jobs`` option now specifies how many Darker jobs are used to process files in
   parallel to complete reformatting/linting faster.
-- Linters can now be run in the GitHub Action using the ``lint:`` option.
+- Linters can now be installed and run in the GitHub Action using the ``lint:`` option.
   
 Fixed
 -----

--- a/README.rst
+++ b/README.rst
@@ -575,7 +575,7 @@ Create a file named ``.github/workflows/darker.yml`` inside your repository with
              revision: "master..."
              src: "./src"
              version: "1.4.2"
-             lint: "flake8,pylint"
+             lint: "flake8,pylint==2.13.1"
 
 There needs to be a working Python environment, set up using ``actions/setup-python``
 in the above example. Darker will be installed in an isolated virtualenv to prevent
@@ -603,6 +603,7 @@ You can e.g. add ``"--isort"`` to sort imports, or ``"--verbose"`` for debug log
 
 To run linters through Darker, you can provide a comma separated list of linters using
 the ``lint:`` option. Only ``flake8``, ``pylint`` and ``mypy`` are supported.
+Versions can be constrained using ``pip`` syntax, e.g. ``"flake8>=3.9.2"``.
 
 *New in version 1.1.0:*
 GitHub Actions integration. Modeled after how Black_ does it,

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   lint:
     description: >-
       Comma-separated list of linters to `pip install` and run from Darker.
-      Optionally, version constraints (using pip syntax) can be specifed.
+      Optionally, version constraints (using pip syntax) can be specified.
       Example: flake8,pylint==2.13.1
     required: false
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,8 @@ inputs:
   lint:
     description: >-
       Comma-separated list of linters to `pip install` and run from Darker.
-      Example: flake8,pylint
+      Optionally, version constraints (using pip syntax) can be specifed.
+      Example: flake8,pylint==2.13.1
     required: false
     default: ''
 branding:

--- a/action/tests/test_main.py
+++ b/action/tests/test_main.py
@@ -103,6 +103,10 @@ def test_creates_virtualenv(tmp_path, main_patch):
         run_main_env={"INPUT_LINT": "  flake8  ,  pylint  "},
         expect=["darker[isort]", "flake8", "pylint"],
     ),
+    dict(
+        run_main_env={"INPUT_LINT": "  flake8  >=  3.9.2  ,  pylint  ==  2.13.1  "},
+        expect=["darker[isort]", "flake8>=3.9.2", "pylint==2.13.1"],
+    ),
 )
 def test_installs_packages(tmp_path, main_patch, run_main_env, expect):
     """Darker, isort and linters are installed in the virtualenv using pip"""
@@ -126,7 +130,7 @@ def test_installs_packages(tmp_path, main_patch, run_main_env, expect):
 
 
 @pytest.mark.parametrize(
-    "linters", ["foo", "  foo  ", "foo,bar", "  foo  ,  bar  ", "pylint,foo"]
+    "linters", ["foo", "  foo  ", "foo==2.0,bar", "  foo>1.0  ,  bar  ", "pylint,foo"]
 )
 def test_wont_install_unknown_packages(tmp_path, linters):
     """Non-whitelisted linters raise an exception"""
@@ -171,6 +175,10 @@ def test_wont_install_unknown_packages(tmp_path, linters):
     ),
     dict(
         env={"INPUT_SRC": ".", "INPUT_LINT": "pylint,flake8"},
+        expect=["--lint", "pylint", "--lint", "flake8", "--revision", "HEAD^", "."],
+    ),
+    dict(
+        env={"INPUT_SRC": ".", "INPUT_LINT": "pylint == 2.13.1,flake8>=3.9.2"},
         expect=["--lint", "pylint", "--lint", "flake8", "--revision", "HEAD^", "."],
     ),
     dict(


### PR DESCRIPTION
Fixes #337. Being tested in akaihola/pgtricks#18.

Linter support was added in #313.