### PR TITLE
Move `bump_version.py` to `darkgray-dev-tools`

### DIFF
--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -20,7 +20,8 @@ jobs:
         # This is used to update the call for reviewing pull requests
         # in `README.rst`.
         run: |
-          pip install https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
+          pip install \
+            https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
           darkgray_bump_version \
             --minor \
             --dry-run \

--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -1,5 +1,5 @@
 ---
-name: bump_version.py check
+name: darkgray_bump_version check
 
 on: push  # yamllint disable-line rule:truthy
 
@@ -11,16 +11,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
-      - name: Make sure that `bump_version.py` still finds all version strings
+      - name: Make sure that `darkgray_bump_version` still finds all version strings
               and that there's a future milestone on GitHub Issues.
-        # If this fails, make sure the regular expressions in `bump_version.py`
+        # If this fails, make sure the regular expressions in
+        # release_tools/bump-version-patterns.yaml
         # match changes in the files to modify. Also ensure there's a milestone
-        # in https://github.com/akaihola/darker/milestones with a future
-        # version number as its name. This is used to update the call for
-        # reviewing pull requests in `README.rst`.
+        # in the GitHub repository with a future version number as its name.
+        # This is used to update the call for reviewing pull requests
+        # in `README.rst`.
         run: |
-          pip install click packaging requests
-          python release_tools/bump_version.py \
+          pip install https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
+          darkgray_bump_version \
             --minor \
             --dry-run \
             --token=${{ secrets.GITHUB_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+
+extends: default
+
+rules:
+  line-length:
+    max: 88
+    level: warning
+    ignore: |
+      release_tools/bump-version-patterns.yaml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Added
 - Mark the Darker package as annotated with type hints.
 - Update to ``ioggstream/bandit-report-artifacts@v1.7.4`` in CI.
 
+Removed
+-------
+- ``bump_version.py`` is now in the separate ``darkgray-dev-tools`` repository.
+
 Fixed
 -----
 

--- a/release_tools/bump-version-patterns.yaml
+++ b/release_tools/bump-version-patterns.yaml
@@ -1,0 +1,70 @@
+---
+
+# Below are the regular expression patterns for finding and replacing version and
+# milestone numbers in files. Keys are file paths relative to the repository root.
+# Values are sets of regular expression pattern strings which contain a magic
+# `{OLD->NEW}` expression. For matching text, that expression will be turned into a
+# regular expression string which matches the expected version or milestone string in
+# the current content of a file. For replacing those matches with updated information,
+# `NEW` specifies which kind of a version or milestone number should be used as the
+# replacement.
+#
+# For example, if the current version ("old_version") was `1.0.1` and bumping the minor
+# version was requested, the entry
+#
+#   "README.rst":
+#   - |-
+#     next version: {old_version->new_version}
+#
+# would use this regular expression:
+#
+#   `r"next version: (1\.0\.1)"`
+#
+# in `README.rst` and replace the text matched by the capture group with "1.1".
+
+
+".github/ISSUE_TEMPLATE/bug_report.md":
+- |-
+  ^ - Darker version \[e\.g\. {old_version->new_version}\]
+
+"README.rst":
+- |-
+  ^  conda install -c conda-forge darker~={old_version->new_version} isort
+
+- |-
+  ^\.\. _next-milestone: https://github\.com/akaihola/darker/milestone/{any_milestone->next_milestone}
+
+- |-
+  ^     (?:   )?rev: {old_version->new_version}
+
+- |-
+  ^\.\. \|next-milestone\| image:: https://img\.shields\.io/github/milestones/progress/akaihola/darker/{any_milestone->next_milestone}
+
+- |-
+  ^             version: "~={old_version->new_version}"
+
+- |-
+  ^         - uses: akaihola/darker@{old_version->new_version}
+
+- |-
+  ^  pip install --upgrade darker~={old_version->new_version}
+
+- |-
+  label=release%20{any_version->next_version}
+
+"action.yml":
+- |-
+  ^    description: \'Version of Darker to use, e\.g\. "~={old_version->new_version}"
+
+- |-
+  ^    description: \'Version of Darker to use, e\.g\. "~=.*?", "{old_version->new_version}"
+
+- |-
+  ^    default: "~={old_version->new_version}"
+
+- |-
+  ^      uses: akaihola/darker/.github/actions/commit-range@{old_version->new_version}
+
+"src/darker/version.py":
+- |-
+  ^__version__ *= *\"{old_version->new_version}\"

--- a/release_tools/bump-version-patterns.yaml
+++ b/release_tools/bump-version-patterns.yaml
@@ -24,47 +24,47 @@
 
 
 ".github/ISSUE_TEMPLATE/bug_report.md":
-- |-
-  ^ - Darker version \[e\.g\. {old_version->new_version}\]
+  - |-
+    ^ - Darker version \[e\.g\. {old_version->new_version}\]
 
 "README.rst":
-- |-
-  ^  conda install -c conda-forge darker~={old_version->new_version} isort
+  - |-
+    ^  conda install -c conda-forge darker~={old_version->new_version} isort
 
-- |-
-  ^\.\. _next-milestone: https://github\.com/akaihola/darker/milestone/{any_milestone->next_milestone}
+  - |-
+    ^\.\. _next-milestone: https://github\.com/akaihola/darker/milestone/{any_milestone->next_milestone}
 
-- |-
-  ^     (?:   )?rev: {old_version->new_version}
+  - |-
+    ^     (?:   )?rev: {old_version->new_version}
 
-- |-
-  ^\.\. \|next-milestone\| image:: https://img\.shields\.io/github/milestones/progress/akaihola/darker/{any_milestone->next_milestone}
+  - |-
+    ^\.\. \|next-milestone\| image:: https://img\.shields\.io/github/milestones/progress/akaihola/darker/{any_milestone->next_milestone}
 
-- |-
-  ^             version: "~={old_version->new_version}"
+  - |-
+    ^             version: "~={old_version->new_version}"
 
-- |-
-  ^         - uses: akaihola/darker@{old_version->new_version}
+  - |-
+    ^         - uses: akaihola/darker@{old_version->new_version}
 
-- |-
-  ^  pip install --upgrade darker~={old_version->new_version}
+  - |-
+    ^  pip install --upgrade darker~={old_version->new_version}
 
-- |-
-  label=release%20{any_version->next_version}
+  - |-
+    label=release%20{any_version->next_version}
 
 "action.yml":
-- |-
-  ^    description: \'Version of Darker to use, e\.g\. "~={old_version->new_version}"
+  - |-
+    ^    description: \'Version of Darker to use, e\.g\. "~={old_version->new_version}"
 
-- |-
-  ^    description: \'Version of Darker to use, e\.g\. "~=.*?", "{old_version->new_version}"
+  - |-
+    ^    description: \'Version of Darker to use, e\.g\. "~=.*?", "{old_version->new_version}"
 
-- |-
-  ^    default: "~={old_version->new_version}"
+  - |-
+    ^    default: "~={old_version->new_version}"
 
-- |-
-  ^      uses: akaihola/darker/.github/actions/commit-range@{old_version->new_version}
+  - |-
+    ^      uses: akaihola/darker/.github/actions/commit-range@{old_version->new_version}
 
 "src/darker/version.py":
-- |-
-  ^__version__ *= *\"{old_version->new_version}\"
+  - |-
+    ^__version__ *= *\"{old_version->new_version}\"

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ test =
 release =
     airium>=0.2.3
     click>=8.0.0
+    darkgray-dev-tools @ https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
     defusedxml>=0.7.1
     requests_cache>=0.7
 


### PR DESCRIPTION
The new repository will contain common development, testing and releasing tooling for Darker, Graylint and Darkgraylib.