### PR TITLE
Satisfy Pylint's `use-dict-literal` check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Fixed
   deals with quoting correctly.
 - Configure ``coverage`` to use relative paths in the Darker repository. This enables
   use of ``cov_to_lint.py``
+- Satisfy Pylint's ``use-dict-literal`` check in Darker's code base.
 
 
 1.6.1_ - 2022-12-28

--- a/action/tests/test_main.py
+++ b/action/tests/test_main.py
@@ -1,5 +1,7 @@
 """Tests for the GitHub Action ``main.py`` module"""
 
+# pylint: disable=use-dict-literal
+
 import re
 import sys
 from contextlib import contextmanager

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -152,7 +152,7 @@ def filter_python_files(
     """
     sig = inspect.signature(gen_python_files)
     # those two exist and are required in black>=21.7b1.dev9
-    kwargs = dict(verbose=False, quiet=False) if "verbose" in sig.parameters else {}
+    kwargs = {"verbose": False, "quiet": False} if "verbose" in sig.parameters else {}
     # `gitignore=` was replaced with `gitignore_dict=` in black==22.10.1.dev19+gffaaf48
     for param in sig.parameters:
         if param.startswith("gitignore"):

--- a/src/darker/tests/test_argparse_helpers.py
+++ b/src/darker/tests/test_argparse_helpers.py
@@ -1,5 +1,7 @@
 """Tests for the ``darker.argparse_helpers`` module"""
 
+# pylint: disable=use-dict-literal
+
 from argparse import ArgumentParser, Namespace
 from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
 

--- a/src/darker/tests/test_black_diff.py
+++ b/src/darker/tests/test_black_diff.py
@@ -1,6 +1,6 @@
 """Unit tests for `darker.black_diff`"""
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,use-dict-literal
 
 import re
 import sys

--- a/src/darker/tests/test_chooser.py
+++ b/src/darker/tests/test_chooser.py
@@ -1,5 +1,7 @@
 """Unit tests for `darker.chooser`"""
 
+# pylint: disable=use-dict-literal
+
 import pytest
 
 from darker.chooser import choose_lines

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments,too-many-locals
+# pylint: disable=too-many-arguments,too-many-locals,use-dict-literal
 
 """Unit tests for :mod:`darker.command_line` and :mod:`darker.__main__`"""
 

--- a/src/darker/tests/test_concurrency.py
+++ b/src/darker/tests/test_concurrency.py
@@ -1,5 +1,7 @@
 """Tests for `darker.concurrency`"""
 
+# pylint: disable=use-dict-literal
+
 from concurrent.futures import Future, ProcessPoolExecutor
 from unittest.mock import Mock
 

--- a/src/darker/tests/test_config.py
+++ b/src/darker/tests/test_config.py
@@ -1,6 +1,6 @@
 """Tests for `darker.config`"""
 
-# pylint: disable=unused-argument,too-many-arguments
+# pylint: disable=unused-argument,too-many-arguments,use-dict-literal
 
 import os
 import re

--- a/src/darker/tests/test_diff.py
+++ b/src/darker/tests/test_diff.py
@@ -1,5 +1,7 @@
 """Unit tests for `darker.diff`"""
 
+# pylint: disable=use-dict-literal
+
 from itertools import chain
 from textwrap import dedent
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`darker.git`"""
 
 # pylint: disable=redefined-outer-name,protected-access,too-many-arguments
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,use-dict-literal
 
 import os
 import re

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -1,6 +1,6 @@
 """Tests for :mod:`darker.import_sorting`"""
 
-# pylint: disable=unused-argument,protected-access,too-many-arguments
+# pylint: disable=unused-argument,protected-access,too-many-arguments,use-dict-literal
 
 from importlib import reload
 from pathlib import Path

--- a/src/darker/tests/test_linting.py
+++ b/src/darker/tests/test_linting.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access,too-many-arguments
+# pylint: disable=protected-access,too-many-arguments,use-dict-literal
 
 """Unit tests for :mod:`darker.linting`"""
 

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-locals,use-implicit-booleaness-not-comparison,unused-argument
 # pylint: disable=protected-access,redefined-outer-name,too-many-arguments
+# pylint: disable=use-dict-literal
 
 import logging
 import re

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -1,6 +1,6 @@
 """Unit tests for the ``--revision`` argument in `darker.main`"""
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,use-dict-literal
 
 import pytest
 

--- a/src/darker/tests/test_multiline_strings.py
+++ b/src/darker/tests/test_multiline_strings.py
@@ -1,5 +1,7 @@
 """Tests for `darker.multiline_strings`"""
 
+# pylint: disable=use-dict-literal
+
 import pytest
 
 from darker import multiline_strings

--- a/src/darker/tests/test_utils.py
+++ b/src/darker/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`darker.utils`"""
 
-# pylint: disable=redefined-outer-name, comparison-with-callable
+# pylint: disable=comparison-with-callable,redefined-outer-name,use-dict-literal
 
 import logging
 import os

--- a/src/darker/tests/test_verification.py
+++ b/src/darker/tests/test_verification.py
@@ -1,5 +1,7 @@
 """Unit tests for :mod:`darker.verification`"""
 
+# pylint: disable=use-dict-literal
+
 from typing import List
 
 import pytest


### PR DESCRIPTION
A Pylint update must have caused this to suddenly appear.