### PR TITLE
Fix Git error output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Fixed
 - Compatibility of highlighting unit tests with Pygments 2.14.0.
 - In the CI test workflow, don't use environment variables to add a Black version
   constraint to the ``pip`` command. This fixes the Windows builds.
+- Pass Git errors to stderr correctly both in raw and encoded subprocess output mode.
 
 
 1.6.1_ - 2022-12-28

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -290,7 +290,10 @@ def _git_check_output(
         if not exit_on_error:
             raise
         if exc_info.returncode != 128:
-            sys.stderr.write(exc_info.stderr)
+            if encoding:
+                sys.stderr.write(exc_info.stderr)
+            else:
+                sys.stderr.buffer.write(exc_info.stderr)
             raise
 
         # Bad revision or another Git failure. Follow Black's example and return the


### PR DESCRIPTION
In `_git_check_output()`, stderr output needs to be adapted to work both with `encoding=None` and `encoding="utf-8"`.

Required for #393.

- [x] Update change log
- [x] Review