### PR TITLE
Avoid Mypy error when there's an `__init__.py` in the repo root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Fixed
 - Revert running ``commit-range`` from the repository itself. This broke the GitHub
   action.
 - Python 3.12 compatibility in multi-line string scanning.
+- Use the original repository working directory name as the name of the temporary
+  directory for getting the linter baseline. This avoids issues with Mypy when there's
+  an ``__init__.py`` in the repository root.
 
 
 1.7.1_ - 2023-03-26

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -10,6 +10,7 @@ flake8-2020==1.6.1
 flake8-bugbear==22.1.11
 flake8-comprehensions==3.7.0
 flynt==0.76
+mypy==0.990
 Pygments==2.4.0
 pytest==6.2.0
 pytest-kwparametrize==0.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ test =
     defusedxml>=0.7.1
     flynt>=0.76,<0.78
     isort>=5.0.1
+    mypy>=0.990
     pygments
     pytest>=6.2.0
     pytest-darker

--- a/src/darker/linting.py
+++ b/src/darker/linting.py
@@ -524,7 +524,7 @@ def _get_messages_from_linters_for_baseline(
 
     """
     with TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir) / "baseline-revision"
+        tmp_path = Path(tmpdir) / "baseline-revision" / root.name
         with git_clone_local(root, revision, tmp_path) as clone_root:
             rev1_commit = git_rev_parse(revision, root)
             result = _get_messages_from_linters(


### PR DESCRIPTION
Fixes #498.