### PR TITLE
Deprecate `skip_*` Black options in `[tool.darker]`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,15 @@ These features will be included in the next release:
 
 Added
 -----
+- In the Darker configuration file under ``[tool.darker]``, the Black configuration
+  options ``skip_string_normalization`` and ``skip_magic_trailing_comma`` have been
+  deprecated and will be removed in Darker 3.0. A deprecation warning is now displayed
+  if they are still used.
 
 Removed
 -------
-The ``release_tools/update_contributors.py`` script was moved to the
-``darkgray-dev-tools`` repository.
+- The ``release_tools/update_contributors.py`` script was moved to the
+  ``darkgray-dev-tools`` repository.
 
 Fixed
 -----

--- a/README.rst
+++ b/README.rst
@@ -367,12 +367,12 @@ The following `command line arguments`_ can also be used to modify the defaults:
 -S, --skip-string-normalization
        Don't normalize string quotes or prefixes
 --no-skip-string-normalization
-       Normalize string quotes or prefixes. This can be used to override
-       ``skip_string_normalization = true`` from a configuration file.
+       Normalize string quotes or prefixes. This can be used to override ``skip-string-
+       normalization = true`` from a Black configuration file.
 --skip-magic-trailing-comma
        Skip adding trailing commas to expressions that are split by comma where each
        element is on its own line. This includes function signatures. This can be used
-       to override ``skip_magic_trailing_comma = true`` from a configuration file.
+       to override ``skip-magic-trailing-comma = true`` from a Black configuration file.
 -l LENGTH, --line-length LENGTH
        How many characters per line to allow [default: 88]
 -t VERSION, --target-version VERSION
@@ -380,9 +380,20 @@ The following `command line arguments`_ can also be used to modify the defaults:
        that should be supported by Black's output. [default: per-file auto-detection]
 
 To change default values for these options for a given project,
-add a ``[tool.darker]`` or ``[tool.black]`` section to ``pyproject.toml`` in the
-project's root directory, or to a different TOML file specified using the ``-c`` /
-``--config`` option. For example:
+add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory,
+or to a different TOML file specified using the ``-c`` / ``--config`` option.
+
+You should configure invoked tools like Black_, isort_ and flynt_
+using their own configuration files.
+
+As an exception, the ``line-length`` and ``target-version`` options in ``[tool.darker]``
+can be used to override corresponding options for individual tools.
+
+Note that Black_ honors only the options listed in the below example
+when called by ``darker``, because ``darker`` reads the Black configuration
+and passes it on when invoking Black_ directly through its Python API.
+
+An example ``pyproject.toml`` configuration file:
 
 .. code-block:: toml
 
@@ -399,13 +410,14 @@ project's root directory, or to a different TOML file specified using the ``-c``
        "pylint",
    ]
    line-length = 80                  # Passed to isort and Black, override their config
+   target-version = ["py312"]        # Passed to Black, overriding its config
    log_level = "INFO"
 
    [tool.black]
    line-length = 88                  # Overridden by [tool.darker] above
    skip-magic-trailing-comma = false
    skip-string-normalization = false
-   target-version = ["py38", "py39", "py310", "py311", "py312"]
+   target-version = ["py38", "py39", "py310", "py311", "py312"]  # Overridden above
    exclude = "test_*\.py"
    extend_exclude = "/generated/"
    force_exclude = ".*\.pyi"
@@ -414,10 +426,6 @@ project's root directory, or to a different TOML file specified using the ``-c``
    profile = "black"
    known_third_party = ["pytest"]
    line_length = 88                  # Overridden by [tool.darker] above
-
-While isort_ reads all of its options from the configuration file, Black_ only honors
-the ones listed above when called by ``darker``. Other tools are invoked as
-subprocesses and use their configuration mechanisms unmodified.
 
 Be careful to not use options which generate output which is unexpected for
 other tools. For example, VSCode only expects the reformat diff, so
@@ -452,6 +460,9 @@ command line options
 *New in version 1.7.0:* The ``-t`` / ``--target-version`` command line option
 
 *New in version 1.7.0:* The ``-f`` / ``--flynt`` command line option
+
+*New in version 2.1.1:* In ``[tool.darker]``, deprecate the the Black options
+``skip_string_normalization`` and ``skip_magic_trailing_comma``
 
 .. _Black documentation about pyproject.toml: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file
 .. _isort documentation about config files: https://timothycrosley.github.io/isort/docs/configuration/config_files/

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -5,6 +5,7 @@
 # versions in `setup.cfg`.
 airium==0.2.3
 black==22.3.0
+darkgraylib==1.2.0
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -11,6 +11,7 @@ flake8-2020==1.6.1
 flake8-bugbear==22.1.11
 flake8-comprehensions==3.7.0
 flynt==0.76
+graylint==1.1.1
 mypy==0.990
 Pygments==2.4.0
 pytest==6.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,7 @@ ignore = [
     "C408",  # Unnecessary `dict` call (rewrite as a literal)
     "S101",  # Use of `assert` detected
 ]
+
+[tool.ruff.lint.isort]
+known-first-party = ["darkgraylib", "graylint"]
+known-third-party = ["pytest"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     black>=22.3.0
     darkgraylib~=1.2.0
-    graylint~=1.0.1
+    graylint~=1.1.1
     toml>=0.10.0
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync
 #       with the minimum required Python version

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     black>=22.3.0
-    darkgraylib~=1.1.1
+    darkgraylib~=1.2.0
     graylint~=1.0.1
     toml>=0.10.0
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -10,6 +10,9 @@ from darkgraylib.config import BaseConfig, ConfigurationError
 UnvalidatedConfig = Dict[str, Union[List[str], str, bool, int]]
 
 
+DEPRECATED_CONFIG_OPTIONS = {"skip_string_normalization", "skip_magic_trailing_comma"}
+
+
 class DarkerConfig(BaseConfig, total=False):
     """Dictionary representing ``[tool.darker]`` from ``pyproject.toml``"""
 

--- a/src/darker/help.py
+++ b/src/darker/help.py
@@ -124,13 +124,13 @@ VERSION = "Show the version of `darker`"
 SKIP_STRING_NORMALIZATION = "Don't normalize string quotes or prefixes"
 NO_SKIP_STRING_NORMALIZATION = (
     "Normalize string quotes or prefixes. This can be used to override"
-    " `skip_string_normalization = true` from a configuration file."
+    " `skip-string-normalization = true` from a Black configuration file."
 )
 SKIP_MAGIC_TRAILING_COMMA = (
     "Skip adding trailing commas to expressions that are split by comma"
     " where each element is on its own line. This includes function signatures."
     " This can be used to override"
-    " `skip_magic_trailing_comma = true` from a configuration file."
+    " `skip-magic-trailing-comma = true` from a Black configuration file."
 )
 
 LINE_LENGTH = "How many characters per line to allow [default: 88]"


### PR DESCRIPTION
Fixes #447

Steps before this PR can be merged:
- [x] Release Darkgraylib 1.2.0
- [x] akaihola/graylint#36
- [x] Release Graylint 1.1.1
- [x] Update to Graylint 1.1.1