### PR TITLE
[DEBUG] baseline linting with debug logging to troubleshoot Windows

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -117,7 +117,10 @@ jobs:
                          ${{ matrix.upgrade }} ${{ matrix.constraints }}
       - name: Run Pytest
         run: |
-          pytest --darker
+          # unit tests and Darker with debug level logging:
+          pytest --override-ini=addopts= --log-cli-level=DEBUG --darker
+          # doctests only with warning level logging:
+          pytest --override-ini=python_files=
 
   build-sdist-validate-dists:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,13 @@ What?
 =====
 
 This utility reformats and checks Python source code files.
-However, when run in a Git repository, it only applies reformatting and reports errors
-in regions which have changed in the Git working tree since the last commit.
+However, when run in a Git repository, it compares an old revision of the source tree
+to a newer revision (or the working tree). It then
+
+- only applies reformatting in regions which have changed in the Git working tree
+  between the two revisions, and
+- only reports those linting messages which appeared after the modifications to the
+  source code files.
 
 The reformatters supported are:
 
@@ -697,7 +702,8 @@ It defaults to ``"--check --diff --color"``.
 You can e.g. add ``"--isort"`` to sort imports, or ``"--verbose"`` for debug logging.
 
 To run linters through Darker, you can provide a comma separated list of linters using
-the ``lint:`` option. Only ``flake8``, ``pylint`` and ``mypy`` are supported.
+the ``lint:`` option. Only ``flake8``, ``pylint`` and ``mypy`` are supported. Other
+linters may or may not work with Darker, depending on their message output format.
 Versions can be constrained using ``pip`` syntax, e.g. ``"flake8>=3.9.2"``.
 
 *New in version 1.1.0:*
@@ -716,7 +722,8 @@ The ``lint:`` option.
 Using linters
 =============
 
-One way to use Darker is to filter linter output to modified lines only.
+One way to use Darker is to filter linter output to only those linter messages
+which appeared after the modifications to source code files.
 Darker supports any linter with output in one of the following formats::
 
     <file>:<linenum>: <description>
@@ -858,7 +865,8 @@ are applied to the edited file.
 Also, in case the ``--isort`` option was specified,
 isort_ is run on each edited file before applying Black_.
 Similarly, each linter requested using the `--lint <command>` option is run,
-and only linting errors/warnings on modified lines are displayed.
+and only those linting messages are displayed which appeared after the modifications to
+the source code files..
 
 
 License

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -350,11 +350,14 @@ def main(  # pylint: disable=too-many-locals,too-many-branches,too-many-statemen
     8. verify that the resulting reformatted source code parses to an identical AST as
        the original edited to-file
     9. write the reformatted source back to the original file
-    10. run linter subprocesses for all edited files (10.-13. optional)
-    11. diff the given revision and worktree (after isort and Black reformatting) for
-        each file reported by a linter
-    12. extract line numbers in each file reported by a linter for changed lines
-    13. print only linter error lines which fall on changed lines
+    10. run linter subprocesses twice for all modified and unmodified files which are
+        mentioned on the command line: first establish a baseline by running against
+        ``rev1``, then get current linting status by running against the working tree
+        (steps 10.-12. are optional)
+    11. create a mapping from line numbers of unmodified lines in the current versions
+        to corresponding line numbers in ``rev1``
+    12. hide linter messages which appear in the current versions and identically on
+        corresponding lines in ``rev1``, and show all other linter messages
 
     :param argv: The command line arguments to the ``darker`` command
     :return: 1 if the ``--check`` argument was provided and at least one file was (or
@@ -421,38 +424,35 @@ def main(  # pylint: disable=too-many-locals,too-many-branches,too-many-statemen
             f"Error: Path(s) {missing_reprs} do not exist in {rev2_repr}",
         )
 
-    # These are absolute paths:
+    # These paths are relative to `root`:
     files_to_process = filter_python_files(paths, root, {})
     files_to_blacken = filter_python_files(paths, root, black_config)
+    # Now decide which files to reformat (Black & isort). Note that this doesn't apply
+    # to linting.
     if output_mode == OutputMode.CONTENT:
-        # With `-d` / `--stdout`, process the file whether modified or not. Paths have
+        # With `-d` / `--stdout`, reformat the file whether modified or not. Paths have
         # previously been validated to contain exactly one existing file.
-        changed_files_to_process = {
-            p.resolve().relative_to(root) for p in files_to_process
-        }
+        changed_files_to_reformat = files_to_process
         black_exclude = set()
     else:
-        # In other modes, only process files which have been modified.
+        # In other modes, only reformat files which have been modified.
         if git_is_repository(root):
-            changed_files_to_process = git_get_modified_python_files(
+            changed_files_to_reformat = git_get_modified_python_files(
                 files_to_process, revrange, root
             )
         else:
-            changed_files_to_process = {
-                path.relative_to(root) for path in files_to_process
-            }
+            changed_files_to_reformat = files_to_process
         black_exclude = {
             str(path)
-            for path in changed_files_to_process
-            if root / path not in files_to_blacken
+            for path in changed_files_to_reformat
+            if path not in files_to_blacken
         }
-
     use_color = should_use_color(config["color"])
     formatting_failures_on_modified_lines = False
     for path, old, new in sorted(
         format_edited_parts(
             root,
-            changed_files_to_process,
+            changed_files_to_reformat,
             Exclusions(black=black_exclude, isort=set() if args.isort else {"**/*"}),
             revrange,
             black_config,
@@ -470,7 +470,8 @@ def main(  # pylint: disable=too-many-locals,too-many-branches,too-many-statemen
     linter_failures_on_modified_lines = run_linters(
         args.lint,
         root,
-        changed_files_to_process,
+        # paths to lint are not limited to modified files or just Python files:
+        {p.resolve().relative_to(root) for p in paths},
         revrange,
         use_color,
     )

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -131,8 +131,8 @@ def filter_python_files(
     :param root: A common root directory for all ``paths``
     :param black_config: Black configuration which contains the exclude options read
                          from Black's configuration files
-    :return: Absolute paths of files which should be reformatted according to
-             ``black_config``
+    :return: Paths of files which should be reformatted according to
+             ``black_config``, relative to ``root``.
 
     """
     sig = inspect.signature(gen_python_files)
@@ -157,7 +157,7 @@ def filter_python_files(
             **kwargs,
         )
     )
-    return files_from_directories | files
+    return {p.resolve().relative_to(root) for p in files_from_directories | files}
 
 
 def run_black(src_contents: TextDocument, black_config: BlackConfig) -> TextDocument:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -66,6 +66,16 @@ def git_get_version() -> Tuple[int, ...]:
     raise RuntimeError(f"Unable to parse Git version: {output_lines!r}")
 
 
+def git_rev_parse(revision: str, cwd: Path) -> str:
+    """Return the commit hash for the given revision
+
+    :param revision: The revision to get the commit hash for
+    :param cwd: The root of the Git repository
+
+    """
+    return _git_check_output_lines(["rev-parse", revision], cwd)[0]
+
+
 def git_is_repository(path: Path) -> bool:
     """Return ``True`` if ``path`` is inside a Git working tree"""
     try:

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -300,7 +300,10 @@ def _git_check_output(
         if not exit_on_error:
             raise
         if exc_info.returncode != 128:
-            sys.stderr.write(exc_info.stderr)
+            if encoding:
+                sys.stderr.write(exc_info.stderr)
+            else:
+                sys.stderr.buffer.write(exc_info.stderr)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -344,7 +344,7 @@ def get_missing_at_revision(paths: Iterable[Path], rev2: str, cwd: Path) -> Set[
 
 
 def _git_diff_name_only(
-    rev1: str, rev2: str, relative_paths: Set[Path], cwd: Path
+    rev1: str, rev2: str, relative_paths: Iterable[Path], cwd: Path
 ) -> Set[Path]:
     """Collect names of changed files between commits from Git
 
@@ -371,7 +371,7 @@ def _git_diff_name_only(
     return {Path(line) for line in lines}
 
 
-def _git_ls_files_others(relative_paths: Set[Path], cwd: Path) -> Set[Path]:
+def _git_ls_files_others(relative_paths: Iterable[Path], cwd: Path) -> Set[Path]:
     """Collect names of untracked non-excluded files from Git
 
     This will return those files in ``relative_paths`` which are untracked and not
@@ -401,18 +401,15 @@ def git_get_modified_python_files(
     - ``git diff --name-only --relative <rev> -- <path(s)>``
     - ``git ls-files --others --exclude-standard -- <path(s)>``
 
-    :param paths: Paths to the files to diff
+    :param paths: Relative paths to the files to diff
     :param revrange: Git revision range to compare
     :param cwd: The Git repository root
     :return: File names relative to the Git repository root
 
     """
-    relative_paths = {p.resolve().relative_to(cwd) for p in paths}
-    changed_paths = _git_diff_name_only(
-        revrange.rev1, revrange.rev2, relative_paths, cwd
-    )
+    changed_paths = _git_diff_name_only(revrange.rev1, revrange.rev2, paths, cwd)
     if revrange.rev2 == WORKTREE:
-        changed_paths.update(_git_ls_files_others(relative_paths, cwd))
+        changed_paths.update(_git_ls_files_others(paths, cwd))
     return {path for path in changed_paths if should_reformat_file(cwd / path)}
 
 

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -416,6 +416,30 @@ def git_get_modified_python_files(
     return {path for path in changed_paths if should_reformat_file(cwd / path)}
 
 
+def git_clone_local(source_repository: Path, revision: str, destination: Path) -> Path:
+    """Clone a local repository and check out the given revision
+
+    :param source_repository: Path to the root of the local repository checkout
+    :param revision: The revision to check out, or ``HEAD``
+    :param destination: Directory to create for the clone
+    :return: Path to the root of the new clone
+
+    """
+    clone_path = destination / source_repository.name
+    _ = _git_check_output(
+        [
+            "clone",
+            "--quiet",
+            str(source_repository),
+            str(clone_path),
+        ],
+        Path("."),
+    )
+    if revision != "HEAD":
+        _ = _git_check_output(["checkout", revision], clone_path)
+    return clone_path
+
+
 def _revision_vs_lines(
     root: Path, path_in_repo: Path, rev1: str, content: TextDocument, context_lines: int
 ) -> List[int]:

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -20,13 +20,22 @@ provided that the ``<linenum>`` falls on a changed line.
 """
 
 import logging
+from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
+from tempfile import TemporaryDirectory
 from typing import IO, Collection, Dict, Generator, Iterable, List, Set, Tuple
 
-from darker.git import WORKTREE, EditedLinenumsDiffer, RevisionRange
+from darker.diff import map_unmodified_lines
+from darker.git import (
+    WORKTREE,
+    RevisionRange,
+    git_clone_local,
+    git_get_content_at_revision,
+    git_get_root,
+)
 from darker.highlighting import colorize
 
 logger = logging.getLogger(__name__)
@@ -110,11 +119,13 @@ def _strict_nonneg_int(text: str) -> int:
     return int(text)
 
 
-def _parse_linter_line(line: str, root: Path) -> Tuple[Path, int, str, str]:
+def _parse_linter_line(
+    linter: str, line: str, cwd: Path
+) -> Tuple[MessageLocation, LinterMessage]:
     """Parse one line of linter output
 
     Only parses lines with
-    - a file path (without leading-trailing whitespace),
+    - a relative or absolute file path (without leading-trailing whitespace),
     - a non-negative line number (without leading/trailing whitespace),
     - optionally a column number (without leading/trailing whitespace), and
     - a description.
@@ -122,25 +133,25 @@ def _parse_linter_line(line: str, root: Path) -> Tuple[Path, int, str, str]:
     Examples of successfully parsed lines::
 
         path/to/file.py:42: Description
-        path/to/file.py:42:5: Description
+        /absolute/path/to/file.py:42:5: Description
 
-    Given a root of ``Path("path/")``, these would be parsed into::
+    Given ``cwd=Path("/absolute")``, these would be parsed into::
 
-        (Path("to/file.py"), 42, "path/to/file.py:42:", "Description")
-        (Path("to/file.py"), 42, "path/to/file.py:42:5:", "Description")
+        (Path("path/to/file.py"), 42, "path/to/file.py:42:", "Description")
+        (Path("path/to/file.py"), 42, "path/to/file.py:42:5:", "Description")
 
     For all other lines, a dummy entry is returned: an empty path, zero as the line
     number, an empty location string and an empty description. Such lines should be
     simply ignored, since many linters display supplementary information insterspersed
     with the actual linting notifications.
 
+    :param linter: The name of the linter
     :param line: The linter output line to parse. May have a trailing newline.
-    :param root: The root directory to resolve full file paths against
-    :return: A 4-tuple of
-             - a ``root``-relative file path,
-             - the line number,
-             - the path and location string, and
-             - the description.
+    :param cwd: The directory in which the linter was run, and relative to which paths
+                are returned
+    :return: A 2-tuple of
+             - the file path, line and column numbers of the linter message, and
+             - the linter name and message description.
 
     """
     try:
@@ -158,26 +169,29 @@ def _parse_linter_line(line: str, root: Path) -> Tuple[Path, int, str, str]:
         if len(rest) > 1:
             raise ValueError("Too many colon-separated tokens in {location!r}")
         if len(rest) == 1:
-            # Make sure it column looks like an int on "<path>:<linenum>:<column>"
-            _column = _strict_nonneg_int(rest[0])  # noqa: F841
+            # Make sure the column looks like an int in "<path>:<linenum>:<column>"
+            column = _strict_nonneg_int(rest[0])  # noqa: F841
+        else:
+            column = 0
     except ValueError:
         # Encountered a non-parsable line which doesn't express a linting error.
         # For example, on Mypy:
         # "Found XX errors in YY files (checked ZZ source files)"
         # "Success: no issues found in 1 source file"
         logger.debug("Unparsable linter output: %s", line[:-1])
-        return Path(), 0, "", ""
-    path_from_cwd = Path(path_str).absolute()
-    try:
-        path_in_repo = path_from_cwd.relative_to(root)
-    except ValueError:
-        logger.warning(
-            "Linter message for a file %s outside requested directory %s",
-            path_from_cwd,
-            root,
-        )
-        return Path(), 0, "", ""
-    return path_in_repo, linenum, location + ":", description
+        return (NO_MESSAGE_LOCATION, LinterMessage(linter, ""))
+    path = Path(path_str)
+    if path.is_absolute():
+        try:
+            path = path.relative_to(cwd)
+        except ValueError:
+            logger.warning(
+                "Linter message for a file %s outside root directory %s",
+                path_str,
+                cwd,
+            )
+            return (NO_MESSAGE_LOCATION, LinterMessage(linter, ""))
+    return (MessageLocation(path, linenum, column), LinterMessage(linter, description))
 
 
 def _require_rev2_worktree(rev2: str) -> None:
@@ -197,22 +211,23 @@ def _require_rev2_worktree(rev2: str) -> None:
 
 @contextmanager
 def _check_linter_output(
-    cmdline: str, root: Path, paths: Set[Path]
+    cmdline: str, root: Path, paths: Collection[Path]
 ) -> Generator[IO[str], None, None]:
     """Run a linter as a subprocess and return its standard output stream
 
     :param cmdline: The command line for running the linter
     :param root: The common root of all files to lint
-    :param paths: Paths of files to check, relative to ``git_root``
+    :param paths: Paths of files to check, relative to ``root``
     :return: The standard output stream of the linter subprocess
 
     """
-    cmdline_and_paths = cmdline.split() + [str(root / path) for path in sorted(paths)]
-    logger.debug("[%s]$ %s", Path.cwd(), " ".join(cmdline_and_paths))
+    cmdline_and_paths = cmdline.split() + [str(path) for path in sorted(paths)]
+    logger.debug("[%s]$ %s", root, " ".join(cmdline_and_paths))
     with Popen(  # nosec
         cmdline_and_paths,
         stdout=PIPE,
         encoding="utf-8",
+        cwd=root,
     ) as linter_process:
         # condition needed for MyPy (see https://stackoverflow.com/q/57350490/15770)
         if linter_process.stdout is None:
@@ -221,9 +236,11 @@ def _check_linter_output(
 
 
 def run_linter(  # pylint: disable=too-many-locals
-    cmdline: str, root: Path, paths: Set[Path], revrange: RevisionRange, use_color: bool
-) -> int:
-    """Run the given linter and print linting errors falling on changed lines
+    cmdline: str,
+    root: Path,
+    paths: Collection[Path],
+) -> Dict[MessageLocation, LinterMessage]:
+    """Run the given linter and return linting errors falling on changed lines
 
     :param cmdline: The command line for running the linter
     :param root: The common root of all files to lint
@@ -232,50 +249,27 @@ def run_linter(  # pylint: disable=too-many-locals
     :return: The number of modified lines with linting errors from this linter
 
     """
-    _require_rev2_worktree(revrange.rev2)
-    if not paths:
-        return 0
-    error_count = 0
-    edited_linenums_differ = EditedLinenumsDiffer(root, revrange)
     missing_files = set()
+    result = {}
+    linter = cmdline.split(None, 1)[0]
     with _check_linter_output(cmdline, root, paths) as linter_stdout:
-        prev_path, prev_linenum = None, 0
         for line in linter_stdout:
-            (
-                path_in_repo,
-                linter_error_linenum,
-                location,
-                description,
-            ) = _parse_linter_line(line, root)
-            if (
-                path_in_repo is None
-                or path_in_repo in missing_files
-                or linter_error_linenum == 0
-            ):
+            (location, message) = _parse_linter_line(linter, line, root)
+            if location is NO_MESSAGE_LOCATION or location.path in missing_files:
                 continue
-            if path_in_repo.suffix != ".py":
+            if location.path.suffix != ".py":
                 logger.warning(
-                    "Linter message for a non-Python file: %s %s",
+                    "Linter message for a non-Python file: %s: %s",
                     location,
-                    description,
+                    message.description,
                 )
                 continue
-            try:
-                edited_linenums = edited_linenums_differ.compare_revisions(
-                    path_in_repo, context_lines=0
-                )
-            except FileNotFoundError:
-                logger.warning("Missing file %s from %s", path_in_repo, cmdline)
-                missing_files.add(path_in_repo)
+            if not location.path.is_file() and not location.path.is_symlink():
+                logger.warning("Missing file %s from %s", location.path, cmdline)
+                missing_files.add(location.path)
                 continue
-            if linter_error_linenum in edited_linenums:
-                if path_in_repo != prev_path or linter_error_linenum > prev_linenum + 1:
-                    print()
-                prev_path, prev_linenum = path_in_repo, linter_error_linenum
-                print(colorize(location, "lint_location", use_color), end=" ")
-                print(colorize(description, "lint_description", use_color))
-                error_count += 1
-    return error_count
+            result[location] = message
+    return result
 
 
 def run_linters(
@@ -285,23 +279,140 @@ def run_linters(
     revrange: RevisionRange,
     use_color: bool,
 ) -> int:
-    """Run the given linters on a set of files in the repository
+    """Run the given linters on a set of files in the repository, filter messages
+
+    Linter message filtering works by
+
+    - running linters once in ``rev1`` to establish a baseline,
+    - running them again in ``rev2`` to get linter messages after user changes, and
+    - printing out only new messages which were not present in the baseline.
+
+    If the source tree is not a Git repository, a baseline is not used, and all linter
+    messages are printed
 
     :param linter_cmdlines: The command lines for linter tools to run on the files
     :param root: The root of the relative paths
-    :param paths: The files to check, relative to ``root``. This should only include
-                  files which have been modified in the repository between the given Git
-                  revisions.
+    :param paths: The files and directories to check, relative to ``root``
     :param revrange: The Git revisions to compare
+    :param use_color: ``True`` to use syntax highlighting for linter output
     :return: Total number of linting errors found on modified lines
 
     """
-    # 10. run linter subprocesses for all edited files (10.-13. optional)
-    # 11. diff the given revision and worktree (after isort and Black reformatting)
-    #     for each file reported by a linter
-    # 12. extract line numbers in each file reported by a linter for changed lines
-    # 13. print only linter error lines which fall on changed lines
-    return sum(
-        run_linter(linter_cmdline, root, paths, revrange, use_color)
-        for linter_cmdline in linter_cmdlines
+    if not linter_cmdlines:
+        return 0
+    _require_rev2_worktree(revrange.rev2)
+    git_root = git_get_root(root)
+    if not git_root:
+        # In a non-Git root, don't use a baseline
+        messages = _get_messages_from_linters(linter_cmdlines, root, paths)
+        return _print_new_linter_messages({}, messages, DiffLineMapping(), use_color)
+    git_paths = {(root / path).relative_to(git_root) for path in paths}
+    baseline = _get_messages_from_linters_for_baseline(
+        linter_cmdlines, git_root, git_paths, revrange.rev1
     )
+    messages = _get_messages_from_linters(linter_cmdlines, git_root, git_paths)
+    files_with_messages = {location.path for location in messages}
+    diff_line_mapping = _create_line_mapping(git_root, files_with_messages, revrange)
+    return _print_new_linter_messages(baseline, messages, diff_line_mapping, use_color)
+
+
+def _get_messages_from_linters(
+    linter_cmdlines: Iterable[str],
+    root: Path,
+    paths: Collection[Path],
+) -> Dict[MessageLocation, List[LinterMessage]]:
+    """Run given linters for the given directory and return linting errors
+
+    :param cmdline: The command line for running the linter
+    :param root: The common root of all files to lint
+    :param paths: Paths of files to check, relative to ``root``
+    :param revrange: The Git revision rango to compare
+    :return: Linter messages
+
+    """
+    result = defaultdict(list)
+    for cmdline in linter_cmdlines:
+        for message_location, message in run_linter(cmdline, root, paths).items():
+            result[message_location].append(message)
+    return result
+
+
+def _print_new_linter_messages(
+    baseline: Dict[MessageLocation, List[LinterMessage]],
+    new_messages: Dict[MessageLocation, List[LinterMessage]],
+    diff_line_mapping: DiffLineMapping,
+    use_color: bool,
+) -> int:
+    """Print all linter messages except those same as before on unmodified lines
+
+    :param baseline: Linter messages and their locations for a previous version
+    :param new_messages: New linter messages in a new version of the source file
+    :param diff_line_mapping: Mapping between unmodified lines in old and new versions
+    :param use_color: ``True`` to highlight linter messages in the output
+    :return: The number of linter errors displayed
+
+    """
+    error_count = 0
+    prev_location = NO_MESSAGE_LOCATION
+    for message_location, messages in sorted(new_messages.items()):
+        old_location = diff_line_mapping.get(message_location)
+        is_modified_line = old_location == NO_MESSAGE_LOCATION
+        old_messages: List[LinterMessage] = baseline.get(old_location, [])
+        for message in messages:
+            if not is_modified_line and message in old_messages:
+                # Only hide messages when
+                # - they occurred previously on the corresponding line
+                # - the line hasn't been modified
+                continue
+            if (
+                message_location.path != prev_location.path
+                or message_location.line > prev_location.line + 1
+            ):
+                print()
+            prev_location = message_location
+            print(colorize(f"{message_location}:", "lint_location", use_color), end=" ")
+            print(colorize(message.description, "lint_description", use_color), end=" ")
+            print(f"[{message.linter}]")
+            error_count += 1
+    return error_count
+
+
+def _get_messages_from_linters_for_baseline(
+    linter_cmdlines: List[str], root: Path, paths: Collection[Path], revision: str
+) -> Dict[MessageLocation, List[LinterMessage]]:
+    """Clone the Git repository at a given revision and run linters against it
+
+    :param linter_cmdlines: The command lines for linter tools to run on the files
+    :param root: The root of the Git repository
+    :param paths: The files and directories to check, relative to ``root``
+    :param revision: The revision to check out
+    :return: Linter messages
+
+    """
+    with TemporaryDirectory() as tmp_path:
+        clone_root = git_clone_local(root, revision, Path(tmp_path))
+        return _get_messages_from_linters(linter_cmdlines, clone_root, paths)
+
+
+def _create_line_mapping(
+    root: Path, files_with_messages: Iterable[Path], revrange: RevisionRange
+) -> DiffLineMapping:
+    """Create a mapping from unmodified lines in new files to same lines in old versions
+
+    :param root: The root of the repository
+    :param files_with_messages: Paths to files which have linter messages
+    :param revrange: The revisions to compare
+    :return: A dict which maps the line number of each unmodified line in the new
+             versions of files to corresponding line numbers in old versions of the same
+             files
+
+    """
+    diff_line_mapping = DiffLineMapping()
+    for path in files_with_messages:
+        doc1 = git_get_content_at_revision(path, revrange.rev1, root)
+        doc2 = git_get_content_at_revision(path, revrange.rev2, root)
+        for linenum2, linenum1 in map_unmodified_lines(doc1, doc2).items():
+            location1 = MessageLocation(path, linenum1)
+            location2 = MessageLocation(path, linenum2)
+            diff_line_mapping[location2] = location1
+    return diff_line_mapping

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -362,7 +362,12 @@ def run_linters(
             paths,
             make_linter_env(root, "WORKTREE"),
         )
-        return _print_new_linter_messages({}, messages, DiffLineMapping(), use_color)
+        return _print_new_linter_messages(
+            baseline={},
+            new_messages=messages,
+            diff_line_mapping=DiffLineMapping(),
+            use_color=use_color,
+        )
     git_paths = {(root / path).relative_to(git_root) for path in paths}
     baseline = _get_messages_from_linters_for_baseline(
         linter_cmdlines,

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -21,13 +21,14 @@ provided that the ``<linenum>`` falls on a changed line.
 
 import logging
 import os
+import re
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from tempfile import TemporaryDirectory
-from typing import IO, Collection, Dict, Generator, Iterable, List, Set, Tuple
+from typing import IO, Callable, Collection, Dict, Generator, Iterable, List, Set, Tuple
 
 from darker.diff import map_unmodified_lines
 from darker.git import (
@@ -100,10 +101,33 @@ class DiffLineMapping:
                  of the file
 
         """
-        (old_path, old_line) = self._mapping.get(
-            (new_location.path, new_location.line), (Path(""), 0)
-        )
-        return MessageLocation(old_path, old_line, new_location.column)
+        key = (new_location.path, new_location.line)
+        if key in self._mapping:
+            (old_path, old_line) = self._mapping[key]
+            return MessageLocation(old_path, old_line, new_location.column)
+        return NO_MESSAGE_LOCATION
+
+
+def normalize_whitespace(message: LinterMessage) -> LinterMessage:
+    """Given a line of linter output, shortens runs of whitespace to a single space
+
+    Also removes any leading or trailing whitespace.
+
+    This is done to support comparison of different ``cov_to_lint.py`` runs. To make the
+    output more readable and compact, the tool adjusts whitespace. This is done to both
+    align runs of lines and to remove blocks of extra indentation. For differing sets of
+    coverage messages from ``pytest-cov`` runs of different versions of the code, these
+    whitespace adjustments can differ, so we need to normalize them to compare and match
+    them.
+
+    :param message: The linter message to normalize
+    :return: The normalized linter message with leading and trailing whitespace stripped
+             and runs of whitespace characters collapsed into single spaces
+
+    """
+    return LinterMessage(
+        message.linter, re.sub(r"\s\s+", " ", message.description).strip()
+    )
 
 
 def make_linter_env(root: Path, revision: str) -> Dict[str, str]:
@@ -357,11 +381,17 @@ def run_linters(
     return _print_new_linter_messages(baseline, messages, diff_line_mapping, use_color)
 
 
+def _identity_line_processor(message: LinterMessage) -> LinterMessage:
+    """Default line processor which doesn't modify the line at all"""
+    return message
+
+
 def _get_messages_from_linters(
     linter_cmdlines: Iterable[str],
     root: Path,
     paths: Collection[Path],
     env: Dict[str, str],
+    line_processor: Callable[[LinterMessage], LinterMessage] = _identity_line_processor,
 ) -> Dict[MessageLocation, List[LinterMessage]]:
     """Run given linters for the given directory and return linting errors
 
@@ -369,13 +399,14 @@ def _get_messages_from_linters(
     :param root: The common root of all files to lint
     :param paths: Paths of files to check, relative to ``root``
     :param env: The environment variables to pass to the linter
+    :param line_processor: Pre-processing callback for linter output lines
     :return: Linter messages
 
     """
     result = defaultdict(list)
     for cmdline in linter_cmdlines:
         for message_location, message in run_linter(cmdline, root, paths, env).items():
-            result[message_location].append(message)
+            result[message_location].append(line_processor(message))
     return result
 
 
@@ -401,7 +432,7 @@ def _print_new_linter_messages(
         is_modified_line = old_location == NO_MESSAGE_LOCATION
         old_messages: List[LinterMessage] = baseline.get(old_location, [])
         for message in messages:
-            if not is_modified_line and message in old_messages:
+            if not is_modified_line and normalize_whitespace(message) in old_messages:
                 # Only hide messages when
                 # - they occurred previously on the corresponding line
                 # - the line hasn't been modified
@@ -439,6 +470,7 @@ def _get_messages_from_linters_for_baseline(
             clone_root,
             paths,
             make_linter_env(root, rev1_commit),
+            normalize_whitespace,
         )
 
 

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -54,6 +54,14 @@ class MessageLocation:
 NO_MESSAGE_LOCATION = MessageLocation(Path(""), 0, 0)
 
 
+@dataclass
+class LinterMessage:
+    """Information about a linter message"""
+
+    linter: str
+    description: str
+
+
 def _strict_nonneg_int(text: str) -> int:
     """Strict parsing of strings to non-negative integers
 

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+import shlex
 from subprocess import PIPE, Popen  # nosec
 from tempfile import TemporaryDirectory
 from typing import IO, Callable, Collection, Dict, Generator, Iterable, List, Set, Tuple
@@ -271,7 +272,7 @@ def _check_linter_output(
     :return: The standard output stream of the linter subprocess
 
     """
-    cmdline_and_paths = cmdline.split() + [str(path) for path in sorted(paths)]
+    cmdline_and_paths = shlex.split(cmdline) + [str(path) for path in sorted(paths)]
     logger.debug("[%s]$ %s", root, " ".join(cmdline_and_paths))
     with Popen(  # nosec
         cmdline_and_paths,
@@ -303,7 +304,7 @@ def run_linter(  # pylint: disable=too-many-locals
     """
     missing_files = set()
     result = {}
-    linter = cmdline.split(None, 1)[0]
+    linter = shlex.split(cmdline)[0]
     with _check_linter_output(cmdline, root, paths, env) as linter_stdout:
         for line in linter_stdout:
             (location, message) = _parse_linter_line(linter, line, root)

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -21,6 +21,7 @@ provided that the ``<linenum>`` falls on a changed line.
 
 import logging
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from typing import IO, Generator, List, Set, Tuple
@@ -29,6 +30,28 @@ from darker.git import WORKTREE, EditedLinenumsDiffer, RevisionRange
 from darker.highlighting import colorize
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(eq=True, frozen=True, order=True)
+class MessageLocation:
+    """A file path, line number and column number for a linter message
+
+    Line and column numbers a 0-based, and zero is used for an unspecified column, and
+    for the non-specified location.
+
+    """
+
+    path: Path
+    line: int
+    column: int = 0
+
+    def __str__(self) -> str:
+        if self.column:
+            return f"{self.path}:{self.line}:{self.column}"
+        return f"{self.path}:{self.line}"
+
+
+NO_MESSAGE_LOCATION = MessageLocation(Path(""), 0, 0)
 
 
 def _strict_nonneg_int(text: str) -> int:

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -100,7 +100,11 @@ class GitRepoFixture:
 
         """
         return [
-            re.sub(r"\{root/(.*?)\}", lambda m: str(self.root / str(m.group(1))), line)
+            re.sub(
+                r"\{root(/.*?)?\}",
+                lambda m: str(self.root / (str(m.group(1)[1:]) if m.group(1) else "")),
+                line,
+            )
             for line in lines
         ]
 

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -167,9 +167,7 @@ def test_filter_python_files(  # pylint: disable=too-many-arguments
 
     result = filter_python_files({Path(".")} | explicit, tmp_path, black_config)
 
-    expect_paths = {tmp_path / f"{path}.py" for path in expect} | {
-        tmp_path / p for p in explicit
-    }
+    expect_paths = {Path(f"{path}.py") for path in expect} | explicit
     assert result == expect_paths
 
 

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -7,6 +7,7 @@ import pytest
 
 from darker.diff import (
     diff_and_get_opcodes,
+    map_unmodified_lines,
     opcodes_to_chunks,
     opcodes_to_edit_linenums,
 )
@@ -266,3 +267,38 @@ def test_opcodes_to_edit_linenums_empty_opcodes():
     )
 
     assert result == []  # pylint: disable=use-implicit-booleaness-not-comparison
+
+
+@pytest.mark.kwparametrize(
+    dict(
+        expect={},
+    ),
+    dict(
+        lines2=["file", "was", "empty", "but", "eventually", "not"],
+        expect={},
+    ),
+    dict(
+        lines1=["file", "had", "content", "but", "becomes", "empty"],
+        expect={},
+    ),
+    dict(
+        lines1=["1 unmoved", "2 modify", "3 to 4 moved"],
+        lines2=["1 unmoved", "2 modified", "3 inserted", "3 to 4 moved"],
+        expect={1: 1, 4: 3},
+    ),
+    dict(
+        lines1=["can't", "follow", "both", "when", "order", "is", "changed"],
+        lines2=["when", "order", "is", "changed", "can't", "follow", "both"],
+        expect={1: 4, 2: 5, 3: 6, 4: 7},
+    ),
+    lines1=[],
+    lines2=[],
+)
+def test_map_unmodified_lines(lines1, lines2, expect):
+    """``map_unmodified_lines`` returns a 1-based mapping from new to old linenums"""
+    doc1 = TextDocument.from_lines(lines1)
+    doc2 = TextDocument.from_lines(lines2)
+
+    result = map_unmodified_lines(doc1, doc2)
+
+    assert result == expect

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -100,7 +100,10 @@ def test_require_rev2_worktree(rev2, expect):
 def test_check_linter_output(tmp_path):
     """``_check_linter_output()`` runs linter and returns the stdout stream"""
     with linting._check_linter_output(
-        "echo", tmp_path, {Path("first.py"), Path("second.py")}
+        "echo",
+        tmp_path,
+        {Path("first.py"), Path("second.py")},
+        {},
     ) as stdout:
         lines = list(stdout)
 


### PR DESCRIPTION
In #393, taking `shlex.split()` into use started causing test failures. Here we're enabling debug log output from unit tests to better see what's going on with command line construction.