### PR TITLE
GH action to respect `working-directory`

### DIFF
--- a/.github/workflows/test-working-directory.yml
+++ b/.github/workflows/test-working-directory.yml
@@ -1,0 +1,107 @@
+---
+name: "GH Action `working-directory:` test"
+
+on: push  # yamllint disable-line rule:truthy
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up initial test repository
+        run: |
+          mkdir -p test-repo
+          cd test-repo
+          git init
+          git config user.email "test@example.com"
+          git config user.name "Test User"
+          git commit --allow-empty -m "Initial empty commit"
+          echo 'def hello(): return "Hello, World!"' > test.py
+          git add test.py
+          git commit -m "Add test.py file"
+          echo 'def  hello():    return  "Hello, World!"' > test.py
+
+      - name: Upload test repository
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-repo
+          path: test-repo
+
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        scenario:
+          - name: no-work-dir
+            working_directory: null  # Consider it omitted
+            src: test.py
+            options: --check --diff
+            expected_exitcode: 2
+          - name: right-workdir
+            working_directory: test-repo
+            src: test.py
+            options: --check --diff
+            expected_exitcode: 1
+          - name: wrong-work-dir
+            working_directory: non-existent-dir
+            src: test.py
+            options: --check --diff
+            expected_exitcode: 21
+          - name: file-not-found
+            working_directory: test-repo
+            src: non_existent_file.py
+            options: --check --diff
+            expected_exitcode: 2
+          - name: invalid-arguments
+            working_directory: test-repo
+            src: test.py
+            options: --invalid-option
+            expected_exitcode: 3
+          - name: missing-deps
+            working_directory: test-repo
+            src: test.py
+            options: --flynt  # not yet supported by the action
+            expected_exitcode: 4
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Download test repository
+        uses: actions/download-artifact@v3
+        with:
+          name: test-repo
+          path: ${{ runner.temp }}/test-repo
+
+      - name: "Run Darker - ${{ matrix.scenario.name }}"
+        uses: ./
+        continue-on-error: true
+        id: darker-run
+        with:
+          version: "@gh-action-working-directory"
+          options: ${{ matrix.scenario.options }}
+          # In the action, '.' is the default value used if `working-directory` omitted
+          working-directory: >-
+            ${{
+              matrix.scenario.working_directory == null && '.'
+              || format('{0}/{1}', runner.temp, matrix.scenario.working_directory)
+            }}
+          src: ${{ matrix.scenario.src }}
+          revision: HEAD
+
+      - name: Check exit code
+        if: >-
+          steps.darker-run.outputs.exitcode != matrix.scenario.expected_exitcode
+        run: |
+          echo "::error::Expected exit code ${{ matrix.scenario.expected_exitcode }}"
+          echo "::error::Darker exited with ${{ steps.darker-run.outputs.exitcode }}"
+          exit 1
+
+      - name: Verify diff output for right-workdir scenario
+        if: >
+          matrix.scenario.name == 'right-workdir' &&
+          !contains(steps.darker-run.outputs.stdout, '@@')
+        run: |
+          echo "::error::Darker did not output a diff as expected"
+          exit 1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Fixed
   The work-around should be removed when Python 3.8 and 3.9 are no longer supported.
 - Add missing configuration flag for Flynt_.
 - Only split source code lines at Python's universal newlines (LF, CRLF, CR).
+- The Darker GitHub action now respects the ``working-directory`` input option.
 
 
 2.1.1_ - 2024-04-16

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,19 @@ inputs:
       NOTE: Baseline linting has been moved to the Graylint package.
     required: false
     default: ''
+  working-directory:
+    description: >-
+      Directory to run Darker in, either absolute or relative to
+      $GITHUB_WORKSPACE. By default, Darker is run in $GITHUB_WORKSPACE.
+    required: false
+    default: '.'
+outputs:
+  exitcode:
+    description: "Exit code of Darker"
+    value: ${{ steps.darker.outputs.exitcode }}
+  stdout:
+    description: "Standard output of Darker"
+    value: ${{ steps.darker.outputs.stdout }}
 branding:
   color: "black"
   icon: "check-circle"
@@ -35,8 +48,29 @@ runs:
   steps:
     - name: Commit Range
       id: commit-range
-      uses: akaihola/darker/.github/actions/commit-range@1.7.1
+      uses: ./.github/actions/commit-range
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Cache Darker environment
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.action_path }}/.darker-env
+          ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-darker-${{ inputs.version }}-lint-${{ inputs.lint }}
+        save-always: true
+    - name: Install dependencies
+      run: |
+        pip install pip-requirements-parser
+      shell: bash
     - name: Run Darker
+      id: darker
       run: |
         # Exists since using github.action_path + path to main script doesn't
         # work because bash interprets the backslashes in github.action_path
@@ -68,5 +102,6 @@ runs:
         INPUT_REVISION: ${{ inputs.revision }}
         INPUT_LINT: ${{ inputs.lint }}
         INPUT_COMMIT_RANGE: ${{ steps.commit-range.outputs.commit-range }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
         pythonioencoding: utf-8
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -53,18 +53,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: Get pip cache dir
-      id: pip-cache
-      run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Cache Darker environment
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ github.action_path }}/.darker-env
-          ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-darker-${{ inputs.version }}-lint-${{ inputs.lint }}
-        save-always: true
+        cache: 'pip'
     - name: Install dependencies
       run: |
         pip install pip-requirements-parser

--- a/action/main.py
+++ b/action/main.py
@@ -68,7 +68,9 @@ if not ENV_PATH.exists():
 req = ["darker[black,color,isort]"]
 if VERSION:
     if VERSION.startswith("@"):
-        req[0] = f"git+https://github.com/akaihola/darker{VERSION}#egg=darker"
+        req[0] = (
+            f"git+https://github.com/akaihola/darker{VERSION}[color,isort]#egg=darker"
+        )
     elif VERSION.startswith(("~", "=", "<", ">")):
         req[0] += VERSION
     else:

--- a/action/main.py
+++ b/action/main.py
@@ -68,9 +68,7 @@ if not ENV_PATH.exists():
 req = ["darker[black,color,isort]"]
 if VERSION:
     if VERSION.startswith("@"):
-        req[0] = (
-            f"git+https://github.com/akaihola/darker{VERSION}[color,isort]#egg=darker"
-        )
+        req[0] += f"@git+https://github.com/akaihola/darker{VERSION}"
     elif VERSION.startswith(("~", "=", "<", ">")):
         req[0] += VERSION
     else:

--- a/action/main.py
+++ b/action/main.py
@@ -13,6 +13,7 @@ OPTIONS = os.getenv("INPUT_OPTIONS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 REVISION = os.getenv("INPUT_REVISION") or os.getenv("INPUT_COMMIT_RANGE") or "HEAD^"
+WORKING_DIRECTORY = os.getenv("INPUT_WORKING_DIRECTORY", ".")
 
 if os.getenv("INPUT_LINT", default=""):
     print(
@@ -20,28 +21,60 @@ if os.getenv("INPUT_LINT", default=""):
         " See https://pypi.org/project/graylint for more information.",
     )
 
-run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)  # nosec
+
+def set_github_output(key: str, val: str) -> None:
+    """Write a key-value pair to the output file."""
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="UTF-8") as f:
+        if "\n" in val:
+            print(f"{key}<<DARKER_ACTION_EOF", file=f)
+            print(val, file=f, end="" if val.endswith("\n") else "\n")
+            print("DARKER_ACTION_EOF", file=f)
+        else:
+            print(f"{key}={val}", file=f)
+
+
+def exit_with_exitcode(exitcode: int) -> None:
+    """Write the exit code to the output file and exit with it."""
+    set_github_output("exitcode", str(exitcode))
+    sys.exit(exitcode)
+
+
+# Check if the working directory exists
+if not os.path.isdir(WORKING_DIRECTORY):
+    print(f"::error::Working directory does not exist: {WORKING_DIRECTORY}", flush=True)
+    exit_with_exitcode(21)
+
+
+def pip_install(*packages):
+    """Install the specified Python packages using a pip subprocess."""
+    python = str(ENV_BIN / "python")
+    args = [python, "-m", "pip", "install", *packages]
+    pip_proc = run(  # nosec
+        args,
+        check=False,
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+    )
+    print(pip_proc.stdout, end="")
+    if pip_proc.returncode:
+        print(f"::error::Failed to install {' '.join(packages)}.", flush=True)
+        sys.exit(pip_proc.returncode)
+
+
+if not ENV_PATH.exists():
+    run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)  # nosec
 
 req = ["darker[black,color,isort]"]
 if VERSION:
     if VERSION.startswith("@"):
-        req[0] = f"git+https://github.com/akaihola/darker{VERSION}#egg={req[0]}"
+        req[0] = f"git+https://github.com/akaihola/darker{VERSION}#egg=darker"
     elif VERSION.startswith(("~", "=", "<", ">")):
         req[0] += VERSION
     else:
         req[0] += f"=={VERSION}"
 
-pip_proc = run(  # nosec
-    [str(ENV_BIN / "python"), "-m", "pip", "install"] + req,
-    check=False,
-    stdout=PIPE,
-    stderr=STDOUT,
-    encoding="utf-8",
-)
-print(pip_proc.stdout, end="")
-if pip_proc.returncode:
-    print(f"::error::Failed to install {' '.join(req)}.", flush=True)
-    sys.exit(pip_proc.returncode)
+pip_install(*req)
 
 
 base_cmd = [str(ENV_BIN / "darker")]
@@ -58,7 +91,9 @@ proc = run(  # nosec
     stderr=STDOUT,
     env={**os.environ, "PATH": f"{ENV_BIN}:{os.environ['PATH']}"},
     encoding="utf-8",
+    cwd=WORKING_DIRECTORY,
 )
 print(proc.stdout, end="")
 
-sys.exit(proc.returncode)
+set_github_output("stdout", proc.stdout)
+exit_with_exitcode(proc.returncode)


### PR DESCRIPTION
:orange_circle: Pending review is [delaying](https://github.com/users/akaihola/projects/4/views/2?pane=info&statusUpdateId=50063) Darker 3.0.0 release.

---

This patch introduces the following changes to the Darker GitHub Action:
- new `working-directory` input option (defined in `action.yml`)
- new `exitcode` and `stdout` outputs, and Python helpers for setting them
- use the `commit-range` action straight from the current Darker Git checkout
- install `pip-requirements-parser` in a separate action step instead of the entrypoint script
- cache the Python environment
- exit with code 21 if specified `working-directory` doesn't exist
- refactor `pip install` into a helper function
- only create virtualenv if it doesn't already exist
- correct GitHub URL when `version` starts with `@` (pointing to a branch or tag)
- run Darker in the specified `working-directory`
- return Darker terminal output in the `stdout` output
- check exit code and output in the `working-directory` test workflow
- update action tests to match new behavior

FIxes #587

Goes into Darker 3.0.0 since exit codes will need to change in a backwards incompatible way.