### PR TITLE
Ignore Bandit reports in action `run()`

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -18,7 +18,7 @@ VERSION = os.getenv("INPUT_VERSION", default="")
 LINT = os.getenv("INPUT_LINT", default="")
 REVISION = os.getenv("INPUT_REVISION") or os.getenv("INPUT_COMMIT_RANGE") or "HEAD^"
 
-run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
+run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)  # nosec
 
 req = ["darker[color,isort]"]
 if VERSION:


### PR DESCRIPTION
```python
>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
   Severity: Low   Confidence: High
   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
   More Info: https://bandit.readthedocs.io/en/1.7.5/plugins/b603_subprocess_without_shell_equals_true.html
   Location: ./action/main.py:21:0
20	
21	run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
22	
```