### PR TITLE
Escape pipe symbols (`|`) in the README

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Removed
 Fixed
 -----
 - Bump-version pre-commit hook pattern: ``rev: vX.Y.Z`` instead of ``X.Y.Z``.
+- Escape pipe symbols (``|``) in the README to avoid RestructuredText rendering issues.
 
 
 2.0.0_ - 2024-03-13

--- a/README.rst
+++ b/README.rst
@@ -376,8 +376,8 @@ The following `command line arguments`_ can also be used to modify the defaults:
 -l LENGTH, --line-length LENGTH
        How many characters per line to allow [default: 88]
 -t VERSION, --target-version VERSION
-       [py33|py34|py35|py36|py37|py38|py39|py310|py311|py312] Python versions that
-       should be supported by Black's output. [default: per-file auto-detection]
+       [py33\|py34\|py35\|py36\|py37\|py38\|py39\|py310\|py311\|py312] Python versions
+       that should be supported by Black's output. [default: per-file auto-detection]
 
 To change default values for these options for a given project,
 add a ``[tool.darker]`` or ``[tool.black]`` section to ``pyproject.toml`` in the


### PR DESCRIPTION
This avoids ReStructuredText rendering issues.