### PR TITLE
Bugfix black .gitignore usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
     flynt>=0.76,<0.78
     isort>=5.0.1
     mypy>=0.990
+    pathspec  # to test `gen_python_files` in `test_black_diff.py`
     pip-requirements-parser
     pygments
     pytest>=6.2.0

--- a/src/darker/black_diff.py
+++ b/src/darker/black_diff.py
@@ -155,8 +155,10 @@ def filter_python_files(
     kwargs = {"verbose": False, "quiet": False} if "verbose" in sig.parameters else {}
     # `gitignore=` was replaced with `gitignore_dict=` in black==22.10.1.dev19+gffaaf48
     for param in sig.parameters:
-        if param.startswith("gitignore"):
+        if param == "gitignore":
             kwargs[param] = None  # type: ignore[assignment]
+        elif param == "gitignore_dict":
+            kwargs[param] = {}  # type: ignore[assignment]
     absolute_paths = {p.resolve() for p in paths}
     directories = {p for p in absolute_paths if p.is_dir()}
     files = {p for p in absolute_paths if p not in directories}


### PR DESCRIPTION
Black didn't use the `.gitignore` file, because `gen_python_files()` will be called with `gitignore_dict=None` and `None` will disable the `.gitignore` usage.

see: https://github.com/akaihola/darker/discussions/323#discussioncomment-6676869