### PR TITLE
Fix compatibility with Flynt v1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ pygments.lexers =
 
 [options.extras_require]
 flynt =
-    flynt>=0.76,<0.78
+    flynt>=0.76
 isort =
     isort>=5.0.1
 color =
@@ -58,7 +58,7 @@ test =
     black>=21.7b1  # to prevent Mypy error about `gen_python_files`, see issue #189
     cryptography>=3.3.2  # through twine, fixes CVE-2020-36242
     defusedxml>=0.7.1
-    flynt>=0.76,<0.78
+    flynt>=0.76
     isort>=5.0.1
     mypy>=0.990
     pip-requirements-parser

--- a/src/darker/tests/helpers.py
+++ b/src/darker/tests/helpers.py
@@ -89,6 +89,7 @@ def flynt_present(present: bool) -> Generator[None, None, None]:
     with _package_present("flynt", present) as fake_flynt_module:
         if present:
             # dummy module and function required by `fstring`:
-            fake_flynt_module.process = ModuleType("process")  # type: ignore
-            fake_flynt_module.process.fstringify_code_by_line = None  # type: ignore
+            fake_flynt_module.__version__ = "1.0.0"  # type: ignore
+            fake_flynt_module.code_editor = ModuleType("process")  # type: ignore
+            fake_flynt_module.code_editor.fstringify_code_by_line = None  # type: ignore
         yield


### PR DESCRIPTION
Updates the existing flynt-0.78-compatibility branch (https://github.com/akaihola/darker/pull/480) to support, additionally, flynt-1.0.0. It also fixes various issues with the existing flynt 0.78 compatibility changes (e.g. gracefully handling non-installed flynt).

All tests pass locally on Python 3.11, with flynt versions 0.77, 0.78, and 1.0.0, and without flynt installed.

Code formatted with black and isort.