### PR TITLE
Fix CI compatibility with Pip >= 24.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
 
 
 2.1.1_ - 2024-04-16

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ test =
     urllib3>=1.25.9  # through requests-cache and twine, fixes CVE-2020-26137
     wheel>=0.21.0
 release =
-    darkgray-dev-tools~=0.0.2
+    darkgray-dev-tools~=0.1.1
 
 [flake8]
 # Line length according to Black rules


### PR DESCRIPTION
Airium 0.2.3 to 0.2.5 wheel metadata isn't supported by Pip >= 24.1. Airium 0.2.6 fixes the metadata. `darkgray-dev-tools==0.1.1 updates Airium to version 0.2.6.

This needs to be fixed before #595 which is in turn needed for #591.