### PR TITLE
Run `commit-range` action from local checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Commit Range
       id: commit-range
-      uses: akaihola/darker/.github/actions/commit-range@1.7.0
+      uses: ./.github/actions/commit-range
     - name: Run Darker
       run: |
         # Exists since using github.action_path + path to main script doesn't


### PR DESCRIPTION
This should avoid the problem of looking for the `commit-range` in the yet unreleased version when running the CI build in a release branch e.g. [in this build](/akaihola/darker/actions/runs/4523963269/jobs/7967467444?pr=482):
```
Error: Unable to resolve action `akaihola/darker@1.7.1`, unable to find version `1.7.1`
```