### PR TITLE
Update vulnerable dependencies (Nov 2022)

### DIFF
--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           # strict dependency resolution added in pip 20.3
-          python -m pip install --upgrade 'pip>=20.3'
+          # CVE-2021-3572 fixed in pip 21.1
+          python -m pip install --upgrade 'pip>=21.1'
           pip install \
             --constraint=constraints-future.txt \
             --upgrade \

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     airium>=0.2.3
     black>=21.7b1  # to prevent Mypy error about `gen_python_files`, see issue #189
+    cryptography>=3.3.2  # through twine, fixes CVE-2020-36242
     defusedxml>=0.7.1
     isort>=5.0.1
     pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
     twine>=2.0.0
     types-requests>=2.27.9
     types-toml>=0.10.4
+    urllib3>=1.25.9  # through requests-cache and twine, fixes CVE-2020-26137
     wheel>=0.21.0
 release =
     airium>=0.2.3


### PR DESCRIPTION
Fixes CVE-2020-26137 found by Safety:

```
-> Vulnerability found in urllib3 version 1.25.8
   Vulnerability ID: 38834
   Affected spec: <1.25.9
   ADVISORY: Urllib3 before 1.25.9 allows CRLF injection if the attacker
   controls the HTTP request method, as demonstrated by inserting CR and LF...
   CVE-2020-26137
   For more information, please visit
   https://pyup.io/vulnerabilities/CVE-2020-26137/38834/
```