### PR TITLE
Fix miscellaneous test failures

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
 
+env:
+  PY_IGNORE_IMPORTMISMATCH: 1
 
 jobs:
 

--- a/default.nix
+++ b/default.nix
@@ -3,5 +3,8 @@
   pkgs.stdenv.mkDerivation {
     name = "darker-test";
     buildInputs = [ pkgs.python311 pkgs.git ];
+    shellHook = ''
+      export PY_IGNORE_IMPORTMISMATCH=1
+    '';
   }
 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE
-show_capture = no
 addopts =
   --doctest-modules
   --durations 10

--- a/src/darker/concurrency.py
+++ b/src/darker/concurrency.py
@@ -46,7 +46,7 @@ class DummyExecutor(Executor):
         future = cast(FutureType[T], Future())
         try:
             result = fn(*args, **kwargs)
-        except BaseException as exc_info:
+        except BaseException as exc_info:  # noqa: B036
             future.set_exception(exc_info)
         else:
             future.set_result(result)

--- a/src/darker/tests/helpers.py
+++ b/src/darker/tests/helpers.py
@@ -89,6 +89,7 @@ def flynt_present(present: bool) -> Generator[None, None, None]:
     with _package_present("flynt", present) as fake_flynt_module:
         if present:
             # dummy module and function required by `fstring`:
+            # pylint: disable=no-member
             fake_flynt_module.process = ModuleType("process")  # type: ignore
             fake_flynt_module.process.fstringify_code_by_line = None  # type: ignore
         yield


### PR DESCRIPTION
- Ignore import mismatch when running Pytest
- Add a Pylint disable (error appeared with a recent Pylint version)
- Ignore Flake8 BaseException lint message (appeared with a recent Flake8 update)
