### PR TITLE
Include `.pyi` files in package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ where = src
 [options.package_data]
 darker =
   py.typed
+  .pyi
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This allows Mypy to understand typing when doing an editable install. See:
https://github.com/python/mypy/issues/13392#issuecomment-2026018615