### PR TITLE
`pip-compile` to get dependencies for safety check

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      - run: pip install -U pip-tools
+      - run: pip-compile setup.cfg
       - run: pip install -U safety
       - name: Check dependencies for known security vulnerabilities using Safety
-        run: safety check
+        run: safety check --file requirements.txt


### PR DESCRIPTION
This way Safety actually checks the dependencies of Darker, not everything that happens to be installed in the CI image.