### PR TITLE
Fix Python 3.12 compatibility in multi-line string scanning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Fixed
 -----
 - Revert running ``commit-range`` from the repository itself. This broke the GitHub
   action.
+- Python 3.12 compatibility in multi-line string scanning.
 
 
 1.7.1_ - 2023-03-26

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -563,7 +563,7 @@ def _revision_vs_lines(
     old = git_get_content_at_revision(path_in_repo, rev1, root)
     # 2. diff the given revisions for the file
     edited_opcodes = diff_and_get_opcodes(old, content)
-    multiline_string_ranges = get_multiline_string_ranges(content)
+    multiline_string_ranges = list(get_multiline_string_ranges(content))
     # 3. extract line numbers in each edited to-file for changed lines
     return list(
         opcodes_to_edit_linenums(edited_opcodes, context_lines, multiline_string_ranges)

--- a/src/darker/tests/test_multiline_strings.py
+++ b/src/darker/tests/test_multiline_strings.py
@@ -71,7 +71,7 @@ def test_get_multiline_string_ranges():
         ]
     )
 
-    result = multiline_strings.get_multiline_string_ranges(content)
+    result = list(multiline_strings.get_multiline_string_ranges(content))
 
     assert result == [
         # 1-based, end-exclusive


### PR DESCRIPTION
Partially fixes #495.

Starting from Python 3.12, `tokenizer` emits an f-string and a triple-quoted f-string as a sequence of tokens starting with `FSTRING_START` and ending with `FSTRING_END`, instead of a single `STRING` token.

Note that as expected, we're still getting the [25 other test failures](/akaihola/darker/actions/runs/5118177370/jobs/9201949165?pr=496) which will be fixed by #497:
```python
FAILED action/tests/test_main.py::test_creates_virtualenv - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env0-expect0] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env1-expect1] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env2-expect2] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env3-expect3] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env4-expect4] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env5-expect5] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env6-expect6] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_installs_packages[run_main_env7-expect7] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_wont_install_unknown_packages[foo] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_wont_install_unknown_packages[  foo  ] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_wont_install_unknown_packages[foo==2.0,bar] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_wont_install_unknown_packages[  foo>1.0  ,  bar  ] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_wont_install_unknown_packages[pylint,foo] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env0-expect0] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env1-expect1] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env2-expect2] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env3-expect3] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env4-expect4] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env5-expect5] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env6-expect6] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env7-expect7] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_runs_darker[env8-expect8] - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_error_if_pip_fails - ModuleNotFoundError: No module named 'pkg_resources'
FAILED action/tests/test_main.py::test_exits - ModuleNotFoundError: No module named 'pkg_resources'
```