### PR TITLE
Remove revision from GitHub Action example

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Fixed
 - Fix compatibility with ``black-22.10.1.dev19+gffaaf48`` and later – an argument was
   replaced in ``black.files.gen_python_files()``.
 - Fix tests to work with Git older than version 2.28.x.
+- GitHub Action example now omits ``revision:`` since the commit range is obtained
+  automatically.
 
 
 1.6.0_ - 2022-12-19

--- a/README.rst
+++ b/README.rst
@@ -637,8 +637,7 @@ Create a file named ``.github/workflows/darker.yml`` inside your repository with
          - uses: actions/setup-python@v4
          - uses: akaihola/darker@1.6.0
            with:
-             options: "--check --diff --color"
-             revision: "master..."
+             options: "--check --diff --isort --color"
              src: "./src"
              version: "~=1.6.0"
              lint: "flake8,pylint==2.13.1"


### PR DESCRIPTION
It obtains the commit range automatically.

Fixes #410.