### PR TITLE
Pass "darker" to config dump function to get the correct configuration section name

### DIFF
--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -492,7 +492,7 @@ def main(  # pylint: disable=too-many-locals,too-many-branches,too-many-statemen
     logging.getLogger("blib2to3.pgen2.driver").setLevel(logging.WARNING)
     logging.getLogger("flynt.transform.transform").setLevel(logging.CRITICAL)
 
-    show_config_if_debug(config, config_nondefault, args.log_level)
+    show_config_if_debug(config, config_nondefault, args.log_level, "darker")
 
     if args.isort and not isort:
         raise MissingPackageError(


### PR DESCRIPTION
`darker -vv` used to output:

```toml
# Effective configuration:

[tool.darkgraylib]
# [...]


# Configuration options which differ from defaults:

[tool.darkgraylib]
# [...]
```

This patch corrects it to:

```toml
# Effective configuration:

[tool.darker]
# [...]


# Configuration options which differ from defaults:

[tool.darker]
# [...]
```

Darkgraylib 1.3.0 now requires the section name argument, which we are passing in since this PR.