### PR TITLE
Drop Python 3.7 tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,7 +86,6 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -96,7 +95,7 @@ jobs:
         post_install: ['']
         include:
           - os: ubuntu-latest
-            python-version: '3.7'
+            python-version: '3.8'
             constraints: '--constraint constraints-oldest.txt'
           - os: ubuntu-latest
             python-version: '3.11'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ These features will be included in the next release:
 Added
 -----
 - Limit Black to versions before 24.2 until the incompatibility is resolved.
+- Stop testing on Python 3.7. Note: dropping support to be done in a separate PR.
 
 Fixed
 -----


### PR DESCRIPTION
Note: Dropping support for Python 3.7 will come in a separate PR.