### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,6 +89,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12-dev'
         constraints: ['black==22.12.0']
         include:
           - os: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,13 +88,14 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         constraints: ['black==22.12.0']
         include:
           - os: ubuntu-latest
             python-version: '3.7'
             constraints: '--constraint constraints-oldest.txt'
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.11'
             constraints: '--constraint constraints-future.txt'
             upgrade: '--upgrade --upgrade-strategy=eager'
     needs:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,7 +56,7 @@ jobs:
       - build-wheel
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-21.11
       - name: Download wheel uploaded by the build-wheel job

--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           # strict dependency resolution added in pip 20.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,14 @@ These features will be included in the next release:
 
 Added
 -----
+- Declare Python 3.11 as supported in package metadata.
 
 Fixed
 -----
 - Pin Black to version 22.12.0 in the CI build to ensure consistent formatting of
   Darker's own code base.
+- Fix compatibility with ``black-22.10.1.dev19+gffaaf48`` and later – an argument was
+  replaced in ``black.files.gen_python_files()``.
 
 
 1.6.0_ - 2022-12-19
@@ -131,7 +134,7 @@ Fixed
 - Consider ``.py.tmp`` as files which should be reformatted.
   This enables VSCode Format On Save.
 - Use the latest release of Darker instead of 1.3.2 in the GitHub Action.
-  
+
 
 1.4.0_ - 2022-02-08
 ===================

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { }, pythonVersion ? "python310" }:
+{ pkgs ? import <nixpkgs> { }, pythonVersion ? "python311" }:
 (
   pkgs.stdenv.mkDerivation {
     name = "darker-test";

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Source Code = https://github.com/akaihola/darker
     Change Log = https://github.com/akaihola/darker/blob/master/CHANGES.rst


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also test Python 3.12-dev.