### PR TITLE
Update to Darkgraylib 1.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Added
 - Support for Python 3.12 in the package metadata and the CI build.
 - Update to Black 24.2.x and isort 5.13.x in pre-commit configuration.
 - Test against Flynt ``master`` branch in the CI build.
+- Update to Darkgraylib 1.1.1 to get fixes for README formatting.
 
 Removed
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     black>=22.3.0
-    darkgraylib~=1.1.0
+    darkgraylib~=1.1.1
     graylint~=1.0.1
     toml>=0.10.0
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync


### PR DESCRIPTION
This fixes README `--help` formatting when re-generating it.