### PR TITLE
Pin Black to 22.12.0 in CI build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,7 +88,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-        constraints: ['']
+        constraints: ['black==22.12.0']
         include:
           - os: ubuntu-latest
             python-version: '3.7'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- Pin Black to version 22.12.0 in the CI build to ensure consistent formatting of
+  Darker's own code base.
 
 
 1.6.0_ - 2022-12-19


### PR DESCRIPTION
Ensures consistent formatting of the Darker code base itself.