### PR TITLE
Update `cachix/install-nix-action` to `v17`, downgrade to Python 3.9 on macOS Nix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,12 +32,16 @@ jobs:
           nix_path: nixpkgs=channel:nixos-21.11
       - name: Run tests in nix-shell
         run: |
-          nix-shell --pure --argstr pythonVersion ${{ matrix.python-version }} --run '
-            python -m venv venv
-            source venv/bin/activate
-            pip install -e '.[isort,test]'
-            pytest
-          ' ./default.nix
+          nix-shell \
+            --pure \
+            --argstr pythonVersion ${{ matrix.python-version }} \
+            --run '
+              python -m venv venv
+              source venv/bin/activate
+              pip install -e '.[isort,test]'
+              pytest
+            ' \
+            ./default.nix
 
   build:
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixos-21.11
       - name: Run tests in nix-shell

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+            python-version: python310
+          - os: macos-latest
+            python-version: python39
+            # see https://github.com/cachix/install-nix-action/issues/135
     steps:
       - uses: actions/checkout@v3
         with:
@@ -29,7 +32,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-21.11
       - name: Run tests in nix-shell
         run: |
-          nix-shell --pure --run '
+          nix-shell --pure --argstr pythonVersion ${{ matrix.python-version }} --run '
             python -m venv venv
             source venv/bin/activate
             pip install -e '.[isort,test]'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Fixed
 - Handle files encoded with an encoding other than UTF-8 without an exception.
 - The GitHub Action now handles missing ``revision:`` correctly.
 - Update ``cachix/install-nix-action`` to ``v17`` to fix macOS build error.
+- Downgrade Python from 3.10 to 3.9 in the macOS NixOS build on GitHub due to a build
+  error with Python 3.10.
 
 
 1.4.2_ - 2022-03-12

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Fixed
 - Avoid memory leak from using ``@lru_cache`` on a method.
 - Handle files encoded with an encoding other than UTF-8 without an exception.
 - The GitHub Action now handles missing ``revision:`` correctly.
+- Update ``cachix/install-nix-action`` to ``v17`` to fix macOS build error.
 
 
 1.4.2_ - 2022-03-12

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,7 @@
-with import <nixpkgs> {};
-stdenv.mkDerivation {
+{ pkgs ? import <nixpkgs> { }, pythonVersion ? "python310" }:
+(
+  pkgs.stdenv.mkDerivation {
     name = "darker-test";
-    buildInputs = [ python310 git ];
-}
+    buildInputs = [ pkgs.${pythonVersion} pkgs.git ];
+  }
+)


### PR DESCRIPTION
Fixes macOS build error (see e.g. [`text-nixos (macos-latest)` in build #1248](https://github.com/akaihola/darker/runs/5994916141)).