### PR TITLE
Fix Python 3.12 compatibility of the GitHub Action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,6 +16,7 @@ jobs:
             airium \
             black \
             defusedxml \
+            pip-requirements-parser \
             pygments \
             pylint \
             pytest>=6.2.0 \

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Fixed
 - Revert running ``commit-range`` from the repository itself. This broke the GitHub
   action.
 - Python 3.12 compatibility in multi-line string scanning.
+- Python 3.12 compatibility for the GitHub Action.
 - Use the original repository working directory name as the name of the temporary
   directory for getting the linter baseline. This avoids issues with Mypy when there's
   an ``__init__.py`` in the repository root.

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,7 @@ runs:
         sys.exit(proc.returncode)
         "
 
+        pip install pip-requirements-parser
         if [ "$RUNNER_OS" == "Windows" ]; then
           echo $entrypoint | python
         else

--- a/action/main.py
+++ b/action/main.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run  # nosec
 
-from pkg_resources import parse_requirements
+from pip_requirements_parser import parse_reqparts_from_string
 
 LINTER_WHITELIST = {"flake8", "pylint", "mypy"}
 ACTION_PATH = Path(os.environ["GITHUB_ACTION_PATH"])
@@ -29,7 +29,10 @@ if VERSION:
     else:
         req[0] += f"=={VERSION}"
 linter_options = []
-for linter_requirement in parse_requirements(LINT.replace(",", "\n")):
+for requirement_string in LINT.split(","):
+    if not requirement_string.strip():
+        continue
+    linter_requirement = parse_reqparts_from_string(requirement_string).requirement
     linter = linter_requirement.name
     if linter not in LINTER_WHITELIST:
         raise RuntimeError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
     flynt>=0.76,<0.78
     isort>=5.0.1
     mypy>=0.990
+    pip-requirements-parser
     pygments
     pytest>=6.2.0
     pytest-darker


### PR DESCRIPTION
Partially fixes #495.

`pkg_resources` is no longer available by default in the environment since `setuptools` was dropped in Python 3.12. Instead of installing one of those, we're now using [pip-requirements-parser](https://pypi.org/project/pip-requirements-parser/) as a more stable solution since `pkg_resources` is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) in favor of `importlib` which doesn't provide tooling for parsing requirements.