### PR TITLE
Use `git workflow` for generating the linter baseline

### DIFF
--- a/.github/workflows/darker-flake8.yml
+++ b/.github/workflows/darker-flake8.yml
@@ -1,0 +1,21 @@
+---
+name: Test linting using the Darker GitHub Action
+
+on: push  # yamllint disable-line rule:truthy
+
+jobs:
+  darker-github-action-linting-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run Darker's own GitHub action straight from the repository
+        uses: ./
+        with:
+          options: --check --diff --color --isort --config pyproject.toml
+          src: src/darker
+          revision: origin/master...
+          lint: flake8
+          version: "@${{ github.ref_name }}"

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -523,17 +523,18 @@ def _get_messages_from_linters_for_baseline(
     :return: Linter messages
 
     """
-    with TemporaryDirectory() as tmp_path:
-        clone_root = git_clone_local(root, revision, Path(tmp_path))
-        rev1_commit = git_rev_parse(revision, root)
-        result = _get_messages_from_linters(
-            linter_cmdlines,
-            clone_root,
-            paths,
-            make_linter_env(root, rev1_commit),
-            normalize_whitespace,
-        )
-        fix_py37_win_tempdir_permissions(tmp_path)
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "baseline-revision"
+        with git_clone_local(root, revision, tmp_path) as clone_root:
+            rev1_commit = git_rev_parse(revision, root)
+            result = _get_messages_from_linters(
+                linter_cmdlines,
+                clone_root,
+                paths,
+                make_linter_env(root, rev1_commit),
+                normalize_whitespace,
+            )
+            fix_py37_win_tempdir_permissions(tmpdir)
     return result
 
 


### PR DESCRIPTION
Fixes #467.

`actions/checkout@v3` clones a repository in a way which doesn't allow checking out arbitrary branches after making a local clone using `git clone <path1> <path2>`. This effectively broke linting in the Darker action in version 1.7.0.

The fix is to use `git worktree` instead of `git clone` and `git checkout` to create a local copy of the repository.

This PR also adds a CI workflow which tests the Darker action. A Flake8 lint is run in that workflow.