### PR TITLE
Use uv and/or non system Python in CI workflows

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - uses: TrueBrain/actions-flake8@v2
         with:
           plugins: >

--- a/.github/workflows/help-in-readme.yml
+++ b/.github/workflows/help-in-readme.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install '.[flynt,isort]'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Verify that README contains output of darker --help
-        run: darker --verify-readme
+        run: uvx --from '.[flynt,isort]' darker --verify-readme

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install 'isort>=5.0.1'
-      - uses: wearerequired/lint-action@v2.3.0
+      - uses: akaihola/lint-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           isort: true

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - run: pip install 'isort>=5.0.1'
       - uses: wearerequired/lint-action@v2.3.0
         with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,11 +9,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: |
-          pip install -U \
+          uv pip install --system -U \
             black \
             git+https://github.com/akaihola/darkgraylib.git@main \
             flynt \

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - run: |
           pip install -U \
             black \

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,12 +9,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies for running Pylint
         run: |
-          pip install -U \
+          uv pip install --system -U \
             black \
             git+https://github.com/akaihola/darkgraylib.git@main \
             defusedxml \
@@ -26,7 +28,7 @@ jobs:
             requests-cache \
             ruamel.yaml \
             toml
-          pip list
+          uv pip list --system
       - uses: wearerequired/lint-action@v2.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,6 +27,7 @@ jobs:
             requests \
             requests-cache \
             ruamel.yaml \
+            setuptools \
             toml
           uv pip list --system
       - uses: wearerequired/lint-action@v2.3.0

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Install dependencies for running Pylint
         run: |
           pip install -U \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,11 +20,11 @@ jobs:
       wheel-path: ${{ steps.get-darker-version.outputs.wheel-path }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
-      - name: Install wheel
-        run: python -m pip install wheel
       - name: Build wheel distribution
-        run: python setup.py bdist_wheel
+        run: uv build --wheel
       - name: Upload wheel for other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -146,12 +146,12 @@ jobs:
       - build-wheel
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
-      - name: Install twine
-        run: python -m pip install twine
       - name: Download wheel uploaded by the build-wheel job
         uses: actions/download-artifact@v4.1.7
       - name: Build source distribution
-        run: python setup.py sdist
+        run: uv build --sdist
       - name: Validate distributions
-        run: twine check dist/*
+        run: uvx twine check dist/*

--- a/.github/workflows/pyupgrade.yml
+++ b/.github/workflows/pyupgrade.yml
@@ -9,12 +9,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
-      - run: pip install pyupgrade
       - name: Ensure modern Python style using pyupgrade
         # This script is written in a Linux / macos / windows portable way
         run: |
-          python -c "
+          uvx --from pyupgrade python -c "
           import sys
           from pyupgrade._main import main
           from glob import glob

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
-      - run: pip install -U pip-tools
-      - run: pip-compile setup.cfg
-      - run: pip install -U safety
+      - run: uvx --from pip-tools pip-compile setup.cfg
       - name: Check dependencies for known security vulnerabilities using Safety
-        run: safety check --file requirements.txt
+        run: uvx safety check --file requirements.txt

--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
 
       - name: Make sure that `darkgray_bump_version` still finds all version strings
@@ -20,9 +22,7 @@ jobs:
         # This is used to update the call for reviewing pull requests
         # in `README.rst`.
         run: |
-          pip install \
-            https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
-          darkgray_bump_version \
+          uvx --from=darkgray-dev-tools darkgray_bump_version \
             --minor \
             --dry-run \
             --token=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Solve the problem introduced by GitHub switching `ubuntu-latest` to Ubuntu 24.04. See e.g. [build #2497](/akaihola/darker/actions/runs/11308368324/job/31451129452?pr=738).

Also speeds up builds.

Probably we should pin to `ubuntu-24.04` and update in a controlled manner to prevent similar issues in the future.