### PR TITLE
Fix various non-test build failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,7 +99,7 @@ Added
 -----
 - Experimental GitHub Actions integration
 - Consecutive lines of linter output are now separated by a blank line.
-- Highligh linter output if Pygments is installed.
+- Highlight linter output if Pygments is installed.
 - Allow running Darker on plain directories in addition to Git repositories.
 
 Fixed

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Fixed
 -----
 - ``darker --revision=a..b .`` now works since the repository root is now always
   considered to have existed in all historical commits.
+- Ignore linter lines which refer to files outside the common root of paths on the
+  command line. Fixes a failure when Pylint notifies about obsolete options in
+  ``.pylintrc``.
 
 
 1.5.0_ - 2022-04-23

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -54,7 +54,11 @@ def _parse_linter_line(line: str, root: Path) -> Tuple[Path, int, str, str]:
         logger.debug("Unparsable linter output: %s", line[:-1])
         return Path(), 0, "", ""
     path_from_cwd = Path(path_str).absolute()
-    path_in_repo = path_from_cwd.relative_to(root)
+    try:
+        path_in_repo = path_from_cwd.relative_to(root)
+    except ValueError as exc_info:
+        logger.debug("Unparsable linter output: %s (%s)", line[:-1], exc_info)
+        return Path(), 0, "", ""
     return path_in_repo, linenum, location + ":", description
 
 


### PR DESCRIPTION
**Ignore .pylintrc lines in Pylint output:** Pylint may notify about obsolete options in `.pylintrc`. Since that file is probably outside the common root directory of `.py` files listed on the Darker command line, it needs to be ignored to avoid errors.

**Fix a typo in `CHANGES.rst`:** this caused a test failure from `codespell`