### PR TITLE
support target-version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -115,6 +115,10 @@ jobs:
       - name: Install Darker and its dependencies from the wheel build earlier
         run: pip install "${{needs.build-wheel.outputs.wheel-path}}[test]"
                          ${{ matrix.upgrade }} ${{ matrix.constraints }}
+      - name: Downgrade target-version when running oldest supported Black
+        if: matrix.constraints == '--constraint constraints-oldest.txt'
+        run: |
+          sed -i 's/py311/py39/' pyproject.toml
       - name: Run Pytest
         run: |
           pytest --darker

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 - Make unit tests compatible with ``pytest --log-cli-level==DEBUG``.
   Doctests are still incompatible due to
   `pytest#5908 <https://github.com/pytest-dev/pytest/issues/5908>`_.
+- Black's ``target-version =`` configuration file option and ``-t`` /
+  ``--target-version`` command line option
 
 
 Fixed

--- a/README.rst
+++ b/README.rst
@@ -340,7 +340,7 @@ The following `command line arguments`_ can also be used to modify the defaults:
        How many characters per line to allow [default: 88]
 -t VERSION, --target-version VERSION
        [py33|py34|py35|py36|py37|py38|py39|py310|py311] Python versions that should be
-       supported by Black's output. [default: py311]
+       supported by Black's output. [default: per-file auto-detection]
 -W WORKERS, --workers WORKERS
        How many parallel workers to allow, or ``0`` for one per core [default: 1]
 

--- a/README.rst
+++ b/README.rst
@@ -338,12 +338,16 @@ The following `command line arguments`_ can also be used to modify the defaults:
        to override ``skip_magic_trailing_comma = true`` from a configuration file.
 -l LENGTH, --line-length LENGTH
        How many characters per line to allow [default: 88]
+-t VERSION, --target-version VERSION
+       [py33|py34|py35|py36|py37|py38|py39|py310|py311] Python versions that should be
+       supported by Black's output. [default: py311]
 -W WORKERS, --workers WORKERS
        How many parallel workers to allow, or ``0`` for one per core [default: 1]
 
 To change default values for these options for a given project,
-add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory.
-For example:
+add a ``[tool.darker]`` or ``[tool.black]`` section to ``pyproject.toml`` in the
+project's root directory, or to a different TOML file specified using the ``-c`` /
+``--config`` option. For example:
 
 .. code-block:: toml
 
@@ -358,7 +362,26 @@ For example:
    lint = [
        "pylint",
    ]
+   line-length = 80                  # Passed to isort and Black, override their config
    log_level = "INFO"
+
+   [tool.black]
+   line-length = 88                  # Overridden by [tool.darker] above
+   skip-magic-trailing-comma = false
+   skip-string-normalization = false
+   target-version = ['py311']
+   exclude = "test_*\.py"
+   extend_exclude = "/generated/"
+   force_exclude = ".*\.pyi"
+
+   [tool.isort]
+   profile = "black"
+   known_third_party = ["pytest"]
+   line_length = 88                  # Overridden by [tool.darker] above
+
+While isort_ reads all of its options from the configuration file, Black_ only honors
+the ones listed above when called by ``darker``. Other tools are invoked as
+subprocesses and use their configuration mechanisms unmodified.
 
 Be careful to not use options which generate output which is unexpected for
 other tools. For example, VSCode only expects the reformat diff, so
@@ -384,13 +407,13 @@ other tools. For example, VSCode only expects the reformat diff, so
 
 *New in version 1.2.2:* Support for ``-r :PRE-COMMIT:`` / ``--revision=:PRE_COMMIT:``
 
-*New in version 1.3.0:* Support for command line option ``--skip-magic-trailing-comma``
+*New in version 1.3.0:* The ``--skip-magic-trailing-comma`` and ``-d`` / ``--stdout``
+command line options
 
-*New in version 1.3.0:* The ``-d`` / ``--stdout`` command line option
+*New in version 1.5.0:* The ``-W`` / ``--workers``, ``--color`` and ``--no-color``
+command line options
 
-*New in version 1.5.0:* The ``-W`` / ``--workers`` command line option
-
-*New in version 1.5.0:* The ``--color`` and ``--no-color`` command line options
+*New in version 1.7.0:* The ``-t`` / ``--target-version`` command line option
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools", "wheel"]  # PEP 508 specifications.
 
 [tool.black]
 skip-string-normalization = false
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -387,6 +387,8 @@ def main(  # pylint: disable=too-many-locals,too-many-branches,too-many-statemen
         black_config["config"] = args.config
     if args.line_length:
         black_config["line_length"] = args.line_length
+    if args.target_version:
+        black_config["target_version"] = {args.target_version}
     if args.skip_string_normalization is not None:
         black_config["skip_string_normalization"] = args.skip_string_normalization
     if args.skip_magic_trailing_comma is not None:

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -85,6 +85,25 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         dest="line_length",
         metavar="LENGTH",
     )
+    add_arg(
+        hlp.TARGET_VERSION,
+        "-t",
+        "--target-version",
+        type=str,
+        dest="target_version",
+        metavar="VERSION",
+        choices=[
+            "py33",
+            "py34",
+            "py35",
+            "py36",
+            "py37",
+            "py38",
+            "py39",
+            "py310",
+            "py311",
+        ],
+    )
     add_arg(hlp.WORKERS, "-W", "--workers", type=int, dest="workers", default=1)
     # A hidden option for printing command lines option in a format suitable for
     # `README.rst`:

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -3,6 +3,8 @@
 from argparse import SUPPRESS, ArgumentParser, Namespace
 from typing import Any, List, Optional, Tuple
 
+from black import TargetVersion
+
 from darker import help as hlp
 from darker.argparse_helpers import (
     LogLevelAction,
@@ -92,17 +94,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         type=str,
         dest="target_version",
         metavar="VERSION",
-        choices=[
-            "py33",
-            "py34",
-            "py35",
-            "py36",
-            "py37",
-            "py38",
-            "py39",
-            "py310",
-            "py311",
-        ],
+        choices=[v.name.lower() for v in TargetVersion],
     )
     add_arg(hlp.WORKERS, "-W", "--workers", type=int, dest="workers", default=1)
     # A hidden option for printing command lines option in a format suitable for

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -42,6 +42,7 @@ class DarkerConfig(TypedDict, total=False):
     skip_string_normalization: bool
     skip_magic_trailing_comma: bool
     line_length: int
+    target_version: str
     workers: int
 
 

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -1,5 +1,7 @@
 """Help and usage instruction texts used for the command line parser"""
 
+from black import TargetVersion
+
 ISORT_INSTRUCTION = "Please run `pip install darker[isort]`"
 
 DESCRIPTION_PARTS = [
@@ -90,9 +92,8 @@ SKIP_MAGIC_TRAILING_COMMA = (
 LINE_LENGTH = "How many characters per line to allow [default: 88]"
 
 TARGET_VERSION = (
-    "[py33|py34|py35|py36|py37|py38|py39|py310|py311]"
-    " Python versions that should be supported by"
-    " Black's output. [default: py311]"
+    f"[{'|'.join(v.name.lower() for v in TargetVersion)}] Python versions that should"
+    " be supported by Black's output. [default: per-file auto-detection]"
 )
 
 WORKERS = "How many parallel workers to allow, or `0` for one per core [default: 1]"

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -89,4 +89,6 @@ SKIP_MAGIC_TRAILING_COMMA = (
 
 LINE_LENGTH = "How many characters per line to allow [default: 88]"
 
+TARGET_VERSION = "Python versions that should be supported. [default: py37]"
+
 WORKERS = "How many parallel workers to allow, or `0` for one per core [default: 1]"

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -89,6 +89,10 @@ SKIP_MAGIC_TRAILING_COMMA = (
 
 LINE_LENGTH = "How many characters per line to allow [default: 88]"
 
-TARGET_VERSION = "Python versions that should be supported. [default: py37]"
+TARGET_VERSION = (
+    "[py33|py34|py35|py36|py37|py38|py39|py310|py311]"
+    " Python versions that should be supported by"
+    " Black's output. [default: py311]"
+)
 
 WORKERS = "How many parallel workers to allow, or `0` for one per core [default: 1]"

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -57,7 +57,9 @@ class RegexEquality:
         config_lines=["skip-magic-trailing-comma = false"],
         expect={"skip_magic_trailing_comma": False},
     ),
-    dict(config_lines=["target-version = ['py37']"], expect={}),
+    dict(
+        config_lines=["target-version = ['py37']"], expect={"target_version": ["py37"]}
+    ),
     dict(config_lines=[r"include = '\.pyi$'"], expect={}),
     dict(
         config_lines=[r"exclude = '\.pyx$'"],


### PR DESCRIPTION
Adds support for target-version in pyproject.toml

I'm not sure how to add (or even run) tests, so help on that would be appreciated.

Also, I've ran black and it formats quite a few code chunks. I'm I running it right?

- [x] Update `README`
- [x] Update the change log
- [x] Review