### PR TITLE
fix: avoid flake8-bugbear version with broken deps

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           plugins: >
             flake8-2020>=1.6.1
-            flake8-bugbear>=22.1.11
+            flake8-bugbear>=22.1.11,!=24.8.19
             flake8-comprehensions>=3.7.0


### PR DESCRIPTION
Needed while waiting for PyCQA/flake8-bugbear#490 to land in a release.