### PR TITLE
Filter out unmodified files from list of changed files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 - New exit codes 2 for file not found, 3 for invalid command line arguments, 4 for
   missing dependencies and 123 for unknown failures.
 - Display exit code in parentheses after error message.
+- Do not reformat renamed files.
 
 Fixed
 -----

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -145,6 +145,7 @@ def _git_diff_name_only(
         "diff",
         "--name-only",
         "--relative",
+        "--diff-filter=M",
         rev1,
         # rev2 is inserted here if not WORKTREE
         "--",

--- a/src/darker/git.py
+++ b/src/darker/git.py
@@ -145,7 +145,7 @@ def _git_diff_name_only(
         "diff",
         "--name-only",
         "--relative",
-        "--diff-filter=M",
+        "--diff-filter=MA",
         rev1,
         # rev2 is inserted here if not WORKTREE
         "--",

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -214,16 +214,16 @@ def test_get_missing_at_revision_worktree(git_repo):
 
 
 def test_git_diff_name_only(git_repo):
-    """``_git_diff_name_only()`` only returns paths of modified files"""
+    """``_git_diff_name_only()`` includes added/modified, skips renamed/moved files."""
     git_repo.add({"a.py": "a", "b.py": "b", "c.py": "c"}, commit="Initial commit")
     first = git_repo.get_hash()
     git_repo.add({"a.py": "A", "b.dy": "B"}, commit="only a.py modified")
+    git_repo.rename("c.py", "x.py", commit="rename c.py to x.py")
     second = git_repo.get_hash()
 
     result = git._git_diff_name_only(
         first, second, {Path("a.py"), Path("c.py"), Path("Z.py")}, git_repo.root
     )
-
     assert result == {Path("a.py")}
 
 

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -337,7 +337,6 @@ def test_git_get_modified_python_files(git_repo, modify_paths, paths, expect):
         _description="from master to worktree and index on branch",
         revrange="master..",
         expect={
-            "del_master.py",
             "mod_master.py",
             "mod_both.py",
             "mod_branch.py",
@@ -353,7 +352,6 @@ def test_git_get_modified_python_files(git_repo, modify_paths, paths, expect):
         ),
         revrange="master..HEAD",
         expect={
-            "del_master.py",
             "mod_master.py",
             "mod_both.py",
             "mod_branch.py",
@@ -363,7 +361,6 @@ def test_git_get_modified_python_files(git_repo, modify_paths, paths, expect):
         _description="from master to branch, excluding worktree and index",
         revrange="master..branch",
         expect={
-            "del_master.py",
             "mod_master.py",
             "mod_both.py",
             "mod_branch.py",

--- a/src/darker/tests/test_git.py
+++ b/src/darker/tests/test_git.py
@@ -219,11 +219,13 @@ def test_git_diff_name_only(git_repo):
     first = git_repo.get_hash()
     git_repo.add({"a.py": "A", "b.dy": "B"}, commit="only a.py modified")
     git_repo.rename("c.py", "x.py", commit="rename c.py to x.py")
+
     second = git_repo.get_hash()
 
     result = git._git_diff_name_only(
         first, second, {Path("a.py"), Path("c.py"), Path("Z.py")}, git_repo.root
     )
+
     assert result == {Path("a.py")}
 
 

--- a/src/darker/tests/test_main_revision.py
+++ b/src/darker/tests/test_main_revision.py
@@ -99,7 +99,9 @@ from darkgraylib.testtools.helpers import raises_if_exception
         worktree_content=b"USERMOD=1\n",
         expect={"+1", "+1M0", "+2-1", "+2", "+2M1-0", "+2M1"},
     ),
-    dict(revision="HEAD~2", worktree_content=b"ORIGINAL=1\n", expect={"+1", "+1M0"}),
+    # These are empty because git diff reports these are renamed files.
+    # We only care about added or modified files. See PR #454
+    dict(revision="HEAD~2", worktree_content=b"ORIGINAL=1\n", expect=set()),
     dict(
         revision="HEAD~2",
         worktree_content=b"MODIFIED=1\n",


### PR DESCRIPTION
~Adds an option `--modified-only/-m` to ignore renamed files from being checked.~

Make the filter the default behaviour. Possibly add an option to include renamed files or not, depending on discussions below

Fixes #544