### PR TITLE
Add `formatter` command line and config option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Added
 - The ``--preview`` configuration flag is now supported in the configuration files for
   Darker and Black
 - Prevent Pylint from updating beyond version 3.2.7 due to dropped Python 3.8 support.
+- The ``--formatter=black`` option (the default) has been added in preparation for
+  future formatters.
 
 Removed
 -------

--- a/README.rst
+++ b/README.rst
@@ -370,6 +370,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
        [py33\|py34\|py35\|py36\|py37\|py38\|py39\|py310\|py311\|py312\|py313] Python
        versions that should be supported by Black's output. [default: per-file auto-
        detection]
+--formatter FORMATTER
+       Formatter to use for reformatting code
 
 To change default values for these options for a given project,
 add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory,

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -83,6 +83,13 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         metavar="VERSION",
         choices=[v.name.lower() for v in TargetVersion],
     )
+    add_arg(
+        "Formatter to use for reformatting code",
+        "--formatter",
+        default="black",
+        choices=["black"],
+        metavar="FORMATTER",
+    )
     return parser
 
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -44,6 +44,7 @@ class DarkerConfig(BaseConfig, total=False):
     skip_magic_trailing_comma: bool
     line_length: int
     target_version: str
+    formatter: str
 
 
 class OutputMode:

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -184,6 +184,30 @@ def get_darker_help_output(capsys):
         expect_modified=("target_version", "py37"),
     ),
     dict(
+        argv=["--formatter", "black", "."],
+        expect_value=("formatter", "black"),
+        expect_config=("formatter", "black"),
+        expect_modified=("formatter", ...),
+    ),
+    dict(
+        argv=["--formatter=black", "."],
+        expect_value=("formatter", "black"),
+        expect_config=("formatter", "black"),
+        expect_modified=("formatter", ...),
+    ),
+    dict(
+        argv=["--formatter", "rustfmt", "."],
+        expect_value=SystemExit,
+        expect_config=None,
+        expect_modified=None,
+    ),
+    dict(
+        argv=["--formatter=rustfmt", "."],
+        expect_value=SystemExit,
+        expect_config=None,
+        expect_modified=None,
+    ),
+    dict(
         argv=["--target-version", "py39", "."],
         expect_value=("target_version", "py39"),
         expect_config=("target_version", "py39"),


### PR DESCRIPTION
The only supported value for now is `black`.

This is the first step to add supports for multiple formatter backends (see [many-formatters](https://github.com/users/akaihola/projects/4/views/5) sub-project).

Fixes #562

Depends on:
- [x] release [Darkgraylib 1.1.1](/akaihola/darkgraylib/milestone/5) (for corrected readme help usage format)

Enables:
- #738 