### PR TITLE
A fix for darkgraylib requiring version for argparser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,9 +9,12 @@ Added
 Fixed
 -----
 - Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
+- Update to Darkgraylib 1.3.1 to fix the configuration dump and the output of
+  ``--version`` (see below).
 - In the configuration dump printed when ``-vv`` verbosity is used, the configuration
   section is now correctly named ``[tool.darker]`` instead of ``[tool.darkgraylib]``.
-  This required an update to Darkgraylib 1.3.0.
+- Pass Graylint version to `~darkgraylib.command_line.make_argument_parser` to make
+  ``--version`` display the correct version number.
 
 
 2.1.1_ - 2024-04-16

--- a/src/darker/command_line.py
+++ b/src/darker/command_line.py
@@ -10,6 +10,7 @@ from black import TargetVersion
 import darkgraylib.command_line
 from darker import help as hlp
 from darker.config import DEPRECATED_CONFIG_OPTIONS, DarkerConfig, OutputMode
+from darker.version import __version__
 from darkgraylib.command_line import add_parser_argument
 from graylint.command_line import add_lint_arg
 
@@ -28,6 +29,7 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         "Make `darker`, `black` and `isort` read configuration from `PATH`. Note that"
         " other tools like `flynt`, `mypy`, `pylint` or `flake8` won't use this"
         " configuration file.",
+        __version__,
     )
 
     add_arg = partial(add_parser_argument, parser)


### PR DESCRIPTION
the argparser in the darkgraylib was using the library version instead of the version of the module calling it

See akaihola/darkgraylib#64