### PR TITLE
Make string match error verbose in `bump_version.py`

### DIFF
--- a/release_tools/bump_version.py
+++ b/release_tools/bump_version.py
@@ -419,7 +419,10 @@ def patch_changelog(next_version: Version, dry_run: bool) -> None:
     path = Path("CHANGES.rst")
     content = path.read_text(encoding="utf-8")
     before_unreleased = "These features will be included in the next release:\n\n"
-    insert_point = content.index(before_unreleased) + len(before_unreleased)
+    try:
+        insert_point = content.index(before_unreleased) + len(before_unreleased)
+    except ValueError as exc:
+        raise ValueError(f"{exc} {before_unreleased!r}") from exc
     before = content[:insert_point]
     after = content[insert_point:]
     title = f"{next_version}_ - {date.today()}"


### PR DESCRIPTION
This helps troubleshooting if `CHANGES.rst` patching fails.