### PR TITLE
fix: keep Pylint at max version 3.2.7

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
             git+https://github.com/akaihola/darkgraylib.git@main \
             defusedxml \
             pygments \
-            pylint \
+            'pylint<=3.2.7' \
             pytest>=6.2.0 \
             regex \
             requests \

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Added
 - CI workflow to post recent project activity in a discussion. Triggered manually.
 - The ``--preview`` configuration flag is now supported in the configuration files for
   Darker and Black
+- Prevent Pylint from updating beyond version 3.2.7 due to dropped Python 3.8 support.
 
 Removed
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ test =
     pathspec  # to test `gen_python_files` in `test_black_diff.py`
     pydocstyle
     pygments
-    pylint
+    pylint<=3.2.7  # pylint 3.3.0 dropped Python 3.8 support
     pytest>=6.2.0
     pytest-kwparametrize>=0.0.3
     regex>=2021.4.4


### PR DESCRIPTION
This way we continue to support Python 3.8 for just a bit longer. Pylint 3.3.0 already dropped support for Python 3.8.