### PR TITLE
Fix `darker -r a..b .`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- ``darker --revision=a..b .`` now works since the repository root is now always
+  considered to have existed in all historical commits.
 
 
 1.5.0_ - 2022-04-23

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -271,6 +271,8 @@ def _git_exists_in_revision(path: Path, rev2: str, cwd: Path) -> bool:
              it doesn't.
 
     """
+    if (cwd / path).resolve() == cwd.resolve():
+        return True
     # Surprise: On Windows, `git cat-file` doesn't work with backslash directory
     # separators in paths. We need to use Posix paths and forward slashes instead.
     cmd = ["git", "cat-file", "-e", f"{rev2}:{path.as_posix()}"]

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -631,6 +631,21 @@ def test_main_historical(git_repo):
         darker.__main__.main(["--revision=foo..bar", "."])
 
 
+@pytest.mark.parametrize("arguments", [["--diff"], ["--check"], ["--diff", "--check"]])
+@pytest.mark.parametrize("src", [".", "foo/..", "{git_repo_root}"])
+def test_main_historical_ok(git_repo, arguments, src):
+    """Runs ok for repository root with rev2 specified and ``--diff`` or ``--check``"""
+    git_repo.add({"README": "first"}, commit="Initial commit")
+    initial = git_repo.get_hash()
+    git_repo.add({"README": "second"}, commit="Second commit")
+    second = git_repo.get_hash()
+
+    darker.__main__.main(
+        arguments
+        + [f"--revision={initial}..{second}", src.format(git_repo_root=git_repo.root)]
+    )
+
+
 def test_main_pre_commit_head(git_repo, monkeypatch):
     """Warn if run by pre-commit, rev2=HEAD and no ``--diff`` or ``--check`` provided"""
     git_repo.add({"a.py": "original = 1"}, commit="Add a.py")


### PR DESCRIPTION
The fix is to always consider the repository root to exist in all historical commits.

Fixes #362.