### PR TITLE
Apply more granular changes by using `# fmt: skip`

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -204,7 +204,12 @@ def _blacken_single_file(  # pylint: disable=too-many-arguments,too-many-locals
     )
     for i, line in enumerate(rev2_isorted.lines):
         line_num = i + 1
-        if line_num not in modified_line_nums:
+        if (
+            line_num not in modified_line_nums
+            and not line.endswith("\\")
+            and not line.endswith('"')
+            and not line.endswith("'")
+        ):
             line = f"{line}  {FMT_DARKER_SKIP}"
         lines.append(line)
     rev2_isorted_decorated = TextDocument.from_lines(


### PR DESCRIPTION
Close https://github.com/akaihola/darker/issues/388

@akaihola What do you think of this solution? (NOTE: this won't work with nonstandard indentations)

**Before**

<img width="783" alt="image" src="https://user-images.githubusercontent.com/4310419/188326559-69387702-b253-4a83-bf95-02fcbaf0e95d.png">



**After**

<img width="782" alt="image" src="https://user-images.githubusercontent.com/4310419/188326552-30d67424-25e1-4bb8-9f8a-ac3d25efd4cc.png">


**Limitations**

<img width="1030" alt="Screen Shot 2022-09-05 at 2 42 32" src="https://user-images.githubusercontent.com/4310419/188326619-6fa2e0e7-d6f9-4d22-a214-b786e07a35e7.png">

