### PR TITLE
Add docstring linting to the Darker repo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Added
   ``rev2`` to get the current situation. Old linter messages which fall on unmodified
   lines are hidden, so effectively the user gets new linter messages introduced by
   latest changes, as well as persistent linter messages on modified lines.
+- Add configuration for ``darglint`` and ``flake8-docstrings``, preparing for enabling
+  those linters in CI builds.
 
 Fixed
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,10 +81,26 @@ max-line-length = 88
 ignore =
     # C408 Unnecessary dict call - rewrite as a literal.
     C408
+    # D400 First line should end with a period (from flake8-docstrings)
+    D400
+    # D415 First line should end with a period, question mark, or exclamation point
+    D415
     # E231 missing whitespace after ','
     E231
     # W503 line break before binary operator
     W503
+# Darglint options when run as a Flake8 plugin:
+strictness = short
+docstring_style = sphinx
+# This requires https://github.com/terrencepreilly/darglint/pull/210:
+darglint_ignore_regex=^test_
+
+[darglint]
+# Run `darglint --verbosity=2` to get nice descriptions in messages.
+# Unfortunately `verbosity` isn't read from the configuration file.
+message_template = {path}:{line}: {msg} {msg_id} {obj}
+docstring_style = sphinx
+ignore_regex = ^test_
 
 [codespell]
 ignore-words-list = nd

--- a/src/darker/diff.py
+++ b/src/darker/diff.py
@@ -216,6 +216,7 @@ def map_unmodified_lines(src: TextDocument, dst: TextDocument) -> Dict[int, int]
     :param dst: The modified text document
     :return: A mapping from ``dst`` lines to corresponding unmodified ``src`` lines.
              Line numbers are 1-based.
+    :raises RuntimeError: if blocks in opcodes don't make sense
 
     """
     opcodes = diff_and_get_opcodes(src, dst)


### PR DESCRIPTION
- [x] Configure [darglint](https://pypi.org/project/darglint/)
- [x] Configure [flake8-docstrings](https://pypi.org/project/flake8-docstrings/)
- [x] Fix docstring linter errors
- [x] Update the change log