### PR TITLE
No development install in `help-in-readme.yml`

### DIFF
--- a/.github/workflows/help-in-readme.yml
+++ b/.github/workflows/help-in-readme.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: pip install -e '.[isort]'
+      - run: pip install '.[isort]'
       - name: Verify that README contains output of darker --help
         shell: python
         run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,15 @@ These features will be included in the next release:
 
 Added
 -----
+- Upgrade to ``setup-python@v4`` in all GitHub workflows. May be required due to
+  deprecation of ``set-output``.
 
 Fixed
 -----
 - Fix compatibility with ``black-22.10.1.dev19+gffaaf48`` and later – an argument was
-  replaced in ``black.files.gen_python_files()`.
-
-- Upgrade to ``setup-python@v4`` in all GitHub workflows. May be required due to
-  deprecation of ``set-output``.
+  replaced in ``black.files.gen_python_files()``.
+- Don't do a development install in the ``help-in-readme.yml`` workflow. Something
+  broke this recently.
 
 
 1.5.1_ - 2022-09-11


### PR DESCRIPTION
This hopefully fixes the recently introduced build problem, see e.g. [build #205](/akaihola/darker/actions/runs/3732587943/jobs/6332350304).