### PR TITLE
fix: include flynt in darkerconfig

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Added
 - Invoking Black is now implemented as a plugin. This allows for easier integration of
   other formatters in the future. There's also a dummy ``none`` formatter plugin.
 - ``--formatter=none`` now skips running Black. This is useful when you only want to run
-  Isort or Flynt.
+  Isort or Flynt_.
 
 Removed
 -------
@@ -42,6 +42,7 @@ Fixed
 - Pass full environment to Git to avoid the "dubious ownership" error.
 - Work around a `pathlib.Path.resolve` bug in Python 3.8 and 3.9 on Windows.
   The work-around should be removed when Python 3.8 and 3.9 are no longer supported.
+- Add missing configuration flag for Flynt_.
 
 
 2.1.1_ - 2024-04-16
@@ -79,7 +80,7 @@ Added
 - Update to ``ioggstream/bandit-report-artifacts@v1.7.4`` in CI.
 - Support for Python 3.12 in the package metadata and the CI build.
 - Update to Black 24.2.x and isort 5.13.x in pre-commit configuration.
-- Test against Flynt ``master`` branch in the CI build.
+- Test against Flynt_ ``master`` branch in the CI build.
 - Update to Darkgraylib 1.1.1 to get fixes for README formatting.
 - Improved "How does it work?" section in the README.
 - README section on limitations and work-arounds.
@@ -189,7 +190,7 @@ Fixed
 -----
 - Use ``git worktree`` to create a repository checkout for baseline linting. This avoids
   issues with the previous ``git clone`` and ``git checkout`` based approach.
-- Disallow Flynt version 0.78 and newer to avoid an internal API incompatibility.
+- Disallow Flynt_ version 0.78 and newer to avoid an internal API incompatibility.
 - In CI builds, run the ``commit-range`` action from the current checkout instead of
   pointing to a release tag. This fixes workflows when in a release branch.
 - Linting fixes: Use ``stacklevel=2`` in ``warnings.warn()`` calls as suggested by
@@ -678,6 +679,7 @@ Added
 .. _pygments: https://pypi.org/project/Pygments/
 .. _Darkgraylib: https://pypi.org/project/darkgraylib/
 .. _Flake8: https://flake8.pycqa.org/
+.. _Flynt: https://pypi.org/project/flynt/
 .. _Graylint: https://pypi.org/project/graylint/
 .. _Mypy: https://www.mypy-lang.org/
 .. _pydocstyle: http://www.pydocstyle.org/

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -37,6 +37,7 @@ class DarkerConfig(BaseConfig, total=False):
     """Dictionary representing ``[tool.darker]`` from ``pyproject.toml``"""
 
     diff: bool
+    flynt: bool
     check: bool
     isort: bool
     lint: list[str]

--- a/src/darker/config.py
+++ b/src/darker/config.py
@@ -36,14 +36,14 @@ DEPRECATED_CONFIG_OPTIONS: set[str] = set()
 class DarkerConfig(BaseConfig, total=False):
     """Dictionary representing ``[tool.darker]`` from ``pyproject.toml``"""
 
+    check: bool
     diff: bool
     flynt: bool
-    check: bool
     isort: bool
-    lint: list[str]
-    skip_string_normalization: bool
-    skip_magic_trailing_comma: bool
     line_length: int
+    lint: list[str]
+    skip_magic_trailing_comma: bool
+    skip_string_normalization: bool
     target_version: str
     formatter: str
 

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -114,6 +114,24 @@ def get_darker_help_output(capsys):
     ),
     dict(
         argv=["."],
+        expect_value=("flynt", False),
+        expect_config=("flynt", False),
+        expect_modified=("flynt", ...),
+    ),
+    dict(
+        argv=["-f", "."],
+        expect_value=("flynt", True),
+        expect_config=("flynt", True),
+        expect_modified=("flynt", True),
+    ),
+    dict(
+        argv=["--flynt", "."],
+        expect_value=("flynt", True),
+        expect_config=("flynt", True),
+        expect_modified=("flynt", True),
+    ),
+    dict(
+        argv=["."],
         expect_value=("lint", []),
         expect_config=("lint", []),
         expect_modified=("lint", ...),
@@ -280,6 +298,7 @@ def test_parse_command_line(
     dict(config={"stdout": True}, expect_warn=set()),
     dict(config={"check": True}, expect_warn=set()),
     dict(config={"isort": True}, expect_warn=set()),
+    dict(config={"flynt": True}, expect_warn=set()),
     dict(
         config={"lint": ["dummy"]},
         expect_warn={
@@ -690,6 +709,16 @@ def test_black_config_file_and_options(git_repo, config, options, expect):
             Path("git_root"),
             {Path("a.py")},
             Exclusions(flynt={"**/*"}),
+            RevisionRange("HEAD", ":WORKTREE:"),
+            {},
+        ),
+    ),
+    dict(
+        options=["--flynt", "a.py"],
+        expect=(
+            Path("git_root"),
+            {Path("a.py")},
+            Exclusions(isort={"**/*"}),
             RevisionRange("HEAD", ":WORKTREE:"),
             {},
         ),


### PR DESCRIPTION
Included `flynt` in DarkerConfig options.

Also sorted config options alphabetically. 

Fixes #745.