### PR TITLE
Allow `--stdout <...> -`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Added
 
 Fixed
 -----
+- A dash (``-``) is now allowed as the single source filename when using the
+  ``--stdout`` option. This makes the option compatible with the
+  `new Black extension for VSCode`__.
+
+__ https://github.com/microsoft/vscode-black-formatter
 
 
 2.1.0_ - 2024-03-27

--- a/README.rst
+++ b/README.rst
@@ -549,15 +549,21 @@ Visual Studio Code
      $ where darker
      %LocalAppData%\Programs\Python\Python36-32\Scripts\darker.exe  # possible location
 
-3. Add these configuration options to VS code, ``Cmd-Shift-P``, ``Open Settings (JSON)``::
+3. Make sure you have the `VSCode black-formatter extension`__ installed.
 
-    "python.formatting.provider": "black",
-    "python.formatting.blackPath": "<install_location_from_step_2>",
-    "python.formatting.blackArgs": [],
+__ https://github.com/microsoft/vscode-black-formatter
+
+4. Add these configuration options to VSCode
+   (``⌘ Command / Ctrl`` + ``⇧ Shift`` + ``P``
+   and select ``Open Settings (JSON)``)::
+
+    "python.editor.defaultFormatter": "ms-python.black-formatter",
+    "black-formatter.path": "<install_location_from_step_2>",
+    "black-formatter.args": ["-d"],
 
 VSCode will always add ``--diff --quiet`` as arguments to Darker,
-but you can also pass additional arguments in the ``blackArgs`` option
-(e.g. ``["--isort", "--revision=master..."]``).
+but you can also pass additional arguments in the ``black-formatter.args`` option
+(e.g. ``["-d", "--isort", "--revision=master..."]``).
 Be sure to *not* enable any linters here or in ``pyproject.toml``
 since VSCode won't be able to understand output from them.
 

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -57,7 +57,7 @@ class OutputMode:
             return
         if stdin_filename is None and len(src) == 1 and Path(src[0]).is_file():
             return
-        if stdin_filename is not None and len(src) == 0:
+        if stdin_filename is not None and len(src) == 0 or src == ["-"]:
             return
         raise ConfigurationError(
             "Either --stdin-filename=<path> or exactly one Python source file which"


### PR DESCRIPTION
Fixes #523

This makes [VSCode black-formatter extension](https://github.com/microsoft/vscode-black-formatter/tree/main) configuration easier on VSCode.