### PR TITLE
Allow `-` as `SRC` when using `--stdin-filename`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ These features will be included in the next release:
 
 Added
 -----
+- Allow ``-`` as the single source filename when using the ``--stdin-filename`` option.
+  This makes the option compatible with Black.
 
 Fixed
 -----

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -109,7 +109,7 @@ def validate_stdin_src(stdin_filename: Optional[str], src: List[str]) -> None:
     """Make sure both ``stdin`` mode and paths/directories are specified"""
     if stdin_filename is None:
         return
-    if len(src) == 0:
+    if len(src) == 0 or src == ["-"]:
         return
     raise ConfigurationError(
         "No Python source files are allowed when using the `stdin-filename` option"

--- a/src/darker/tests/test_main_stdin_filename.py
+++ b/src/darker/tests/test_main_stdin_filename.py
@@ -110,6 +110,13 @@ pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
     dict(
         stdin_filename="a.py", revision="..:STDIN:", expect_a_py='modified = "stdin"\n'
     ),
+    dict(src=["-"], stdin_filename="a.py", expect_a_py='modified = "stdin"\n'),
+    dict(
+        src=["-"],
+        stdin_filename="a.py",
+        revision="..:STDIN:",
+        expect_a_py='modified = "stdin"\n',
+    ),
     dict(
         stdin_filename="a.py",
         revision="..:WORKTREE:",


### PR DESCRIPTION
Fixes #492. Makes Darker behave like Black.

Required:
- [x] merge #496 
- [x] merge #497 