### PR TITLE
Support the `NO_COLOR` environment variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Added
 - Sort imports only if the range of modified lines overlaps with changes resulting from
   sorting the imports.
 - Allow force enabling/disabling of syntax highlighting using the ``color`` option in
-  ``pyproject.toml``, the ``PY_COLORS`` environment variable, and the
+  ``pyproject.toml``, the ``PY_COLORS`` and ``NO_COLOR`` environment variables, and the
   ``--color``/``--no-color`` command line options.
 - Syntax highlighting is now enabled by default in the GitHub Action.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Added
   ``pyproject.toml``, the ``PY_COLORS`` and ``NO_COLOR`` environment variables, and the
   ``--color``/``--no-color`` command line options.
 - Syntax highlighting is now enabled by default in the GitHub Action.
+- ``pytest>=6.2.0`` now required for the test suite due to type hinting issues.
 
 Fixed
 -----

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -13,7 +13,7 @@ flake8-bugbear==22.1.11
 flake8-comprehensions==3.7.0
 mypy==0.940
 Pygments==2.4.0
-pytest==6.1.0
+pytest==6.2.0
 pytest-flake8==1.0.6
 pytest-isort==1.1.0
 pytest-kwparametrize==0.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ test =
     mypy>=0.940
     pygments
     pylint
-    pytest>=6.1.0
+    pytest>=6.2.0
     pytest-darker
     pytest-flake8>=1.0.6
     pytest-isort>=1.1.0

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -106,11 +106,12 @@ def override_color_with_environment(pyproject_config: DarkerConfig) -> DarkerCon
     :return: The modified configuration
 
     """
-    py_colors = os.getenv("PY_COLORS")
-    if py_colors not in {"0", "1"}:
-        return pyproject_config
     config = pyproject_config.copy()
-    config["color"] = py_colors == "1"
+    py_colors = os.getenv("PY_COLORS")
+    if py_colors in {"0", "1"}:
+        config["color"] = py_colors == "1"
+    elif os.getenv("NO_COLOR"):
+        config["color"] = False
     return config
 
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -112,6 +112,8 @@ def override_color_with_environment(pyproject_config: DarkerConfig) -> DarkerCon
         config["color"] = py_colors == "1"
     elif os.getenv("NO_COLOR") is not None:
         config["color"] = False
+    elif os.getenv("FORCE_COLOR") is not None:
+        config["color"] = True
     return config
 
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -110,7 +110,7 @@ def override_color_with_environment(pyproject_config: DarkerConfig) -> DarkerCon
     py_colors = os.getenv("PY_COLORS")
     if py_colors in {"0", "1"}:
         config["color"] = py_colors == "1"
-    elif os.getenv("NO_COLOR"):
+    elif os.getenv("NO_COLOR") is not None:
         config["color"] = False
     return config
 

--- a/src/darker/tests/test_highlighting.py
+++ b/src/darker/tests/test_highlighting.py
@@ -7,7 +7,7 @@ import os
 import sys
 from pathlib import Path
 from shlex import shlex
-from typing import Dict, Generator, cast
+from typing import Dict, Generator
 from unittest.mock import patch
 
 import pytest
@@ -48,7 +48,7 @@ def clean_environ():
 
     """
     old = os.environ
-    os.environ = cast(os._Environ[str], old.copy())  # noqa: B003
+    os.environ = old.copy()  # type: ignore  # noqa: B003
     unset_our_env_vars()
 
     yield

--- a/src/darker/tests/test_highlighting.py
+++ b/src/darker/tests/test_highlighting.py
@@ -93,7 +93,7 @@ def _parse_environment_variables(definitions: str) -> Dict[str, str]:
     return dict(item.split("=") for item in shlex(definitions, punctuation_chars=" "))
 
 
-@pytest.fixture(params=["", "NO_COLOR=foo"])
+@pytest.fixture(params=["", "NO_COLOR=", "NO_COLOR=foo"])
 def env_no_color(request: SubRequest) -> Generator[Dict[str, str], None, None]:
     """Parametrized fixture for patching ``NO_COLOR``
 
@@ -257,6 +257,12 @@ def test_should_use_color_pygments_and_py_colors(
         ("color = false", "            ", "tty", "                          "),
         ("color = true ", "            ", "   ", "should_use_color() == True"),
         ("color = true ", "            ", "tty", "should_use_color() == True"),
+        ("             ", "NO_COLOR=   ", "   ", "                          "),
+        ("             ", "NO_COLOR=   ", "tty", "                          "),
+        ("color = false", "NO_COLOR=   ", "   ", "                          "),
+        ("color = false", "NO_COLOR=   ", "tty", "                          "),
+        ("color = true ", "NO_COLOR=   ", "   ", "                          "),
+        ("color = true ", "NO_COLOR=   ", "tty", "                          "),
         ("             ", "NO_COLOR=foo", "   ", "                          "),
         ("             ", "NO_COLOR=foo", "tty", "                          "),
         ("color = false", "NO_COLOR=foo", "   ", "                          "),


### PR DESCRIPTION
Setting `NO_COLOR` to any non-empty value will disable syntax highlighting even on terminal output. This overrides the `color = true` setting in `pyproject.toml`, but will be overridden by `PY_COLORS=1` or the `--color` command line option, if those are present.

Fixes #355.

Previously, #353 added a command line options, a `pyproject.toml` option and the `PY_COLORS` environment variable to for enabling/disabling syntax highlighting.

See [earlier discussion](https://github.com/akaihola/darker/pull/353#discussion_r846746769) in #353, and pypa/pip#10909, for the reasoning behind supporting both `NO_COLOR` and `PY_COLORS`.

- [x] decide whether it would make sense to support `FORCE_COLOR` as well (see [this comment](https://github.com/pypa/pip/issues/10909#issuecomment-1066153211) in pypa/pip)
- [x] add suppert for `FORCE_COLOR`
- [x] empty value of `NO_COLOR` and `FORCE_COLOR` should be considered as activating that option, similar to how Pytest works
- [x] tests
- [x] ensure fast performing tests
- [x] change log
- [x] code review
