### PR TITLE
Update pre-commit hook in README.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Removed
 
 Fixed
 -----
+- Bump-version pre-commit hook pattern: ``rev: vX.Y.Z`` instead of ``X.Y.Z``.
 
 
 2.0.0_ - 2024-03-13

--- a/README.rst
+++ b/README.rst
@@ -639,7 +639,7 @@ do the following:
    .. code-block:: yaml
 
       - repo: https://github.com/akaihola/darker
-        rev: 2.0.0
+        rev: v2.0.0
         hooks:
           - id: darker
 
@@ -658,7 +658,7 @@ other reformatter/linter tools you use to known compatible versions, for example
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/darker
-     rev: 2.0.0
+     rev: v2.0.0
      hooks:
        - id: darker
          args:
@@ -689,7 +689,7 @@ Note the inclusion of the isort Python package under ``additional_dependencies``
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/darker
-     rev: 2.0.0
+     rev: v2.0.0
      hooks:
        - id: darker
          args: [--isort]

--- a/release_tools/bump-version-patterns.yaml
+++ b/release_tools/bump-version-patterns.yaml
@@ -35,7 +35,7 @@
     ^\.\. _next-milestone: https://github\.com/akaihola/darker/milestone/{any_milestone->next_milestone}
 
   - |-
-    ^     (?:   )?rev: {old_version->new_version}
+    ^     (?:   )?rev: v{old_version->new_version}
 
   - |-
     ^\.\. \|next-milestone\| image:: https://img\.shields\.io/github/milestones/progress/akaihola/darker/{any_milestone->next_milestone}


### PR DESCRIPTION
This just sets the correct git tag (`v2.0.0` instead of `2.0.0`).

Thanks for your work!