### PR TITLE
Temporarily limit Flynt to versions before 0.78

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Added
 Fixed
 -----
 - Use ``stacklevel=2`` in ``warnings.warn()`` calls as suggested by Flake8.
+- Disallow Flynt version 0.78 and newer to avoid an internal API incompatibility.
 
 
 1.7.0_ - 2023-02-11

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ pygments.lexers =
 
 [options.extras_require]
 flynt =
-    flynt>=0.76
+    flynt>=0.76,<0.78
 isort =
     isort>=5.0.1
 color =
@@ -57,7 +57,7 @@ test =
     black>=21.7b1  # to prevent Mypy error about `gen_python_files`, see issue #189
     cryptography>=3.3.2  # through twine, fixes CVE-2020-36242
     defusedxml>=0.7.1
-    flynt>=0.76
+    flynt>=0.76,<0.78
     isort>=5.0.1
     pygments
     pytest>=6.2.0


### PR DESCRIPTION
This works around the internal API change. In the next minor release compatibility with Flynt 0.78 will be introduced.