### PR TITLE
Run NixOS tests on NixOS unstable and Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,12 +46,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: python310
-          - os: macos-latest
-            python-version: python39
-            # see https://github.com/cachix/install-nix-action/issues/135
+        os:
+          - ubuntu-latest
+          - macos-latest
     needs:
       - build-wheel
     steps:
@@ -65,7 +62,6 @@ jobs:
         run: |
           nix-shell \
             --pure \
-            --argstr pythonVersion ${{ matrix.python-version }} \
             --run '
               python -m venv venv
               source venv/bin/activate

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22
         with:
-          nix_path: nixpkgs=channel:nixos-21.11
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Download wheel uploaded by the build-wheel job
         uses: actions/download-artifact@v3
       - name: Run tests in nix-shell

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Added
 -----
 - Allow ``-`` as the single source filename when using the ``--stdin-filename`` option.
   This makes the option compatible with Black.
+- Upgrade NixOS tests to use Python 3.11 on both Linux and macOS.
 
 Fixed
 -----

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
-{ pkgs ? import <nixpkgs> { }, pythonVersion ? "python311" }:
+{ pkgs ? import <nixpkgs> { } }:
 (
   pkgs.stdenv.mkDerivation {
     name = "darker-test";
-    buildInputs = [ pkgs.${pythonVersion} pkgs.git ];
+    buildInputs = [ pkgs.python310 pkgs.git ];
   }
 )

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,6 @@
 (
   pkgs.stdenv.mkDerivation {
     name = "darker-test";
-    buildInputs = [ pkgs.python310 pkgs.git ];
+    buildInputs = [ pkgs.python311 pkgs.git ];
   }
 )


### PR DESCRIPTION
This way we get early notification of incompatibilities.