### PR TITLE
Add support for Ruff as a code-formatter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,9 @@ You can enable additional features with command line options:
 - ``-f`` / ``--flynt``: Also convert string formatting to use f-strings using the
   ``flynt`` package
 
+If you only want to run those tools without reformatting with Black,
+use the ``--formatter=none`` option.
+
 *New in version 1.1.0:* The ``-L`` / ``--lint`` option.
 
 *New in version 1.2.2:* Package available in conda-forge_.
@@ -175,6 +178,8 @@ You can enable additional features with command line options:
 
 *New in version 3.0.0:* Removed the ``-L`` / ``--lint`` functionality and moved it into
 the Graylint_ package.
+
+*New in version 3.0.0:* The ``--formatter`` option.
 
 .. _Conda: https://conda.io/
 .. _conda-forge: https://conda-forge.org/

--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,7 @@ The following `command line arguments`_ can also be used to modify the defaults:
        versions that should be supported by Black's output. [default: per-file auto-
        detection]
 --formatter FORMATTER
-       [black\|none] Formatter to use for reformatting code. [default: black]
+       [black\|none\|ruff] Formatter to use for reformatting code. [default: black]
 
 To change default values for these options for a given project,
 add a ``[tool.darker]`` section to ``pyproject.toml`` in the project's root directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ target-version = "py38"
 select = ["ALL"]
 ignore = [
     "A002",  # builtin-argument-shadowing
-    "ANN101",  # Missing type annotation for `self` in method
     "COM812",  # Trailing comma missing
     "D203",  # One blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,8 +97,14 @@ ignore =
     D400
     # D415 First line should end with a period, question mark, or exclamation point
     D415
+    # E203 Whitespace before ':'
+    E203
     # E231 missing whitespace after ','
     E231
+    # E501 Line too long (82 > 79 characters)
+    E501
+    # E701 Multiple statements on one line (colon)
+    E701
     # W503 line break before binary operator
     W503
 # Darglint options when run as a Flake8 plugin:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ darker =
 [options.entry_points]
 darker.formatter =
     black = darker.formatters.black_formatter:BlackFormatter
+    ruff = darker.formatters.ruff_formatter:RuffFormatter
     none = darker.formatters.none_formatter:NoneFormatter
 console_scripts =
     darker = darker.__main__:main_with_error_handling

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -293,7 +293,7 @@ def _maybe_reformat_single_file(
     if glob_any(relpath_in_rev2, exclude):
         # File was excluded by Black configuration, don't reformat
         return fstringified
-    return formatter.run(fstringified)
+    return formatter.run(fstringified, relpath_in_rev2)
 
 
 def _drop_changes_on_unedited_lines(

--- a/src/darker/formatters/base_formatter.py
+++ b/src/darker/formatters/base_formatter.py
@@ -9,6 +9,7 @@ from darker.formatters.formatter_config import FormatterConfig
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from pathlib import Path
 
     from darkgraylib.utils import TextDocument
 
@@ -41,7 +42,7 @@ class BaseFormatter(HasConfig[FormatterConfig]):
             self._read_config_file(config_path)
         self._read_cli_args(args)
 
-    def run(self, content: TextDocument) -> TextDocument:
+    def run(self, content: TextDocument, path_from_cwd: Path) -> TextDocument:
         """Reformat the content."""
         raise NotImplementedError
 

--- a/src/darker/formatters/base_formatter.py
+++ b/src/darker/formatters/base_formatter.py
@@ -2,38 +2,51 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Pattern
+from typing import TYPE_CHECKING, Generic, Pattern, TypeVar
+
+from darker.files import find_pyproject_toml
+from darker.formatters.formatter_config import FormatterConfig
 
 if TYPE_CHECKING:
     from argparse import Namespace
 
-    from darker.formatters.formatter_config import FormatterConfig
     from darkgraylib.utils import TextDocument
 
 
-class BaseFormatter:
+T = TypeVar("T", bound=FormatterConfig)
+
+
+class HasConfig(Generic[T]):  # pylint: disable=too-few-public-methods
     """Base class for code re-formatters."""
 
     def __init__(self) -> None:
         """Initialize the code re-formatter plugin base class."""
-        self.config: FormatterConfig = {}
+        self.config = {}  # type: ignore[var-annotated]
+
+
+class BaseFormatter(HasConfig[FormatterConfig]):
+    """Base class for code re-formatters."""
 
     name: str
 
     def read_config(self, src: tuple[str, ...], args: Namespace) -> None:
-        """Read the formatter configuration from a configuration file
-
-        If not implemented by the subclass, this method does nothing, so the formatter
-        has no configuration options.
+        """Read code re-formatter configuration from a configuration file.
 
         :param src: The source code files and directories to be processed by Darker
         :param args: Command line arguments
 
         """
+        config_path = args.config or find_pyproject_toml(src)
+        if config_path:
+            self._read_config_file(config_path)
+        self._read_cli_args(args)
 
     def run(self, content: TextDocument) -> TextDocument:
         """Reformat the content."""
         raise NotImplementedError
+
+    def _read_cli_args(self, args: Namespace) -> None:
+        pass
 
     def get_config_path(self) -> str | None:
         """Get the path of the configuration file."""
@@ -60,3 +73,6 @@ class BaseFormatter:
         if not isinstance(other, BaseFormatter):
             return NotImplemented
         return type(self) is type(other) and self.config == other.config
+
+    def _read_config_file(self, config_path: str) -> None:
+        pass

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -117,10 +117,15 @@ class BlackFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
         if "target_version" in raw_config:
             target_version = raw_config["target_version"]
             if isinstance(target_version, str):
-                self.config["target_version"] = target_version
+                self.config["target_version"] = (
+                    int(target_version[2]),
+                    int(target_version[3:]),
+                )
             elif isinstance(target_version, list):
-                # Convert TOML list to a Python set
-                self.config["target_version"] = set(target_version)
+                # Convert TOML list to a Python set of int-tuples
+                self.config["target_version"] = {
+                    (int(v[2]), int(v[3:])) for v in target_version
+                }
             else:
                 message = (
                     f"Invalid target-version = {target_version!r} in {config_path}"
@@ -183,7 +188,10 @@ class BlackFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
         if "line_length" in self.config:
             mode["line_length"] = self.config["line_length"]
         if "target_version" in self.config:
-            all_target_versions = {tgt_v.name.lower(): tgt_v for tgt_v in TargetVersion}
+            all_target_versions = {
+                (int(tgt_v.name[2]), int(tgt_v.name[3:])): tgt_v
+                for tgt_v in TargetVersion
+            }
             target_versions_in = validate_target_versions(
                 self.config["target_version"], all_target_versions
             )

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -57,8 +57,6 @@ if TYPE_CHECKING:
     from black import FileMode as Mode
     from black import TargetVersion
 
-    from darker.formatters.formatter_config import BlackConfig
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -13,7 +13,7 @@ The first line will be reformatted by Black, and the second left intact::
     ...     ]
     ... )
 
-First, :func:`run_black` uses Black to reformat the contents of a given file.
+First, `BlackFormatter.run` uses Black to reformat the contents of a given file.
 Reformatted lines are returned e.g.::
 
     >>> from darker.formatters.black_formatter import BlackFormatter
@@ -40,7 +40,12 @@ import logging
 from typing import TYPE_CHECKING, TypedDict
 
 from darker.files import find_pyproject_toml
-from darker.formatters.base_formatter import BaseFormatter
+from darker.formatters.base_formatter import BaseFormatter, HasConfig
+from darker.formatters.formatter_config import (
+    BlackCompatibleConfig,
+    read_black_compatible_cli_args,
+    validate_target_versions,
+)
 from darkgraylib.config import ConfigurationError
 from darkgraylib.utils import TextDocument
 
@@ -68,12 +73,10 @@ class BlackModeAttributes(TypedDict, total=False):
     preview: bool
 
 
-class BlackFormatter(BaseFormatter):
+class BlackFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
     """Black code formatter plugin interface."""
 
-    def __init__(self) -> None:  # pylint: disable=super-init-not-called
-        """Initialize the Black code re-formatter plugin."""
-        self.config: BlackConfig = {}
+    config: BlackCompatibleConfig  # type: ignore[assignment]
 
     name = "black"
 
@@ -135,18 +138,7 @@ class BlackFormatter(BaseFormatter):
             )
 
     def _read_cli_args(self, args: Namespace) -> None:
-        if args.config:
-            self.config["config"] = args.config
-        if getattr(args, "line_length", None):
-            self.config["line_length"] = args.line_length
-        if getattr(args, "target_version", None):
-            self.config["target_version"] = {args.target_version}
-        if getattr(args, "skip_string_normalization", None) is not None:
-            self.config["skip_string_normalization"] = args.skip_string_normalization
-        if getattr(args, "skip_magic_trailing_comma", None) is not None:
-            self.config["skip_magic_trailing_comma"] = args.skip_magic_trailing_comma
-        if getattr(args, "preview", None):
-            self.config["preview"] = args.preview
+        return read_black_compatible_cli_args(args, self.config)
 
     def run(self, content: TextDocument) -> TextDocument:
         """Run the Black code re-formatter for the Python source code given as a string.
@@ -191,15 +183,10 @@ class BlackFormatter(BaseFormatter):
         if "line_length" in self.config:
             mode["line_length"] = self.config["line_length"]
         if "target_version" in self.config:
-            if isinstance(self.config["target_version"], set):
-                target_versions_in = self.config["target_version"]
-            else:
-                target_versions_in = {self.config["target_version"]}
             all_target_versions = {tgt_v.name.lower(): tgt_v for tgt_v in TargetVersion}
-            bad_target_versions = target_versions_in - set(all_target_versions)
-            if bad_target_versions:
-                message = f"Invalid target version(s) {bad_target_versions}"
-                raise ConfigurationError(message)
+            target_versions_in = validate_target_versions(
+                self.config["target_version"], all_target_versions
+            )
             mode["target_versions"] = {
                 all_target_versions[n] for n in target_versions_in
             }

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -17,7 +17,7 @@ First, `BlackFormatter.run` uses Black to reformat the contents of a given file.
 Reformatted lines are returned e.g.::
 
     >>> from darker.formatters.black_formatter import BlackFormatter
-    >>> dst = BlackFormatter().run(src_content)
+    >>> dst = BlackFormatter().run(src_content, src)
     >>> dst.lines
     ('for i in range(5):', '    print(i)', 'print("done")')
 
@@ -51,6 +51,7 @@ from darkgraylib.utils import TextDocument
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from pathlib import Path
     from typing import Pattern
 
     from black import FileMode as Mode
@@ -145,10 +146,14 @@ class BlackFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
     def _read_cli_args(self, args: Namespace) -> None:
         return read_black_compatible_cli_args(args, self.config)
 
-    def run(self, content: TextDocument) -> TextDocument:
+    def run(
+        self, content: TextDocument, path_from_cwd: Path  # noqa: ARG002
+    ) -> TextDocument:
         """Run the Black code re-formatter for the Python source code given as a string.
 
         :param content: The source code
+        :param path_from_cwd: The path to the source code file being reformatted, either
+                              absolute or relative to the current working directory
         :return: The reformatted content
 
         """

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -80,6 +80,7 @@ class BlackFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
     config: BlackCompatibleConfig  # type: ignore[assignment]
 
     name = "black"
+    config_section = "tool.black"
 
     def read_config(self, src: tuple[str, ...], args: Namespace) -> None:
         """Read Black configuration from ``pyproject.toml``.

--- a/src/darker/formatters/formatter_config.py
+++ b/src/darker/formatters/formatter_config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-from decimal import Decimal
 from typing import TYPE_CHECKING, Iterable, Pattern, TypedDict
 
 from darkgraylib.config import ConfigurationError
@@ -17,11 +15,12 @@ class FormatterConfig(TypedDict):
 
 
 def validate_target_versions(
-    value: str | set[str], valid_target_versions: Iterable[str]
-) -> set[str]:
+    value: tuple[int, int] | set[tuple[int, int]],
+    valid_target_versions: Iterable[tuple[int, int]],
+) -> set[tuple[int, int]]:
     """Validate the target-version configuration option value."""
-    target_versions_in = {value} if isinstance(value, str) else value
-    if not isinstance(value, (str, set)):
+    target_versions_in = value if isinstance(value, set) else {value}
+    if not isinstance(value, (tuple, set)):
         message = f"Invalid target version(s) {value!r}"  # type: ignore[unreachable]
         raise ConfigurationError(message)
     bad_target_versions = target_versions_in - set(valid_target_versions)
@@ -31,16 +30,6 @@ def validate_target_versions(
     return target_versions_in
 
 
-get_version_num = re.compile(r"\d+").search
-
-
-def get_minimum_target_version(target_versions: set[str]) -> str:
-    """Get the minimum target version from a set of target versions."""
-    nums_and_tgts = ((get_version_num(tgt), tgt) for tgt in target_versions)
-    matches = ((Decimal(match.group()), tgt) for match, tgt in nums_and_tgts if match)
-    return min(matches)[1]
-
-
 class BlackCompatibleConfig(FormatterConfig, total=False):
     """Type definition for configuration dictionaries of Black compatible formatters."""
 
@@ -48,7 +37,7 @@ class BlackCompatibleConfig(FormatterConfig, total=False):
     exclude: Pattern[str]
     extend_exclude: Pattern[str] | None
     force_exclude: Pattern[str] | None
-    target_version: str | set[str]
+    target_version: tuple[int, int] | set[tuple[int, int]]
     line_length: int
     skip_string_normalization: bool
     skip_magic_trailing_comma: bool
@@ -64,7 +53,9 @@ def read_black_compatible_cli_args(
     if getattr(args, "line_length", None):
         config["line_length"] = args.line_length
     if getattr(args, "target_version", None):
-        config["target_version"] = {args.target_version}
+        config["target_version"] = {
+            (int(args.target_version[2]), int(args.target_version[3:]))
+        }
     if getattr(args, "skip_string_normalization", None) is not None:
         config["skip_string_normalization"] = args.skip_string_normalization
     if getattr(args, "skip_magic_trailing_comma", None) is not None:

--- a/src/darker/formatters/formatter_config.py
+++ b/src/darker/formatters/formatter_config.py
@@ -2,15 +2,47 @@
 
 from __future__ import annotations
 
-from typing import Pattern, TypedDict
+import re
+from decimal import Decimal
+from typing import TYPE_CHECKING, Iterable, Pattern, TypedDict
+
+from darkgraylib.config import ConfigurationError
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 
 class FormatterConfig(TypedDict):
     """Base class for code re-formatter configuration."""
 
 
-class BlackConfig(FormatterConfig, total=False):
-    """Type definition for Black configuration dictionaries."""
+def validate_target_versions(
+    value: str | set[str], valid_target_versions: Iterable[str]
+) -> set[str]:
+    """Validate the target-version configuration option value."""
+    target_versions_in = {value} if isinstance(value, str) else value
+    if not isinstance(value, (str, set)):
+        message = f"Invalid target version(s) {value!r}"  # type: ignore[unreachable]
+        raise ConfigurationError(message)
+    bad_target_versions = target_versions_in - set(valid_target_versions)
+    if bad_target_versions:
+        message = f"Invalid target version(s) {bad_target_versions}"
+        raise ConfigurationError(message)
+    return target_versions_in
+
+
+get_version_num = re.compile(r"\d+").search
+
+
+def get_minimum_target_version(target_versions: set[str]) -> str:
+    """Get the minimum target version from a set of target versions."""
+    nums_and_tgts = ((get_version_num(tgt), tgt) for tgt in target_versions)
+    matches = ((Decimal(match.group()), tgt) for match, tgt in nums_and_tgts if match)
+    return min(matches)[1]
+
+
+class BlackCompatibleConfig(FormatterConfig, total=False):
+    """Type definition for configuration dictionaries of Black compatible formatters."""
 
     config: str
     exclude: Pattern[str]
@@ -21,3 +53,21 @@ class BlackConfig(FormatterConfig, total=False):
     skip_string_normalization: bool
     skip_magic_trailing_comma: bool
     preview: bool
+
+
+def read_black_compatible_cli_args(
+    args: Namespace, config: BlackCompatibleConfig
+) -> None:
+    """Read Black-compatible configuration from command line arguments."""
+    if args.config:
+        config["config"] = args.config
+    if getattr(args, "line_length", None):
+        config["line_length"] = args.line_length
+    if getattr(args, "target_version", None):
+        config["target_version"] = {args.target_version}
+    if getattr(args, "skip_string_normalization", None) is not None:
+        config["skip_string_normalization"] = args.skip_string_normalization
+    if getattr(args, "skip_magic_trailing_comma", None) is not None:
+        config["skip_magic_trailing_comma"] = args.skip_magic_trailing_comma
+    if getattr(args, "preview", None):
+        config["preview"] = args.preview

--- a/src/darker/formatters/none_formatter.py
+++ b/src/darker/formatters/none_formatter.py
@@ -8,6 +8,7 @@ from darker.formatters.base_formatter import BaseFormatter
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from pathlib import Path
 
     from darkgraylib.utils import TextDocument
 
@@ -17,10 +18,14 @@ class NoneFormatter(BaseFormatter):
 
     name = "dummy reformat"
 
-    def run(self, content: TextDocument) -> TextDocument:
+    def run(
+        self, content: TextDocument, path_from_cwd: Path  # noqa: ARG002
+    ) -> TextDocument:
         """Return the Python source code unmodified.
 
         :param content: The source code
+        :param path_from_cwd: The path to the source code file being reformatted, either
+                              absolute or relative to the current working directory
         :return: The source code unmodified
 
         """

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -53,12 +53,14 @@ from darkgraylib.config import ConfigurationError
 from darkgraylib.utils import TextDocument
 
 if sys.version_info >= (3, 11):
+    # On Python 3.11+, we can use the `tomllib` module from the standard library.
     try:
         import tomllib
     except ImportError:
         # Help users on older Python 3.11 alphas
         import tomli as tomllib  # type: ignore[no-redef,import-not-found]
 else:
+    # On older Pythons, we must use the backport.
     import tomli as tomllib
 
 if TYPE_CHECKING:

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -177,7 +177,7 @@ def _get_supported_target_versions() -> set[str]:
     if not type_lines:
         message = f"`{cmdline}` returned no target versions on a 'Type: \"py...' line"
         raise ConfigurationError(message)
-    quoted_targets = type_lines[0][6:].split(" | ")
+    quoted_targets = type_lines[0][len('Type: '):].split(" | ")
     if any(tgt_ver[0] != '"' or tgt_ver[-1] != '"' for tgt_ver in quoted_targets):
         message = f"`{cmdline}` returned invalid target versions {type_lines[0]!r}"
         raise ConfigurationError(message)

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -1,0 +1,198 @@
+"""Re-format Python source code using Ruff.
+
+In examples below, a simple two-line snippet is used.
+The first line will be reformatted by Ruff, and the second left intact::
+
+    >>> from pathlib import Path
+    >>> from unittest.mock import Mock
+    >>> src = Path("dummy/file/path.py")
+    >>> src_content = TextDocument.from_lines(
+    ...     [
+    ...         "for i in range(5): print(i)",
+    ...         'print("done")',
+    ...     ]
+    ... )
+
+First, `RuffFormatter.run` uses Ruff to reformat the contents of a given file.
+Reformatted lines are returned e.g.::
+
+    >>> from darker.formatters.ruff_formatter import RuffFormatter
+    >>> dst = RuffFormatter().run(src_content)
+    >>> dst.lines
+    ('for i in range(5):', '    print(i)', 'print("done")')
+
+See :mod:`darker.diff` and :mod:`darker.chooser`
+for how this result is further processed with:
+
+- :func:`~darker.diff.diff_and_get_opcodes`
+  to get a diff of the reformatting
+- :func:`~darker.diff.opcodes_to_chunks`
+  to split the diff into chunks of original and reformatted content
+- :func:`~darker.chooser.choose_lines`
+  to reconstruct the source code from original and reformatted chunks
+  based on whether reformats touch user-edited lines
+
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from subprocess import PIPE, run  # nosec
+from typing import TYPE_CHECKING, Collection
+
+from darker.formatters.base_formatter import BaseFormatter, HasConfig
+from darker.formatters.formatter_config import (
+    BlackCompatibleConfig,
+    get_minimum_target_version,
+    read_black_compatible_cli_args,
+    validate_target_versions,
+)
+from darkgraylib.config import ConfigurationError
+from darkgraylib.utils import TextDocument
+
+if sys.version_info >= (3, 11):
+    try:
+        import tomllib
+    except ImportError:
+        # Help users on older Python 3.11 alphas
+        import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+else:
+    import tomli as tomllib
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from typing import Pattern
+
+logger = logging.getLogger(__name__)
+
+
+class RuffFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
+    """Ruff code formatter plugin interface."""
+
+    config: BlackCompatibleConfig  # type: ignore[assignment]
+
+    name = "ruff format"
+
+    def run(self, content: TextDocument) -> TextDocument:
+        """Run the Ruff code re-formatter for the Python source code given as a string.
+
+        :param content: The source code
+        :return: The reformatted content
+
+        """
+        # Collect relevant Ruff configuration options from ``self.config`` in order to
+        # pass them to Ruff's ``format_str()``. File exclusion options aren't needed
+        # since at this point we already have a single file's content to work on.
+        # Ignore ISC001 (single-line-implicit-string-concatenation) since it conflicts
+        # with Black's string formatting
+        args = ['--config=lint.ignore=["ISC001"]']
+        if "line_length" in self.config:
+            args.append(f"--line-length={self.config['line_length']}")
+        if "target_version" in self.config:
+            supported_target_versions = _get_supported_target_versions()
+            target_versions_in = validate_target_versions(
+                self.config["target_version"], supported_target_versions
+            )
+            target_version = get_minimum_target_version(target_versions_in)
+            args.append(f"--target-version={target_version}")
+        if self.config.get("skip_magic_trailing_comma", False):
+            args.append('--config="format.skip-magic-trailing-comma=true"')
+            args.append('--config="lint.isort.split-on-trailing-comma=false"')
+        if self.config.get("skip_string_normalization", False):
+            args.append('''--config=format.quote-style="preserve"''')
+        if self.config.get("preview", False):
+            args.append("--preview")
+
+        # The custom handling of empty and all-whitespace files below will be
+        # unnecessary if https://github.com/psf/ruff/pull/2484 lands in Ruff.
+        contents_for_ruff = content.string_with_newline("\n")
+        dst_contents = _ruff_format_stdin(contents_for_ruff, args)
+        return TextDocument.from_str(
+            dst_contents,
+            encoding=content.encoding,
+            override_newline=content.newline,
+        )
+
+    def _read_config_file(self, config_path: str) -> None:
+        """Read Ruff configuration from a configuration file.
+
+        :param config_path: Path to the configuration file
+        :raises ConfigurationError: If the configuration file cannot be read or parsed
+
+        """
+        try:
+            with Path(config_path).open(mode="rb") as config_file:
+                raw_config = tomllib.load(config_file).get("tool", {}).get("ruff", {})
+            if "line-length" in raw_config:
+                self.config["line_length"] = int(raw_config["line-length"])
+        except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+            message = f"Failed to read Ruff config: {exc}"
+            raise ConfigurationError(message) from exc
+
+    def _read_cli_args(self, args: Namespace) -> None:
+        return read_black_compatible_cli_args(args, self.config)
+
+    def get_config_path(self) -> str | None:
+        """Get the path of the configuration file."""
+        return self.config.get("config")
+
+    # pylint: disable=duplicate-code
+    def get_line_length(self) -> int | None:
+        """Get the ``line-length`` Ruff configuration option value."""
+        return self.config.get("line_length")
+
+    # pylint: disable=duplicate-code
+    def get_exclude(self, default: Pattern[str]) -> Pattern[str]:
+        """Get the ``exclude`` Ruff configuration option value."""
+        return self.config.get("exclude", default)
+
+    # pylint: disable=duplicate-code
+    def get_extend_exclude(self) -> Pattern[str] | None:
+        """Get the ``extend_exclude`` Ruff configuration option value."""
+        return self.config.get("extend_exclude")
+
+    # pylint: disable=duplicate-code
+    def get_force_exclude(self) -> Pattern[str] | None:
+        """Get the ``force_exclude`` Ruff configuration option value."""
+        return self.config.get("force_exclude")
+
+
+def _get_supported_target_versions() -> set[str]:
+    """Get the supported target versions for Ruff.
+
+    Calls ``ruff config target-version`` as a subprocess, looks for the line looking
+    like ``Type: "py38" | "py39" | "py310"``, and returns the target versions as a set
+    of strings.
+
+    """
+    cmdline = "ruff config target-version"
+    output = run(  # noqa: S603  # nosec
+        cmdline.split(), stdout=PIPE, check=True, text=True
+    ).stdout
+    type_lines = [line for line in output.splitlines() if line.startswith('Type: "py')]
+    if not type_lines:
+        message = f"`{cmdline}` returned no target versions on a 'Type: \"py...' line"
+        raise ConfigurationError(message)
+    quoted_targets = type_lines[0][6:].split(" | ")
+    if any(tgt_ver[0] != '"' or tgt_ver[-1] != '"' for tgt_ver in quoted_targets):
+        message = f"`{cmdline}` returned invalid target versions {type_lines[0]!r}"
+        raise ConfigurationError(message)
+    return {tgt_ver[1:-1] for tgt_ver in quoted_targets}
+
+
+def _ruff_format_stdin(contents: str, args: Collection[str]) -> str:
+    """Run the contents through ``ruff format``.
+
+    :param contents: The source code to be reformatted
+    :param args: Additional command line arguments to pass to Ruff
+    :return: The reformatted source code
+
+    """
+    cmdline = ["ruff", "format", *args, "-"]
+    logger.debug("Running %s", " ".join(cmdline))
+    result = run(  # noqa: S603  # nosec
+        cmdline, input=contents, stdout=PIPE, check=True, text=True, encoding="utf-8"
+    )
+    return result.stdout

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -45,7 +45,6 @@ from typing import TYPE_CHECKING, Collection
 from darker.formatters.base_formatter import BaseFormatter, HasConfig
 from darker.formatters.formatter_config import (
     BlackCompatibleConfig,
-    get_minimum_target_version,
     read_black_compatible_cli_args,
     validate_target_versions,
 )
@@ -97,8 +96,8 @@ class RuffFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
             target_versions_in = validate_target_versions(
                 self.config["target_version"], supported_target_versions
             )
-            target_version = get_minimum_target_version(target_versions_in)
-            args.append(f"--target-version={target_version}")
+            target_version_str = supported_target_versions[min(target_versions_in)]
+            args.append(f"--target-version={target_version_str}")
         if self.config.get("skip_magic_trailing_comma", False):
             args.append('--config="format.skip-magic-trailing-comma=true"')
             args.append('--config="lint.isort.split-on-trailing-comma=false"')
@@ -161,7 +160,7 @@ class RuffFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
         return self.config.get("force_exclude")
 
 
-def _get_supported_target_versions() -> set[str]:
+def _get_supported_target_versions() -> dict[tuple[int, int], str]:
     """Get the supported target versions for Ruff.
 
     Calls ``ruff config target-version`` as a subprocess, looks for the line looking
@@ -181,7 +180,10 @@ def _get_supported_target_versions() -> set[str]:
     if any(tgt_ver[0] != '"' or tgt_ver[-1] != '"' for tgt_ver in quoted_targets):
         message = f"`{cmdline}` returned invalid target versions {type_lines[0]!r}"
         raise ConfigurationError(message)
-    return {tgt_ver[1:-1] for tgt_ver in quoted_targets}
+    return {
+        (int(tgt_ver[3]), int(tgt_ver[4:-1])): tgt_ver[1:-1]
+        for tgt_ver in quoted_targets
+    }
 
 
 def _ruff_format_stdin(contents: str, args: Collection[str]) -> str:

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -75,6 +75,7 @@ class RuffFormatter(BaseFormatter, HasConfig[BlackCompatibleConfig]):
     config: BlackCompatibleConfig  # type: ignore[assignment]
 
     name = "ruff format"
+    config_section = "tool.ruff"
 
     def run(self, content: TextDocument, path_from_cwd: Path) -> TextDocument:
         """Run the Ruff code re-formatter for the Python source code given as a string.

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -821,7 +821,7 @@ def options_repo(request, tmp_path_factory):
             {Path("a.py")},
             Exclusions(isort={"**/*"}, flynt={"**/*"}),
             RevisionRange("HEAD", ":WORKTREE:"),
-            {"target_version": {"py39"}},
+            {"target_version": {(3, 9)}},
         ),
     ),
     dict(

--- a/src/darker/tests/test_command_line_ruff.py
+++ b/src/darker/tests/test_command_line_ruff.py
@@ -1,0 +1,102 @@
+"""Unit tests for Ruff related parts of `darker.command_line`."""
+
+# pylint: disable=no-member,redefined-outer-name,unused-argument,use-dict-literal
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from darker.__main__ import main
+from darker.formatters import ruff_formatter
+from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
+
+
+@pytest.fixture(scope="module")
+def ruff_options_files(request, tmp_path_factory):
+    """Fixture for the `ruff_black_options` test."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        (repo.root / "pyproject.toml").write_bytes(b"[tool.ruff]\n")
+        (repo.root / "ruff.cfg").write_text(
+            dedent(
+                """
+                [tool.ruff]
+                line-length = 81
+                skip-string-normalization = false
+                target-version = 'py38'
+                """
+            )
+        )
+        yield repo.add({"main.py": 'print("Hello World!")\n'}, commit="Initial commit")
+
+
+@pytest.mark.kwparametrize(
+    dict(options=[]),
+    dict(options=["-c", "ruff.cfg"], expect_opts=["--line-length=81"]),
+    dict(options=["--config", "ruff.cfg"], expect_opts=["--line-length=81"]),
+    dict(
+        options=["-S"],
+        expect_opts=['--config=format.quote-style="preserve"'],
+    ),
+    dict(
+        options=["--skip-string-normalization"],
+        expect_opts=['--config=format.quote-style="preserve"'],
+    ),
+    dict(options=["-l", "90"], expect_opts=["--line-length=90"]),
+    dict(options=["--line-length", "90"], expect_opts=["--line-length=90"]),
+    dict(
+        options=["-c", "ruff.cfg", "-S"],
+        expect_opts=["--line-length=81", '--config=format.quote-style="preserve"'],
+    ),
+    dict(
+        options=["-c", "ruff.cfg", "-l", "90"],
+        expect_opts=["--line-length=90"],
+    ),
+    dict(
+        options=["-l", "90", "-S"],
+        expect_opts=["--line-length=90", '--config=format.quote-style="preserve"'],
+    ),
+    dict(
+        options=["-c", "ruff.cfg", "-l", "90", "-S"],
+        expect_opts=["--line-length=90", '--config=format.quote-style="preserve"'],
+    ),
+    dict(options=["-t", "py39"], expect_opts=["--target-version=py39"]),
+    dict(options=["--target-version", "py39"], expect_opts=["--target-version=py39"]),
+    dict(
+        options=["-c", "ruff.cfg", "-t", "py39"],
+        expect_opts=["--line-length=81", "--target-version=py39"],
+    ),
+    dict(
+        options=["-t", "py39", "-S"],
+        expect_opts=[
+            "--target-version=py39",
+            '--config=format.quote-style="preserve"',
+        ],
+    ),
+    dict(
+        options=["-c", "ruff.cfg", "-t", "py39", "-S"],
+        expect_opts=[
+            "--line-length=81",
+            "--target-version=py39",
+            '--config=format.quote-style="preserve"',
+        ],
+    ),
+    dict(options=["--preview"], expect_opts=["--preview"]),
+    expect_opts=[],
+)
+def test_ruff_options(monkeypatch, ruff_options_files, options, expect_opts):
+    """Ruff options from the command line are passed correctly to Ruff."""
+    ruff_options_files["main.py"].write_bytes(b'print ("Hello World!")\n')
+    with patch.object(ruff_formatter, "_ruff_format_stdin") as format_stdin:
+        format_stdin.return_value = 'print("Hello World!")\n'
+
+        main([*options, "--formatter=ruff", str(ruff_options_files["main.py"])])
+
+    format_stdin.assert_called_once_with(
+        'print ("Hello World!")\n',
+        Path("main.py"),
+        ['--config=lint.ignore=["ISC001"]', *expect_opts],
+    )

--- a/src/darker/tests/test_command_line_ruff.py
+++ b/src/darker/tests/test_command_line_ruff.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from darker.__main__ import main
 from darker.formatters import ruff_formatter
 from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
+from darkgraylib.utils import joinlines
 
 
 @pytest.fixture(scope="module")
@@ -99,4 +100,51 @@ def test_ruff_options(monkeypatch, ruff_options_files, options, expect_opts):
         'print ("Hello World!")\n',
         Path("main.py"),
         ['--config=lint.ignore=["ISC001"]', *expect_opts],
+    )
+
+
+@pytest.mark.kwparametrize(
+    dict(config=[], options=[], expect=[]),
+    dict(options=["--line-length=50"], expect=["--line-length=50"]),
+    dict(config=["line-length = 60"], expect=["--line-length=60"]),
+    dict(
+        config=["line-length = 60"],
+        options=["--line-length=50"],
+        expect=["--line-length=50"],
+    ),
+    dict(
+        options=["--skip-string-normalization"],
+        expect=['--config=format.quote-style="preserve"'],
+    ),
+    dict(options=["--no-skip-string-normalization"], expect=[]),
+    dict(
+        options=["--skip-magic-trailing-comma"],
+        expect=[
+            '--config="format.skip-magic-trailing-comma=true"',
+            '--config="lint.isort.split-on-trailing-comma=false"',
+        ],
+    ),
+    dict(options=["--target-version", "py39"], expect=["--target-version=py39"]),
+    dict(options=["--preview"], expect=["--preview"]),
+    config=[],
+    options=[],
+)
+def test_ruff_config_file_and_options(git_repo, config, options, expect):
+    """Ruff configuration file and command line options are combined correctly."""
+    # Only line length is both supported as a command line option and read by Darker
+    # from Ruff configuration.
+    added_files = git_repo.add(
+        {"main.py": "foo", "pyproject.toml": joinlines(["[tool.ruff]", *config])},
+        commit="Initial commit",
+    )
+    added_files["main.py"].write_bytes(b"a = [1, 2,]")
+    # Speed up tests by mocking `_ruff_format_stdin` to skip running Ruff
+    format_stdin = Mock(return_value="a = [1, 2,]")
+    with patch.object(ruff_formatter, "_ruff_format_stdin", format_stdin):
+        # end of test setup, now run the test:
+
+        main([*options, "--formatter=ruff", str(added_files["main.py"])])
+
+    format_stdin.assert_called_once_with(
+        "a = [1, 2,]", Path("main.py"), ['--config=lint.ignore=["ISC001"]', *expect]
     )

--- a/src/darker/tests/test_formatters_black.py
+++ b/src/darker/tests/test_formatters_black.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from importlib import reload
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 import pytest
 import regex
@@ -92,15 +92,8 @@ def test_formatter_without_black(caplog):
     ]
 
 
+@pytest.mark.parametrize("option_name_delimiter", ["-", "_"])
 @pytest.mark.kwparametrize(
-    dict(
-        config_path=None, config_lines=["line-length = 79"], expect={"line_length": 79}
-    ),
-    dict(
-        config_path="custom.toml",
-        config_lines=["line-length = 99"],
-        expect={"line_length": 99},
-    ),
     dict(
         config_lines=["skip-string-normalization = true"],
         expect={"skip_string_normalization": True},
@@ -136,7 +129,6 @@ def test_formatter_without_black(caplog):
         config_lines=["target-version = ['py39', 'py37']"],
         expect={"target_version": {(3, 9), (3, 7)}},
     ),
-    dict(config_lines=[r"include = '\.pyi$'"], expect={}),
     dict(
         config_lines=[r"exclude = '\.pyx$'"],
         expect={"exclude": RegexEquality("\\.pyx$")},
@@ -155,12 +147,16 @@ def test_formatter_without_black(caplog):
     ),
     config_path=None,
 )
-def test_read_config(tmpdir, config_path, config_lines, expect):
-    """`BlackFormatter.read_config` reads Black config correctly from a TOML file."""
+def test_read_config(tmpdir, option_name_delimiter, config_path, config_lines, expect):
+    """``read_config()`` reads Black config correctly from a TOML file."""
+    # Test both hyphen and underscore delimited option names
+    config = "\n".join(
+        line.replace("-", option_name_delimiter) for line in config_lines
+    )
     tmpdir = Path(tmpdir)
     src = tmpdir / "src.py"
     toml = tmpdir / (config_path or "pyproject.toml")
-    toml.write_text("[tool.black]\n{}\n".format("\n".join(config_lines)))
+    toml.write_text(f"[tool.black]\n{config}\n")
     with raises_or_matches(expect, []):
         formatter = BlackFormatter()
         args = Namespace()
@@ -255,38 +251,6 @@ def test_filter_python_files(  # pylint: disable=too-many-arguments
     assert result == expect_paths
 
 
-@pytest.mark.parametrize("encoding", ["utf-8", "iso-8859-1"])
-@pytest.mark.parametrize("newline", ["\n", "\r\n"])
-def test_run(encoding, newline):
-    """Running Black through its Python internal API gives correct results"""
-    src = TextDocument.from_lines(
-        [f"# coding: {encoding}", "print ( 'touché' )"],
-        encoding=encoding,
-        newline=newline,
-    )
-
-    result = BlackFormatter().run(src)
-
-    assert result.lines == (
-        f"# coding: {encoding}",
-        'print("touché")',
-    )
-    assert result.encoding == encoding
-    assert result.newline == newline
-
-
-@pytest.mark.parametrize("newline", ["\n", "\r\n"])
-def test_run_always_uses_unix_newlines(newline):
-    """Content is always passed to Black with Unix newlines"""
-    src = TextDocument.from_str(f"print ( 'touché' ){newline}")
-    with patch("darker.formatters.black_wrapper.format_str") as format_str:
-        format_str.return_value = 'print("touché")\n'
-
-        _ = BlackFormatter().run(src)
-
-    format_str.assert_called_once_with("print ( 'touché' )\n", mode=ANY)
-
-
 def test_run_ignores_excludes():
     """Black's exclude configuration is ignored by `BlackFormatter.run`."""
     src = TextDocument.from_str("a=1\n")
@@ -300,28 +264,6 @@ def test_run_ignores_excludes():
     result = formatter.run(src, Path("a.py"))
 
     assert result.string == "a = 1\n"
-
-
-@pytest.mark.parametrize(
-    "src_content, expect",
-    [
-        ("", ""),
-        ("\n", "\n"),
-        ("\r\n", "\r\n"),
-        (" ", ""),
-        ("\t", ""),
-        (" \t", ""),
-        (" \t\n", "\n"),
-        (" \t\r\n", "\r\n"),
-    ],
-)
-def test_run_all_whitespace_input(src_content, expect):
-    """All-whitespace files are reformatted correctly"""
-    src = TextDocument.from_str(src_content)
-
-    result = BlackFormatter().run(src)
-
-    assert result.string == expect
 
 
 @pytest.mark.kwparametrize(

--- a/src/darker/tests/test_formatters_black.py
+++ b/src/darker/tests/test_formatters_black.py
@@ -119,21 +119,22 @@ def test_formatter_without_black(caplog):
     ),
     dict(config_lines=["target-version ="], expect=tomllib.TOMLDecodeError()),
     dict(config_lines=["target-version = false"], expect=ConfigurationError()),
-    dict(config_lines=["target-version = 'py37'"], expect={"target_version": "py37"}),
+    dict(config_lines=["target-version = 'py37'"], expect={"target_version": (3, 7)}),
     dict(
-        config_lines=["target-version = ['py37']"], expect={"target_version": {"py37"}}
+        config_lines=["target-version = ['py37']"],
+        expect={"target_version": {(3, 7)}},
     ),
     dict(
         config_lines=["target-version = ['py39']"],
-        expect={"target_version": {"py39"}},
+        expect={"target_version": {(3, 9)}},
     ),
     dict(
         config_lines=["target-version = ['py37', 'py39']"],
-        expect={"target_version": {"py37", "py39"}},
+        expect={"target_version": {(3, 7), (3, 9)}},
     ),
     dict(
         config_lines=["target-version = ['py39', 'py37']"],
-        expect={"target_version": {"py39", "py37"}},
+        expect={"target_version": {(3, 9), (3, 7)}},
     ),
     dict(config_lines=[r"include = '\.pyi$'"], expect={}),
     dict(
@@ -326,27 +327,27 @@ def test_run_all_whitespace_input(src_content, expect):
 @pytest.mark.kwparametrize(
     dict(black_config={}),
     dict(
-        black_config={"target_version": "py37"},
+        black_config={"target_version": (3, 7)},
         expect_target_versions={TargetVersion.PY37},
     ),
     dict(
-        black_config={"target_version": "py39"},
+        black_config={"target_version": (3, 9)},
         expect_target_versions={TargetVersion.PY39},
     ),
     dict(
-        black_config={"target_version": {"py37"}},
+        black_config={"target_version": {(3, 7)}},
         expect_target_versions={TargetVersion.PY37},
     ),
     dict(
-        black_config={"target_version": {"py39"}},
+        black_config={"target_version": {(3, 9)}},
         expect_target_versions={TargetVersion.PY39},
     ),
     dict(
-        black_config={"target_version": {"py37", "py39"}},
+        black_config={"target_version": {(3, 7), (3, 9)}},
         expect_target_versions={TargetVersion.PY37, TargetVersion.PY39},
     ),
     dict(
-        black_config={"target_version": {"py39", "py37"}},
+        black_config={"target_version": {(3, 9), (3, 7)}},
         expect_target_versions={TargetVersion.PY37, TargetVersion.PY39},
     ),
     dict(

--- a/src/darker/tests/test_formatters_black.py
+++ b/src/darker/tests/test_formatters_black.py
@@ -297,7 +297,7 @@ def test_run_ignores_excludes():
         "force_exclude": regex.compile(r".*"),
     }
 
-    result = formatter.run(src)
+    result = formatter.run(src, Path("a.py"))
 
     assert result.string == "a = 1\n"
 
@@ -398,7 +398,7 @@ def test_run_configuration(
         formatter = BlackFormatter()
         formatter.config = black_config
 
-        check(formatter.run(src))
+        check(formatter.run(src, Path("a.py")))
 
         assert format_str.call_count == 1
         mode = format_str.call_args[1]["mode"]

--- a/src/darker/tests/test_formatters_black.py
+++ b/src/darker/tests/test_formatters_black.py
@@ -36,7 +36,7 @@ else:
     import tomli as tomllib
 
 if TYPE_CHECKING:
-    from darker.formatters.formatter_config import BlackConfig
+    from darker.formatters.formatter_config import BlackCompatibleConfig
 
 
 @dataclass
@@ -230,7 +230,7 @@ def test_filter_python_files(  # pylint: disable=too-many-arguments
     paths = {tmp_path / name for name in names}
     for path in paths:
         path.touch()
-    black_config: BlackConfig = {
+    black_config: BlackCompatibleConfig = {
         "exclude": regex.compile(exclude) if exclude else DEFAULT_EXCLUDE_RE,
         "extend_exclude": regex.compile(extend_exclude) if extend_exclude else None,
         "force_exclude": regex.compile(force_exclude) if force_exclude else None,

--- a/src/darker/tests/test_formatters_black_compatible.py
+++ b/src/darker/tests/test_formatters_black_compatible.py
@@ -1,0 +1,144 @@
+"""Unit tests for Black compatible formatter plugins."""
+
+# pylint: disable=use-dict-literal
+
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from darker.formatters import ruff_formatter
+from darker.formatters.black_formatter import BlackFormatter
+from darker.formatters.ruff_formatter import RuffFormatter
+from darkgraylib.testtools.helpers import raises_or_matches
+from darkgraylib.utils import TextDocument
+
+
+@pytest.mark.parametrize(
+    "formatter_setup",
+    [(BlackFormatter, "-"), (BlackFormatter, "_"), (RuffFormatter, "-")],
+)
+@pytest.mark.kwparametrize(
+    dict(
+        config_path=None, config_lines=["line-length = 79"], expect={"line_length": 79}
+    ),
+    dict(
+        config_path="custom.toml",
+        config_lines=["line-length = 99"],
+        expect={"line_length": 99},
+    ),
+    dict(config_lines=[r"include = '\.pyi$'"], expect={}),
+    config_path=None,
+)
+def test_read_config_black_and_ruff(
+    tmpdir, formatter_setup, config_path, config_lines, expect
+):
+    """``read_config()`` reads Black and Ruff config correctly from a TOML file."""
+    formatter_class, option_name_delimiter = formatter_setup
+    # For Black, we test both hyphen and underscore delimited option names
+    config = "\n".join(  # pylint: disable=duplicate-code
+        line.replace("-", option_name_delimiter) for line in config_lines
+    )
+    tmpdir = Path(tmpdir)
+    src = tmpdir / "src.py"
+    toml = tmpdir / (config_path or "pyproject.toml")
+    section = formatter_class.config_section
+    toml.write_text(f"[{section}]\n{config}\n")
+    with raises_or_matches(expect, []):
+        formatter = formatter_class()
+        args = Namespace()
+        args.config = config_path and str(toml)
+        if config_path:
+            expect["config"] = str(toml)
+
+        # pylint: disable=duplicate-code
+        formatter.read_config((str(src),), args)
+
+        assert formatter.config == expect
+
+
+@pytest.mark.parametrize("formatter_class", [BlackFormatter, RuffFormatter])
+@pytest.mark.parametrize("encoding", ["utf-8", "iso-8859-1"])
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_run(formatter_class, encoding, newline):
+    """Running formatter through their plugin ``run`` method gives correct results."""
+    src = TextDocument.from_lines(
+        [f"# coding: {encoding}", "print ( 'touché' )"],
+        encoding=encoding,
+        newline=newline,
+    )
+
+    result = formatter_class().run(src, Path("a.py"))
+
+    assert result.lines == (
+        f"# coding: {encoding}",
+        'print("touché")',
+    )
+    assert result.encoding == encoding
+    assert result.newline == newline
+
+
+@pytest.mark.parametrize(
+    "formatter_setup",
+    [
+        (BlackFormatter, "darker.formatters.black_wrapper.format_str"),
+        (RuffFormatter, "darker.formatters.ruff_formatter._ruff_format_stdin"),
+    ],
+)
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_run_always_uses_unix_newlines(formatter_setup, newline):
+    """Content is always passed to Black and Ruff with Unix newlines."""
+    formatter_class, formatter_func_name = formatter_setup
+    src = TextDocument.from_str(f"print ( 'touché' ){newline}")
+    with patch(formatter_func_name) as formatter_func:
+        formatter_func.return_value = 'print("touché")\n'
+
+        _ = formatter_class().run(src, Path("a.py"))
+
+    (formatter_func_call,) = formatter_func.call_args_list
+    assert formatter_func_call.args[0] == "print ( 'touché' )\n"
+
+
+@pytest.mark.parametrize("formatter_class", [BlackFormatter, RuffFormatter])
+@pytest.mark.parametrize(
+    ("src_content", "expect"),
+    [
+        ("", ""),
+        ("\n", "\n"),
+        ("\r\n", "\r\n"),
+        (" ", ""),
+        ("\t", ""),
+        (" \t", ""),
+        (" \t\n", "\n"),
+        (" \t\r\n", "\r\n"),
+    ],
+)
+def test_run_all_whitespace_input(formatter_class, src_content, expect):
+    """All-whitespace files are reformatted correctly."""
+    src = TextDocument.from_str(src_content)
+
+    result = formatter_class().run(src, Path("a.py"))
+
+    assert result.string == expect
+
+
+@pytest.mark.kwparametrize(
+    dict(formatter_config={}, expect=[]),
+    dict(formatter_config={"line_length": 80}, expect=["--line-length=80"]),
+)
+def test_run_configuration(formatter_config, expect):
+    """`RuffFormatter.run` passes correct configuration to Ruff."""
+    src = TextDocument.from_str("import  os\n")
+    with patch.object(ruff_formatter, "_ruff_format_stdin") as format_stdin:
+        format_stdin.return_value = "import os\n"
+        formatter = RuffFormatter()
+        formatter.config = formatter_config
+
+        formatter.run(src, Path("a.py"))
+
+        format_stdin.assert_called_once_with(
+            "import  os\n",
+            Path("a.py"),
+            ['--config=lint.ignore=["ISC001"]', *expect],
+        )

--- a/src/darker/tests/test_formatters_ruff.py
+++ b/src/darker/tests/test_formatters_ruff.py
@@ -1,0 +1,66 @@
+"""Unit tests for `darker.formatters.ruff_formatter`."""
+
+# pylint: disable=redefined-outer-name
+
+from subprocess import run  # nosec
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from darker.formatters import ruff_formatter
+
+
+def test_get_supported_target_versions():
+    """`ruff_formatter._get_supported_target_versions` runs Ruff, gets py versions."""
+    with patch.object(ruff_formatter, "run") as run_mock:
+        run_mock.return_value.stdout = dedent(
+            """
+            Default value: "py38"
+            Type: "py37" | "py38" | "py39" | "py310" | "py311" | "py312"
+            Example usage:
+            """
+        )
+
+        # pylint: disable=protected-access
+        result = ruff_formatter._get_supported_target_versions()  # noqa: SLF001
+
+    assert result == {
+        (3, 7): "py37",
+        (3, 8): "py38",
+        (3, 9): "py39",
+        (3, 10): "py310",
+        (3, 11): "py311",
+        (3, 12): "py312",
+    }
+
+
+@pytest.fixture
+def ruff():
+    """Make a Ruff call and return the `subprocess.CompletedProcess` instance."""
+    cmdline = [
+        "ruff",
+        "format",
+        "--force-exclude",  # apply `exclude =` from conffile even with stdin
+        "--stdin-filename=myfile.py",  # allow to match exclude patterns
+        '--config=lint.ignore=["ISC001"]',
+        "-",
+    ]
+    return run(  # noqa: S603  # nosec
+        cmdline, input="print( 1)\n", capture_output=True, check=False, text=True
+    )
+
+
+def test_ruff_returncode(ruff):
+    """A basic Ruff subprocess call returns a zero returncode."""
+    assert ruff.returncode == 0
+
+
+def test_ruff_stderr(ruff):
+    """A basic Ruff subprocess call prints nothing on standard error."""
+    assert ruff.stderr == ""
+
+
+def test_ruff_stdout(ruff):
+    """A basic Ruff subprocess call prints the reformatted file on standard output."""
+    assert ruff.stdout == "print(1)\n"

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -278,7 +278,8 @@ def test_main(
     assert retval == expect_retval
 
 
-def test_main_in_plain_directory(tmp_path, capsys):
+@pytest.mark.parametrize("formatter", [[], ["--formatter=black"], ["--formatter=ruff"]])
+def test_main_in_plain_directory(tmp_path, capsys, formatter):
     """Darker works also in a plain directory tree"""
     subdir_a = tmp_path / "subdir_a"
     subdir_c = tmp_path / "subdir_b/subdir_c"
@@ -289,7 +290,7 @@ def test_main_in_plain_directory(tmp_path, capsys):
     (subdir_c / "another python file.py").write_text("a  =5")
 
     retval = darker.__main__.main(
-        ["--diff", "--check", "--isort", "--lint", "dummy", str(tmp_path)],
+        [*formatter, "--diff", "--check", "--isort", "--lint", "dummy", str(tmp_path)],
     )
 
     assert retval == 1
@@ -319,18 +320,19 @@ def test_main_in_plain_directory(tmp_path, capsys):
     )
 
 
+@pytest.mark.parametrize("formatter", [[], ["--formatter=black"], ["--formatter=ruff"]])
 @pytest.mark.parametrize(
     "encoding, text", [(b"utf-8", b"touch\xc3\xa9"), (b"iso-8859-1", b"touch\xe9")]
 )
 @pytest.mark.parametrize("newline", [b"\n", b"\r\n"])
-def test_main_encoding(git_repo, encoding, text, newline):
+def test_main_encoding(git_repo, formatter, encoding, text, newline):
     """Encoding and newline of the file is kept unchanged after reformatting"""
     paths = git_repo.add({"a.py": newline.decode("ascii")}, commit="Initial commit")
     edited = [b"# coding: ", encoding, newline, b's="', text, b'"', newline]
     expect = [b"# coding: ", encoding, newline, b's = "', text, b'"', newline]
     paths["a.py"].write_bytes(b"".join(edited))
 
-    retval = darker.__main__.main(["a.py"])
+    retval = darker.__main__.main([*formatter, "a.py"])
 
     result = paths["a.py"].read_bytes()
     assert retval == 0
@@ -409,7 +411,8 @@ def test_main_historical_pre_commit(git_repo, monkeypatch):
         darker.__main__.main(["--revision=:PRE-COMMIT:", "a.py"])
 
 
-def test_main_vscode_tmpfile(git_repo, capsys):
+@pytest.mark.parametrize("formatter", [[], ["--formatter=black"], ["--formatter=ruff"]])
+def test_main_vscode_tmpfile(git_repo, capsys, formatter):
     """Main function handles VSCode `.py.<HASH>.tmp` files correctly"""
     _ = git_repo.add(
         {"a.py": "print ( 'reformat me' ) \n"},
@@ -417,7 +420,7 @@ def test_main_vscode_tmpfile(git_repo, capsys):
     )
     (git_repo.root / "a.py.hash.tmp").write_text("print ( 'reformat me now' ) \n")
 
-    retval = darker.__main__.main(["--diff", "a.py.hash.tmp"])
+    retval = darker.__main__.main([*formatter, "--diff", "a.py.hash.tmp"])
 
     assert retval == 0
     outerr = capsys.readouterr()

--- a/src/darker/tests/test_main_reformat_and_flynt_single_file.py
+++ b/src/darker/tests/test_main_reformat_and_flynt_single_file.py
@@ -10,6 +10,7 @@ import pytest
 from darker.__main__ import _reformat_and_flynt_single_file
 from darker.config import Exclusions
 from darker.formatters.black_formatter import BlackFormatter
+from darker.formatters.ruff_formatter import RuffFormatter
 from darker.git import EditedLinenumsDiffer
 from darkgraylib.git import RevisionRange
 from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
@@ -69,6 +70,7 @@ def reformat_and_flynt_single_file_repo(request, tmp_path_factory):
     exclusions=Exclusions(),
     expect="import  original\nprint( original )\n",
 )
+@pytest.mark.parametrize("formatter_class", [BlackFormatter, RuffFormatter])
 def test_reformat_and_flynt_single_file(
     reformat_and_flynt_single_file_repo,
     relative_path,
@@ -76,6 +78,7 @@ def test_reformat_and_flynt_single_file(
     rev2_isorted,
     exclusions,
     expect,
+    formatter_class,
 ):
     """Test for `_reformat_and_flynt_single_file`."""
     repo = reformat_and_flynt_single_file_repo
@@ -88,13 +91,14 @@ def test_reformat_and_flynt_single_file(
         TextDocument(rev2_content),
         TextDocument(rev2_isorted),
         has_isort_changes=False,
-        formatter=BlackFormatter(),
+        formatter=formatter_class(),
     )
 
     assert result.string == expect
 
 
-def test_blacken_and_flynt_single_file_common_ancestor(git_repo):
+@pytest.mark.parametrize("formatter_class", [BlackFormatter, RuffFormatter])
+def test_blacken_and_flynt_single_file_common_ancestor(git_repo, formatter_class):
     """`_blacken_and_flynt_single_file` diffs to common ancestor of ``rev1...rev2``."""
     a_py_initial = dedent(
         """\
@@ -151,7 +155,7 @@ def test_blacken_and_flynt_single_file_common_ancestor(git_repo):
         rev2_content=worktree,
         rev2_isorted=worktree,
         has_isort_changes=False,
-        formatter=BlackFormatter(),
+        formatter=formatter_class(),
     )
 
     assert result.lines == (
@@ -163,7 +167,8 @@ def test_blacken_and_flynt_single_file_common_ancestor(git_repo):
     )
 
 
-def test_reformat_single_file_docstring(git_repo):
+@pytest.mark.parametrize("formatter_class", [BlackFormatter, RuffFormatter])
+def test_reformat_single_file_docstring(git_repo, formatter_class):
     """`_blacken_and_flynt_single_file()` handles docstrings as one contiguous block."""
     initial = dedent(
         '''\
@@ -210,7 +215,7 @@ def test_reformat_single_file_docstring(git_repo):
         rev2_content=TextDocument.from_str(modified),
         rev2_isorted=TextDocument.from_str(modified),
         has_isort_changes=False,
-        formatter=BlackFormatter(),
+        formatter=formatter_class(),
     )
 
     assert result.lines == tuple(expect.splitlines())

--- a/src/darker/tests/test_main_stdin_filename.py
+++ b/src/darker/tests/test_main_stdin_filename.py
@@ -2,9 +2,10 @@
 
 # pylint: disable=no-member,redefined-outer-name,too-many-arguments,use-dict-literal
 
+from __future__ import annotations
+
 from io import BytesIO
 from types import SimpleNamespace
-from typing import List, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -148,14 +149,16 @@ def main_stdin_filename_repo(request, tmp_path_factory):
     expect=0,
     expect_a_py="original\n",
 )
+@pytest.mark.parametrize("formatter", [[], ["--formatter=black"], ["--formatter=ruff"]])
 def test_main_stdin_filename(
     main_stdin_filename_repo: SimpleNamespace,
-    config_src: Optional[List[str]],
-    src: List[str],
-    stdin_filename: Optional[str],
-    revision: Optional[str],
+    config_src: list[str] | None,
+    src: list[str],
+    stdin_filename: str | None,
+    revision: str | None,
     expect: int,
     expect_a_py: str,
+    formatter: list[str],
 ) -> None:
     """Tests for `darker.__main__.main` and the ``--stdin-filename`` option"""
     repo = main_stdin_filename_repo
@@ -177,7 +180,7 @@ def test_main_stdin_filename(
     ), raises_if_exception(expect):
         # end of test setup
 
-        retval = darker.__main__.main(arguments)
+        retval = darker.__main__.main([*formatter, *arguments])
 
         assert retval == expect
         assert repo.paths["a.py"].read_text() == expect_a_py


### PR DESCRIPTION
Fixes #521

- [x] Review #568
- [x] Merge #568
- [x] Review #738
- [x] Merge #738
- [x] Review #761
- [x] Merge #761
- [x] Rebase on `master`
- [x] Review #759
- [x] Merge #759
- [x] Rebase on `master` 
- [x] Review #792
- [x] Merge #792
- [x] Rebase on `master` 