### PR TITLE
Fix args list for pre-commit hook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Added
 
 Fixed
 -----
+- Typo in README.
 
 
 1.7.2_ - 2023-07-12

--- a/README.rst
+++ b/README.rst
@@ -662,9 +662,12 @@ other reformatter/linter tools you use to known compatible versions, for example
        - id: darker
          args:
            - --isort
-           - --lint mypy
-           - --lint flake8
-           - --lint pylint
+           - --lint
+           - mypy
+           - --lint
+           - flake8
+           - --lint
+           - pylint
          additional_dependencies:
            - black==22.12.0
            - isort==5.11.4


### PR DESCRIPTION
The current version makes the call fail as the --lint argument is interpreted as a file.

Each item of the argument list must be on its own line.