### PR TITLE
(action) fix getting revision and commit_range

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Fixed
 -----
 - Avoid memory leak from using ``@lru_cache`` on a method.
 - Handle files encoded with an encoding other than UTF-8 without an exception.
+- The GitHub Action now handles missing ``revision:`` correctly.
 
 
 1.4.2_ - 2022-03-12

--- a/action/main.py
+++ b/action/main.py
@@ -14,9 +14,13 @@ OPTIONS = os.getenv("INPUT_OPTIONS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 LINT = os.getenv("INPUT_LINT", default="")
-REVISION = os.getenv(
-    "INPUT_REVISION", default=os.getenv("INPUT_COMMIT_RANGE", default="HEAD^")
-)
+
+REVISION = os.getenv("INPUT_REVISION")
+COMMIT_RANGE = os.getenv("INPUT_COMMIT_RANGE")
+if not REVISION:
+    if not COMMIT_RANGE:
+        COMMIT_RANGE = "HEAD^"
+    REVISION = COMMIT_RANGE
 
 run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
 

--- a/action/main.py
+++ b/action/main.py
@@ -14,13 +14,7 @@ OPTIONS = os.getenv("INPUT_OPTIONS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 LINT = os.getenv("INPUT_LINT", default="")
-
-REVISION = os.getenv("INPUT_REVISION")
-COMMIT_RANGE = os.getenv("INPUT_COMMIT_RANGE")
-if not REVISION:
-    if not COMMIT_RANGE:
-        COMMIT_RANGE = "HEAD^"
-    REVISION = COMMIT_RANGE
+REVISION = os.getenv("INPUT_REVISION") or os.getenv("INPUT_COMMIT_RANGE") or "HEAD^"
 
 run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
 


### PR DESCRIPTION
`os.getenv` default is only used if key is not defined, not if the value resolves to False.