### PR TITLE
Run Pytest in installed package in Nix test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,7 +68,11 @@ jobs:
               python -m venv venv
               source venv/bin/activate
               pip install "${{needs.build-wheel.outputs.wheel-path}}[test]"
-              pytest
+              # Run tests in installed package to avoid plugin import issue:
+              pytest $(python -c "
+          import os, darker
+          print(os.path.dirname(darker.__file__))
+              ")
             ' \
             ./default.nix
 


### PR DESCRIPTION
Somehow this sidesteps the problem of plugins from `conftest.py` not being available.