### PR TITLE
Use `GITHUB_TOKEN` in the `test-bump-version` workflow

### DIFF
--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -20,4 +20,7 @@ jobs:
         # reviewing pull requests in `README.rst`.
         run: |
           pip install click packaging requests
-          python release_tools/bump_version.py --minor --dry-run
+          python release_tools/bump_version.py \
+            --minor \
+            --dry-run \
+            --token=${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Added
 -----
 - Upgrade to ``setup-python@v4`` in all GitHub workflows. May be required due to
   deprecation of ``set-output``.
+- ``bump_version.py`` now accepts an optional GitHub token with the ``--token=`` argument.
 
 Fixed
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ Added
 -----
 - Upgrade to ``setup-python@v4`` in all GitHub workflows. May be required due to
   deprecation of ``set-output``.
-- ``bump_version.py`` now accepts an optional GitHub token with the ``--token=`` argument.
+- ``bump_version.py`` now accepts an optional GitHub token with the ``--token=``
+  argument. The ``test-bump-version`` workflow uses that, which should help deal with
+  GitHub's API rate limiting.
 
 Fixed
 -----


### PR DESCRIPTION
This helps with
```python
  File "/home/runner/work/darker/darker/release_tools/bump_version.py", line 269, in get_milestone_numbers
    raise TypeError(f"Expected a JSON list from GitHub API, got {milestones}")
TypeError: Expected a JSON list from GitHub API, got {'message': "API rate limit exceeded for 13.64.11.212. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)", 'documentation_url': 'https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting'}
Error: Process completed with exit code 1.
```
seen e.g. in [build #526](/akaihola/darker/actions/runs/3732869497/jobs/6332892263).