### PR TITLE
Use `-c PATH`/`--config PATH` for Darker config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Fixed
 - Update ``cachix/install-nix-action`` to ``v17`` to fix macOS build error.
 - Downgrade Python from 3.10 to 3.9 in the macOS NixOS build on GitHub due to a build
   error with Python 3.10.
+- Darker now reads its own configuration from the file specified using
+  ``-c``/``--config``, or in case a directory is specified, from ``pyproject.toml``
+  inside that directory.
 
 
 1.4.2_ - 2022-03-12

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -108,7 +108,7 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
 
     # 2. Locate `pyproject.toml` based on those paths, or in the current directory if no
     #    paths were given. Load Darker configuration from it.
-    pyproject_config = load_config(args.src)
+    pyproject_config = load_config(args.config, args.src)
     config = override_color_with_environment(pyproject_config)
 
     # 3. Use configuration as defaults for re-parsing command line arguments, and don't

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -106,8 +106,9 @@ def parse_command_line(argv: List[str]) -> Tuple[Namespace, DarkerConfig, Darker
     parser_for_srcs = make_argument_parser(require_src=False)
     args = parser_for_srcs.parse_args(argv)
 
-    # 2. Locate `pyproject.toml` based on those paths, or in the current directory if no
-    #    paths were given. Load Darker configuration from it.
+    # 2. Locate `pyproject.toml` based on the `-c`/`--config` command line option, or
+    #    if it's not provided, based on the paths to process, or in the current
+    #    directory if no paths were given. Load Darker configuration from it.
     pyproject_config = load_config(args.config, args.src)
     config = override_color_with_environment(pyproject_config)
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -122,8 +122,15 @@ def load_config(path: Optional[str], srcs: Iterable[str]) -> DarkerConfig:
 
     """
     if path:
-        config_path = Path(path)
-        if not config_path.is_file():
+        for candidate_path in [Path(path), Path(path) / "pyproject.toml"]:
+            config_path = Path(candidate_path)
+            if config_path.is_file():
+                break
+        else:
+            if Path(path).is_dir() or path.endswith(os.sep):
+                raise ConfigurationError(
+                    f"Configuration file {Path(path) / 'pyproject.toml'} not found"
+                )
             raise ConfigurationError(f"Configuration file {path} not found")
     else:
         config_path = find_project_root(tuple(srcs or ["."])) / "pyproject.toml"

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -131,8 +131,8 @@ def load_config(path: Optional[str], srcs: Iterable[str]) -> DarkerConfig:
     """
     if path:
         for candidate_path in [Path(path), Path(path) / "pyproject.toml"]:
-            config_path = Path(candidate_path)
-            if config_path.is_file():
+            if candidate_path.is_file():
+                config_path = candidate_path
                 break
         else:
             if Path(path).is_dir() or path.endswith(os.sep):

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -130,7 +130,7 @@ def load_config(path: Optional[str], srcs: Iterable[str]) -> DarkerConfig:
 
     """
     if path:
-        for candidate_path in [Path(path), Path(path) / "pyproject.toml"]:
+        for candidate_path in [Path(path), Path(path, "pyproject.toml")]:
             if candidate_path.is_file():
                 config_path = candidate_path
                 break

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -115,10 +115,18 @@ def override_color_with_environment(pyproject_config: DarkerConfig) -> DarkerCon
 
 
 def load_config(path: Optional[str], srcs: Iterable[str]) -> DarkerConfig:
-    """Find and load Darker configuration from given path or pyproject.toml
+    """Find and load Darker configuration from a TOML configuration file
 
-    :param srcs: File(s) and directory/directories which will be processed. Their paths
-                 are used to look for the ``pyproject.toml`` configuration file.
+    Darker determines the location for the configuration file by trying the following:
+    - the file path in the `path` argument, given using the ``-c``/``--config`` command
+      line option
+    - ``pyproject.toml`` inside the directory specified by the `path` argument
+    - ``pyproject.toml`` from a common parent directory to all items in `srcs`
+    - ``pyproject.toml`` in the current working directory if `srcs` is empty
+
+    :param path: The file or directory specified using the ``-c``/``--config`` command
+                 line option, or `None` if the option was omitted.
+    :param srcs: File(s) and directory/directories to be processed by Darker.
 
     """
     if path:

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -137,7 +137,7 @@ def load_config(path: Optional[str], srcs: Iterable[str]) -> DarkerConfig:
         else:
             if Path(path).is_dir() or path.endswith(os.sep):
                 raise ConfigurationError(
-                    f"Configuration file {Path(path) / 'pyproject.toml'} not found"
+                    f"Configuration file {Path(path, 'pyproject.toml')} not found"
                 )
             raise ConfigurationError(f"Configuration file {path} not found")
     else:

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -92,6 +92,36 @@ def test_parse_command_line_config_src(
 
 
 @pytest.mark.kwparametrize(
+    dict(argv=["."], expect="pylint"),
+    dict(argv=["./subdir/"], expect="flake8"),
+    dict(argv=["--config", "./pyproject.toml", "."], expect="pylint"),
+    dict(argv=["--config", "./subdir/pyproject.toml", "."], expect="flake8"),
+    dict(argv=["--config", "./pyproject.toml", "subdir/"], expect="pylint"),
+    dict(argv=["--config", "./subdir/pyproject.toml", "subdir/"], expect="flake8"),
+)
+def test_parse_command_line_config_location_specified(
+    tmp_path,
+    monkeypatch,
+    argv,
+    expect,
+):
+    """Darker configuration is read from file pointed to using ``-c``/``--config``"""
+    monkeypatch.chdir(tmp_path)
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    root_config = tmp_path / "pyproject.toml"
+    subdir_config = subdir / "pyproject.toml"
+    root_config.write_text(toml.dumps({"tool": {"darker": {"lint": "pylint"}}}))
+    subdir_config.write_text(toml.dumps({"tool": {"darker": {"lint": "flake8"}}}))
+
+    args, effective_cfg, modified_cfg = parse_command_line(argv)
+
+    assert args.lint == expect
+    assert effective_cfg["lint"] == expect
+    assert modified_cfg["lint"] == expect
+
+
+@pytest.mark.kwparametrize(
     dict(
         argv=["."],
         expect_value=("src", ["."]),
@@ -375,6 +405,7 @@ def test_parse_command_line(
     """``parse_command_line()`` parses options correctly"""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "dummy.py").touch()
+    (tmp_path / "my.cfg").touch()
     with patch.dict(os.environ, environ, clear=True), raises_if_exception(
         expect_value
     ) as expect_exception:

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -243,6 +243,18 @@ def test_parse_command_line_config_location_specified(
         expect_modified=("config", "my.cfg"),
     ),
     dict(
+        argv=["-c", "subdir_with_config", "."],
+        expect_value=("config", "subdir_with_config"),
+        expect_config=("config", "subdir_with_config"),
+        expect_modified=("config", "subdir_with_config"),
+    ),
+    dict(
+        argv=["--config=subdir_with_config", "."],
+        expect_value=("config", "subdir_with_config"),
+        expect_config=("config", "subdir_with_config"),
+        expect_modified=("config", "subdir_with_config"),
+    ),
+    dict(
         argv=["."],
         expect_value=("log_level", 30),
         expect_config=("log_level", "WARNING"),
@@ -406,6 +418,8 @@ def test_parse_command_line(
     monkeypatch.chdir(tmp_path)
     (tmp_path / "dummy.py").touch()
     (tmp_path / "my.cfg").touch()
+    (tmp_path / "subdir_with_config").mkdir()
+    (tmp_path / "subdir_with_config" / "pyproject.toml").touch()
     with patch.dict(os.environ, environ, clear=True), raises_if_exception(
         expect_value
     ) as expect_exception:

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,3 +1,7 @@
+"""Tests for `darker.config`"""
+
+# pylint: disable=unused-argument
+
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from textwrap import dedent
@@ -130,42 +134,42 @@ def test_output_mode_from_args(diff, stdout, expect):
 
 @pytest.mark.kwparametrize(
     dict(),
-    dict(cwd="level1"),
-    dict(cwd="level1/level2"),
+    dict(cwd="lvl1"),
+    dict(cwd="lvl1/lvl2"),
     dict(cwd="has_git", expect={}),
-    dict(cwd="has_git/level1", expect={}),
-    dict(cwd="has_pyproject", expect={"CONFIG_PATH": "has_pyproject"}),
-    dict(cwd="has_pyproject/level1", expect={"CONFIG_PATH": "has_pyproject"}),
+    dict(cwd="has_git/lvl1", expect={}),
+    dict(cwd="has_pyp", expect={"CONFIG_PATH": "has_pyp"}),
+    dict(cwd="has_pyp/lvl1", expect={"CONFIG_PATH": "has_pyp"}),
     dict(srcs=["root.py"]),
-    dict(srcs=["../root.py"], cwd="level1"),
+    dict(srcs=["../root.py"], cwd="lvl1"),
     dict(srcs=["../root.py"], cwd="has_git"),
-    dict(srcs=["../root.py"], cwd="has_pyproject"),
-    dict(srcs=["root.py", "level1/level1.py"]),
-    dict(srcs=["../root.py", "level1.py"], cwd="level1"),
-    dict(srcs=["../root.py", "../level1/level1.py"], cwd="has_git"),
-    dict(srcs=["../root.py", "../level1/level1.py"], cwd="has_pyproject"),
-    dict(srcs=["has_pyproject/pyp.py", "level1/level1.py"]),
-    dict(srcs=["../has_pyproject/pyp.py", "level1.py"], cwd="level1"),
-    dict(srcs=["../has_pyproject/pyp.py", "../level1/level1.py"], cwd="has_git"),
-    dict(srcs=["pyp.py", "../level1/level1.py"], cwd="has_pyproject"),
+    dict(srcs=["../root.py"], cwd="has_pyp"),
+    dict(srcs=["root.py", "lvl1/lvl1.py"]),
+    dict(srcs=["../root.py", "lvl1.py"], cwd="lvl1"),
+    dict(srcs=["../root.py", "../lvl1/lvl1.py"], cwd="has_git"),
+    dict(srcs=["../root.py", "../lvl1/lvl1.py"], cwd="has_pyp"),
+    dict(srcs=["has_pyp/pyp.py", "lvl1/lvl1.py"]),
+    dict(srcs=["../has_pyp/pyp.py", "lvl1.py"], cwd="lvl1"),
+    dict(srcs=["../has_pyp/pyp.py", "../lvl1/lvl1.py"], cwd="has_git"),
+    dict(srcs=["pyp.py", "../lvl1/lvl1.py"], cwd="has_pyp"),
     dict(
-        srcs=["has_pyproject/level1/l1.py", "has_pyproject/level1b/l1b.py"],
-        expect={"CONFIG_PATH": "has_pyproject"},
+        srcs=["has_pyp/lvl1/l1.py", "has_pyp/lvl1b/l1b.py"],
+        expect={"CONFIG_PATH": "has_pyp"},
     ),
     dict(
-        srcs=["../has_pyproject/level1/l1.py", "../has_pyproject/level1b/l1b.py"],
-        cwd="level1",
-        expect={"CONFIG_PATH": "has_pyproject"},
+        srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
+        cwd="lvl1",
+        expect={"CONFIG_PATH": "has_pyp"},
     ),
     dict(
-        srcs=["../has_pyproject/level1/l1.py", "../has_pyproject/level1b/l1b.py"],
+        srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="has_git",
-        expect={"CONFIG_PATH": "has_pyproject"},
+        expect={"CONFIG_PATH": "has_pyp"},
     ),
     dict(
-        srcs=["level1/l1.py", "level1b/l1b.py"],
-        cwd="has_pyproject",
-        expect={"CONFIG_PATH": "has_pyproject"},
+        srcs=["lvl1/l1.py", "lvl1b/l1b.py"],
+        cwd="has_pyp",
+        expect={"CONFIG_PATH": "has_pyp"},
     ),
     dict(
         srcs=["full_example/full.py"],
@@ -179,25 +183,105 @@ def test_output_mode_from_args(diff, stdout, expect):
             "src": ["src", "tests"],
         },
     ),
+    dict(srcs=["stdout_example/dummy.py"], expect={"stdout": True}),
+    dict(confpath="c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="lvl1", confpath="../c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="lvl1/lvl2", confpath="../../c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="has_git", confpath="../c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="has_git/lvl1", confpath="../../c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="has_pyp", confpath="../c/p.toml", expect={"P_TOML": 1}),
+    dict(cwd="has_pyp/lvl1", confpath="../../c/p.toml", expect={"P_TOML": 1}),
+    dict(srcs=["root.py"], confpath="c/p.toml", expect={"P_TOML": 1}),
+    dict(srcs=["../root.py"], cwd="lvl1", confpath="../c/p.toml", expect={"P_TOML": 1}),
     dict(
-        srcs=["stdout_example/dummy.py"],
-        expect={"stdout": True},
+        srcs=["../root.py"], cwd="has_git", confpath="../c/p.toml", expect={"P_TOML": 1}
     ),
+    dict(
+        srcs=["../root.py"], cwd="has_pyp", confpath="../c/p.toml", expect={"P_TOML": 1}
+    ),
+    dict(srcs=["root.py", "lvl1/lvl1.py"], confpath="c/p.toml", expect={"P_TOML": 1}),
+    dict(
+        srcs=["../root.py", "lvl1.py"],
+        cwd="lvl1",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../root.py", "../lvl1/lvl1.py"],
+        cwd="has_git",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../root.py", "../lvl1/lvl1.py"],
+        cwd="has_pyp",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["has_pyp/pyp.py", "lvl1/lvl1.py"],
+        confpath="c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../has_pyp/pyp.py", "lvl1.py"],
+        cwd="lvl1",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../has_pyp/pyp.py", "../lvl1/lvl1.py"],
+        cwd="has_git",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["pyp.py", "../lvl1/lvl1.py"],
+        cwd="has_pyp",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["has_pyp/lvl1/l1.py", "has_pyp/lvl1b/l1b.py"],
+        confpath="c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
+        cwd="lvl1",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
+        cwd="has_git",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(
+        srcs=["lvl1/l1.py", "lvl1b/l1b.py"],
+        cwd="has_pyp",
+        confpath="../c/p.toml",
+        expect={"P_TOML": 1},
+    ),
+    dict(srcs=["full_example/full.py"], confpath="c/p.toml", expect={"P_TOML": 1}),
+    dict(srcs=["stdout_example/dummy.py"], confpath="c/p.toml", expect={"P_TOML": 1}),
     srcs=[],
     cwd=".",
+    confpath=None,
     expect={"CONFIG_PATH": "."},
 )
 def test_load_config(
-    find_project_root_cache_clear, tmp_path, monkeypatch, srcs, cwd, expect
+    find_project_root_cache_clear, tmp_path, monkeypatch, srcs, cwd, confpath, expect
 ):
     (tmp_path / ".git").mkdir()
     (tmp_path / "pyproject.toml").write_text('[tool.darker]\nCONFIG_PATH = "."\n')
-    (tmp_path / "level1/level2").mkdir(parents=True)
+    (tmp_path / "lvl1/lvl2").mkdir(parents=True)
     (tmp_path / "has_git/.git").mkdir(parents=True)
-    (tmp_path / "has_git/level1").mkdir()
-    (tmp_path / "has_pyproject/level1").mkdir(parents=True)
-    (tmp_path / "has_pyproject/pyproject.toml").write_text(
-        '[tool.darker]\nCONFIG_PATH = "has_pyproject"\n'
+    (tmp_path / "has_git/lvl1").mkdir()
+    (tmp_path / "has_pyp/lvl1").mkdir(parents=True)
+    (tmp_path / "has_pyp/pyproject.toml").write_text(
+        '[tool.darker]\nCONFIG_PATH = "has_pyp"\n'
     )
     (tmp_path / "full_example").mkdir()
     (tmp_path / "full_example/pyproject.toml").write_text(
@@ -225,11 +309,27 @@ def test_load_config(
     (tmp_path / "stdout_example/pyproject.toml").write_text(
         "[tool.darker]\nstdout = true\n"
     )
+    (tmp_path / "c").mkdir()
+    (tmp_path / "c" / "p.toml").write_text("[tool.darker]\nP_TOML = 1\n")
     monkeypatch.chdir(tmp_path / cwd)
 
-    result = load_config(srcs)
+    result = load_config(confpath, srcs)
 
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    "path",
+    [".", "./foo.toml", "subdir", "subdir/", "subdir/foo.toml", "missing_dir/foo.toml"],
+)
+def test_load_config_explicit_path_errors(tmp_path, monkeypatch, path):
+    """``load_config()`` raises an error if given path is not a file"""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "pyproject.toml").write_text("")
+    with pytest.raises(ConfigurationError, match=r"Configuration file .* not found"):
+
+        _ = load_config(path, ["."])
 
 
 @pytest.mark.kwparametrize(


### PR DESCRIPTION
Darker's own configuration is now read from the `PATH` TOML file when `-c PATH` or `--config PATH` is used.

Fixes #244 (partially).

- [x] accept file for `PATH`
- [x] unit tests for file as `PATH`
- [x] accept directory for `PATH`
- [x] unit tests for directory as `PATH`
- [x] change log
- [x] review