### PR TITLE
Release 1.7.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,7 +36,7 @@ If applicable, add copy/paste the output or attach a screenshots to help explain
  - OS: [e.g. Windows / macos / Linux distribution & version]
  - Python version [e.g. 3.10.4]
  - Git version [e.g. 2.36.0]
- - Darker version [e.g. 1.7.2]
+ - Darker version [e.g. 1.7.3]
  - Black version [e.g. 22.3.0]
  - other reformatter and linter versions [e.g. `isort==5.10.1`, `mypy==0.942`
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ These features will be included in the next release:
 
 Added
 -----
+
+Fixed
+-----
+
+
+1.7.3_ - 2024-02-26
+===================
+
+Added
+-----
 - Limit Black to versions before 24.2 until the incompatibility is resolved.
 - Stop testing on Python 3.7. Note: dropping support to be done in a separate PR.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Fixed
 -----
 
 
-1.7.3_ - 2024-02-26
+1.7.3_ - 2024-02-27
 ===================
 
 Added
@@ -20,7 +20,10 @@ Added
 
 Fixed
 -----
-- Typo in README.
+- Typos in README.
+- Usage of the Black ``gen_python_files(gitignore_dict=...)`` parameter.
+- ``show_capture`` option in Pytest configuration.
+- Ignore some linter messages by recent versions of linters used in CI builds.
 
 
 1.7.2_ - 2023-07-12
@@ -508,7 +511,8 @@ Added
 -----
 - Initial implementation
 
-.. _Unreleased: https://github.com/akaihola/darker/compare/1.7.2...HEAD
+.. _Unreleased: https://github.com/akaihola/darker/compare/1.7.3...HEAD
+.. _1.7.3: https://github.com/akaihola/darker/compare/1.7.2...1.7.3
 .. _1.7.2: https://github.com/akaihola/darker/compare/1.7.1...1.7.2
 .. _1.7.1: https://github.com/akaihola/darker/compare/1.7.0...1.7.1
 .. _1.7.0: https://github.com/akaihola/darker/compare/1.6.1...1.7.0

--- a/README.rst
+++ b/README.rst
@@ -137,11 +137,11 @@ How?
 
 To install or upgrade, use::
 
-  pip install --upgrade darker~=1.7.2
+  pip install --upgrade darker~=1.7.3
 
 Or, if you're using Conda_ for package management::
 
-  conda install -c conda-forge darker~=1.7.2 isort
+  conda install -c conda-forge darker~=1.7.3 isort
   conda update -c conda-forge darker
 
 ..
@@ -638,7 +638,7 @@ do the following:
    .. code-block:: yaml
 
       - repo: https://github.com/akaihola/darker
-        rev: 1.7.2
+        rev: 1.7.3
         hooks:
           - id: darker
 
@@ -657,7 +657,7 @@ other reformatter/linter tools you use to known compatible versions, for example
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/darker
-     rev: 1.7.2
+     rev: 1.7.3
      hooks:
        - id: darker
          args:
@@ -688,7 +688,7 @@ Note the inclusion of the isort Python package under ``additional_dependencies``
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/darker
-     rev: 1.7.2
+     rev: 1.7.3
      hooks:
        - id: darker
          args: [--isort]
@@ -733,11 +733,11 @@ Create a file named ``.github/workflows/darker.yml`` inside your repository with
            with:
              fetch-depth: 0 
          - uses: actions/setup-python@v5
-         - uses: akaihola/darker@1.7.2
+         - uses: akaihola/darker@1.7.3
            with:
              options: "--check --diff --isort --color"
              src: "./src"
-             version: "~=1.7.2"
+             version: "~=1.7.3"
              lint: "flake8,pylint==2.13.1"
 
 There needs to be a working Python environment, set up using ``actions/setup-python``

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
     required: false
     default: "."
   version:
-    description: 'Version of Darker to use, e.g. "~=1.7.2", "1.7.2", "@master"'
+    description: 'Version of Darker to use, e.g. "~=1.7.3", "1.7.3", "@master"'
     required: false
-    default: "~=1.7.2"
+    default: "~=1.7.3"
   revision:
     description: >-
       Git revision range to compare when determining modified lines.

--- a/src/darker/version.py
+++ b/src/darker/version.py
@@ -1,3 +1,3 @@
 """The version number for Darker is governed by this file"""
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"


### PR DESCRIPTION
Primary reason for the release is to prevent upgrading Black to 24.2 and beyond in the 1.7.x series of Darker. The compatibility issue will be fixed in 1.8.0, and newer Black versions allowed again.