### PR TITLE
Update to Darkgraylib 2.0.1 (fixes Git "dubious ownership" error)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,12 +14,13 @@ Added
 Fixed
 -----
 - Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
-- Update to Darkgraylib 1.3.1 to fix the configuration dump and the output of
-  ``--version`` (see below).
+- Update to Darkgraylib 2.0.1 to fix the configuration dump, the output of ``--version``
+  and the Git "dubious ownership" issue (see below).
 - In the configuration dump printed when ``-vv`` verbosity is used, the configuration
   section is now correctly named ``[tool.darker]`` instead of ``[tool.darkgraylib]``.
 - Pass Graylint version to `~darkgraylib.command_line.make_argument_parser` to make
   ``--version`` display the correct version number.
+- Pass full environment to Git to avoid the "dubious ownership" error.
 
 
 2.1.1_ - 2024-04-16

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -4,7 +4,7 @@
 # interpreter and Python ependencies. Keep this up-to-date with minimum
 # versions in `setup.cfg`.
 black==22.3.0
-darkgraylib==2.0.0
+darkgraylib==2.0.1
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     black>=22.3.0
-    darkgraylib~=2.0.0
+    darkgraylib~=2.0.1
     graylint~=2.0.0
     toml>=0.10.0
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync


### PR DESCRIPTION
Fixes #524

- [x] review akaihola/darkgraylib#74
- [x] merge akaihola/darkgraylib#74
- [x] update to `darkgraylib==2.0.1` in Darker
- [x] release `darkgraylib==2.0.1`
