### PR TITLE
Speed up parameterized tests which use Git

### DIFF
--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -4,7 +4,7 @@
 # interpreter and Python ependencies. Keep this up-to-date with minimum
 # versions in `setup.cfg`.
 black==22.3.0
-darkgraylib==2.0.1
+darkgraylib==2.1.0
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ ignore = [
     "ANN001",  # Missing type annotation for function argument
     "ANN201",  # Missing return type annotation for public function
     "ANN204",  # Missing return type annotation for special method `__init__`
+    "ARG001",  # Unused function argument
     "C408",  # Unnecessary `dict` call (rewrite as a literal)
     "PLR0913",  # Too many arguments in function definition (n > 5)
     "S101",  # Use of `assert` detected

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
     black>=22.3.0
-    darkgraylib~=2.0.1
+    darkgraylib~=2.1.0
     toml>=0.10.0
     typing_extensions>=4.0.1
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync

--- a/src/darker/tests/conftest.py
+++ b/src/darker/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Configuration and fixtures for the Pytest based test suite."""
+
+import pytest
+
+try:
+    from black.files import _load_toml
+except ImportError:
+    # Black 24.1.1 and earlier don't have `_load_toml`.
+    _load_toml = None  # type: ignore[assignment]
+
+
+@pytest.fixture
+def load_toml_cache_clear() -> None:
+    """Clear LRU caching in `black.files._load_toml` before each test.
+
+    To use this on all test cases in a test module, add this to the top::
+
+        pytestmark = pytest.mark.usefixtures("load_toml_cache_clear")
+
+    """
+    if _load_toml:
+        # Black 24.1.1 and earlier don't have `_load_toml`, so no LRU cache to clear.
+        _load_toml.cache_clear()

--- a/src/darker/tests/helpers.py
+++ b/src/darker/tests/helpers.py
@@ -6,6 +6,8 @@ from types import ModuleType
 from typing import Generator, Optional
 from unittest.mock import patch
 
+from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
+
 
 @contextmanager
 def _package_present(
@@ -43,3 +45,12 @@ def flynt_present(present: bool) -> Generator[None, None, None]:
             fake_flynt_module.code_editor = ModuleType("process")  # type: ignore
             fake_flynt_module.code_editor.fstringify_code_by_line = None  # type: ignore
         yield
+
+
+@contextmanager
+def unix_and_windows_newline_repos(request, tmp_path_factory):
+    """Create temporary repositories for Unix and windows newlines separately."""
+    with GitRepoFixture.context(
+        request, tmp_path_factory
+    ) as repo_unix, GitRepoFixture.context(request, tmp_path_factory) as repo_windows:
+        yield {"\n": repo_unix, "\r\n": repo_windows}

--- a/src/darker/tests/test_command_line.py
+++ b/src/darker/tests/test_command_line.py
@@ -1,7 +1,7 @@
 """Unit tests for `darker.command_line` and `darker.__main__`."""
 
 # pylint: disable=too-many-arguments,too-many-locals
-# pylint: disable=no-member,redefined-outer-name,use-dict-literal
+# pylint: disable=no-member,redefined-outer-name,unused-argument,use-dict-literal
 
 from __future__ import annotations
 
@@ -842,6 +842,14 @@ def test_options(options_repo, monkeypatch, options, expect):
     assert retval == 0
 
 
+@pytest.fixture(scope="module")
+def main_retval_repo(request, tmp_path_factory):
+    """Git repository fixture for the `test_main_retval` test."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        repo.add({"a.py": ""}, commit="Initial commit")
+        yield
+
+
 @pytest.mark.kwparametrize(
     dict(arguments=["a.py"], changes=False),
     dict(arguments=["a.py"], changes=True),
@@ -849,9 +857,8 @@ def test_options(options_repo, monkeypatch, options, expect):
     dict(arguments=["--check", "a.py"], changes=True, expect_retval=1),
     expect_retval=0,
 )
-def test_main_retval(git_repo, arguments, changes, expect_retval):
+def test_main_retval(main_retval_repo, arguments, changes, expect_retval):
     """``main()`` return value is correct based on ``--check`` and reformatting."""
-    git_repo.add({"a.py": ""}, commit="Initial commit")
     format_edited_parts = Mock()
     format_edited_parts.return_value = (
         [

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -14,7 +14,6 @@ import darker.import_sorting
 from darker.git import EditedLinenumsDiffer
 from darker.tests.helpers import isort_present, unix_and_windows_newline_repos
 from darkgraylib.git import RevisionRange
-from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
 from darkgraylib.utils import TextDocument, joinlines
 
 ORIGINAL_SOURCE = ("import sys", "import os", "", "print(42)")
@@ -186,7 +185,6 @@ def test_isort_config(monkeypatch, tmpdir, line_length, settings_file, expect):
     line_length=None,
 )
 def test_build_isort_args(
-    git_repo: GitRepoFixture,
     src: Path,
     config: Optional[str],
     line_length: int,

--- a/src/darker/tests/test_import_sorting.py
+++ b/src/darker/tests/test_import_sorting.py
@@ -96,11 +96,12 @@ def test_apply_isort(apply_isort_repo_root, encoding, newline, content, expect):
         expect=("import   sys", "import os", "", "print(42)"),
     ),
 )
-def test_apply_isort_exclude(git_repo, encoding, newline, content, exclude, expect):
+def test_apply_isort_exclude(
+    apply_isort_repo_root, encoding, newline, content, exclude, expect
+):
     """Import sorting is skipped if file path matches exclusion patterns"""
-    git_repo.add({"test1.py": joinlines(ORIGINAL_SOURCE, newline)}, commit="Initial")
     edited_linenums_differ = EditedLinenumsDiffer(
-        git_repo.root, RevisionRange("HEAD", ":WORKTREE:")
+        apply_isort_repo_root[newline], RevisionRange("HEAD", ":WORKTREE:")
     )
     src = Path("test1.py")
     content_ = TextDocument.from_lines(content, encoding=encoding, newline=newline)

--- a/src/darker/tests/test_main.py
+++ b/src/darker/tests/test_main.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`darker.__main__`"""
 
 # pylint: disable=too-many-locals,use-implicit-booleaness-not-comparison,unused-argument
-# pylint: disable=protected-access,redefined-outer-name,too-many-arguments
+# pylint: disable=no-member,protected-access,redefined-outer-name,too-many-arguments
 # pylint: disable=use-dict-literal
 
 import random
@@ -12,6 +12,7 @@ from argparse import ArgumentError
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run  # nosec
 from textwrap import dedent
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -22,12 +23,15 @@ from darker.git import EditedLinenumsDiffer
 from darker.help import LINTING_GUIDE
 from darker.terminal import output
 from darker.tests.examples import A_PY, A_PY_BLACK, A_PY_BLACK_FLYNT, A_PY_BLACK_ISORT
+from darker.tests.helpers import unix_and_windows_newline_repos
 from darker.tests.test_fstring import FLYNTED_SOURCE, MODIFIED_SOURCE, ORIGINAL_SOURCE
 from darkgraylib.git import RevisionRange
 from darkgraylib.testtools.highlighting_helpers import BLUE, CYAN, RESET, WHITE, YELLOW
 from darkgraylib.utils import WINDOWS, TextDocument, joinlines
 
-pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
+pytestmark = pytest.mark.usefixtures(
+    "find_project_root_cache_clear", "load_toml_cache_clear"
+)
 
 
 def randomword(length: int) -> str:
@@ -84,6 +88,19 @@ A_PY_DIFF_BLACK_FLYNT = [
     "+",
     '+print("42")',
 ]
+
+
+@pytest.fixture(scope="module")
+def main_repo(request, tmp_path_factory):
+    """Create Git repositories to test `darker.__main__.main`."""
+    fixture = {}
+    with unix_and_windows_newline_repos(request, tmp_path_factory) as repos:
+        for newline, repo in repos.items():
+            paths = repo.add(
+                {"subdir/a.py": newline, "b.py": newline}, commit="Initial commit"
+            )
+            fixture[newline] = SimpleNamespace(root=repo.root, paths=paths)
+        yield fixture
 
 
 @pytest.mark.kwparametrize(
@@ -190,7 +207,7 @@ A_PY_DIFF_BLACK_FLYNT = [
 )
 @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["unix", "windows"])
 def test_main(
-    git_repo,
+    main_repo,
     monkeypatch,
     capsys,
     arguments,
@@ -203,27 +220,21 @@ def test_main(
     tmp_path_factory,
 ):
     """Main function outputs diffs and modifies files correctly"""
+    repo = main_repo[newline]
     if root_as_cwd:
-        cwd = git_repo.root
+        cwd = repo.root
         pwd = Path("")
     else:
         cwd = tmp_path_factory.mktemp("not_a_git_repo")
-        pwd = git_repo.root
+        pwd = repo.root
     monkeypatch.chdir(cwd)
-    paths = git_repo.add(
-        {
-            "pyproject.toml": dedent(pyproject_toml),
-            "subdir/a.py": newline,
-            "b.py": newline,
-        },
-        commit="Initial commit",
-    )
-    paths["subdir/a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
-    paths["b.py"].write_bytes(f"print(42 ){newline}".encode("ascii"))
+    (repo.root / "pyproject.toml").write_text(dedent(pyproject_toml))
+    repo.paths["subdir/a.py"].write_bytes(newline.join(A_PY).encode("ascii"))
+    repo.paths["b.py"].write_bytes(f"print(42 ){newline}".encode("ascii"))
 
     retval = darker.__main__.main(arguments + [str(pwd / "subdir")])
 
-    stdout = capsys.readouterr().out.replace(str(git_repo.root), "")
+    stdout = capsys.readouterr().out.replace(str(repo.root), "")
     diff_output = stdout.splitlines(False)
     if expect_stdout:
         if "--diff" in arguments:
@@ -237,10 +248,10 @@ def test_main(
         else:
             assert all("\t" not in line for line in diff_output)
     assert diff_output == expect_stdout
-    assert paths["subdir/a.py"].read_bytes().decode("ascii") == newline.join(
+    assert repo.paths["subdir/a.py"].read_bytes().decode("ascii") == newline.join(
         expect_a_py
     )
-    assert paths["b.py"].read_bytes().decode("ascii") == f"print(42 ){newline}"
+    assert repo.paths["b.py"].read_bytes().decode("ascii") == f"print(42 ){newline}"
     assert retval == expect_retval
 
 

--- a/src/darker/tests/test_main_isort.py
+++ b/src/darker/tests/test_main_isort.py
@@ -1,6 +1,6 @@
 """Tests for the ``--isort`` option of the ``darker`` command-line interface."""
 
-# pylint: disable=redefined-outer-name,unused-argument,use-dict-literal
+# pylint: disable=no-member,redefined-outer-name,unused-argument,use-dict-literal
 
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -12,13 +12,23 @@ import darker.import_sorting
 from darker.exceptions import MissingPackageError
 from darker.formatters import black_formatter
 from darker.tests.helpers import isort_present
+from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
 from darkgraylib.utils import TextDocument
 
 # Need to clear Black's `find_project_root` cache between tests
 pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 
 
-def test_isort_option_without_isort(git_repo):
+@pytest.fixture(scope="module")
+def isort_repo(request, tmp_path_factory):
+    """Git repository fixture for `test_isort_option_with_isort*`."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        paths = repo.add({"test1.py": "original"}, commit="Initial commit")
+        paths["test1.py"].write_bytes(b"changed")
+        yield repo
+
+
+def test_isort_option_without_isort(isort_repo):
     """Without isort, provide isort install instructions and error."""
     # The `git_repo` fixture ensures test is not run in the Darker repository clone in
     # CI builds. It helps avoid a NixOS test issue.
@@ -37,32 +47,33 @@ def test_isort_option_without_isort(git_repo):
 
 
 @pytest.fixture()
-def run_isort(git_repo, monkeypatch, caplog, request):
+def run_isort(isort_repo, make_temp_copy, monkeypatch, caplog, request):
     """Fixture for running Darker with requested arguments and a patched `isort`.
 
     Provides an `run_isort.isort_code` mock object which allows checking whether and how
     the `isort.code()` function was called.
 
     """
-    monkeypatch.chdir(git_repo.root)
-    paths = git_repo.add({"test1.py": "original"}, commit="Initial commit")
-    paths["test1.py"].write_bytes(b"changed")
-    args = getattr(request, "param", ())
-    isorted_code = "import os; import sys;"
-    blacken_code = "import os\nimport sys\n"
-    patch_run_black_ctx = patch.object(
-        black_formatter.BlackFormatter,
-        "run",
-        return_value=TextDocument(blacken_code),
-    )
-    with patch_run_black_ctx, patch("darker.import_sorting.isort_code") as isort_code:
-        isort_code.return_value = isorted_code
-        darker.__main__.main(["--isort", "./test1.py", *args])
-        return SimpleNamespace(
-            isort_code=isort_code,
-            caplog=caplog,
-            root=git_repo.root,
+    with make_temp_copy(isort_repo.root) as root:
+        monkeypatch.chdir(root)
+        args = getattr(request, "param", ())
+        isorted_code = "import os; import sys;"
+        blacken_code = "import os\nimport sys\n"
+        patch_run_black_ctx = patch.object(
+            black_formatter.BlackFormatter,
+            "run",
+            return_value=TextDocument(blacken_code),
         )
+        with patch_run_black_ctx, patch(
+            "darker.import_sorting.isort_code"
+        ) as isort_code:
+            isort_code.return_value = isorted_code
+            darker.__main__.main(["--isort", "./test1.py", *args])
+            return SimpleNamespace(
+                isort_code=isort_code,
+                caplog=caplog,
+                root=root,
+            )
 
 
 def test_isort_option_with_isort(run_isort):

--- a/src/darker/tests/test_main_isort.py
+++ b/src/darker/tests/test_main_isort.py
@@ -18,7 +18,7 @@ from darkgraylib.utils import TextDocument
 pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
 
 
-def test_isort_option_without_isort(git_repo):  # noqa: ARG001
+def test_isort_option_without_isort(git_repo):
     """Without isort, provide isort install instructions and error."""
     # The `git_repo` fixture ensures test is not run in the Darker repository clone in
     # CI builds. It helps avoid a NixOS test issue.

--- a/src/darker/tests/test_main_stdin_filename.py
+++ b/src/darker/tests/test_main_stdin_filename.py
@@ -1,8 +1,9 @@
 """Tests for `darker.__main__.main` and the ``--stdin-filename`` option"""
 
-# pylint: disable=too-many-arguments,use-dict-literal
+# pylint: disable=no-member,redefined-outer-name,too-many-arguments,use-dict-literal
 
 from io import BytesIO
+from types import SimpleNamespace
 from typing import List, Optional
 from unittest.mock import Mock, patch
 
@@ -16,6 +17,18 @@ from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
 from darkgraylib.testtools.helpers import raises_if_exception
 
 pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
+
+
+@pytest.fixture(scope="module")
+def main_stdin_filename_repo(request, tmp_path_factory):
+    """Git repository fixture for `test_main_stdin_filename`."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        yield SimpleNamespace(
+            root=repo.root,
+            paths=repo.add(
+                {"a.py": "original\n", "b.py": "original\n"}, commit="Initial commit"
+            ),
+        )
 
 
 @pytest.mark.kwparametrize(
@@ -136,7 +149,7 @@ pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
     expect_a_py="original\n",
 )
 def test_main_stdin_filename(
-    git_repo: GitRepoFixture,
+    main_stdin_filename_repo: SimpleNamespace,
     config_src: Optional[List[str]],
     src: List[str],
     stdin_filename: Optional[str],
@@ -145,14 +158,13 @@ def test_main_stdin_filename(
     expect_a_py: str,
 ) -> None:
     """Tests for `darker.__main__.main` and the ``--stdin-filename`` option"""
-    if config_src is not None:
-        configuration = {"tool": {"darker": {"src": config_src}}}
-        git_repo.add({"pyproject.toml": toml.dumps(configuration)})
-    paths = git_repo.add(
-        {"a.py": "original\n", "b.py": "original\n"}, commit="Initial commit"
+    repo = main_stdin_filename_repo
+    repo.paths["a.py"].write_text("modified  = 'a.py worktree'")
+    repo.paths["b.py"].write_text("modified  = 'b.py worktree'")
+    configuration = (
+        {} if config_src is None else {"tool": {"darker": {"src": config_src}}}
     )
-    paths["a.py"].write_text("modified  = 'a.py worktree'")
-    paths["b.py"].write_text("modified  = 'b.py worktree'")
+    (repo.root / "pyproject.toml").write_text(toml.dumps(configuration))
     arguments = src[:]
     if stdin_filename is not None:
         arguments.insert(0, f"--stdin-filename={stdin_filename}")
@@ -168,5 +180,5 @@ def test_main_stdin_filename(
         retval = darker.__main__.main(arguments)
 
         assert retval == expect
-        assert paths["a.py"].read_text() == expect_a_py
-        assert paths["b.py"].read_text() == "modified  = 'b.py worktree'"
+        assert repo.paths["a.py"].read_text() == expect_a_py
+        assert repo.paths["b.py"].read_text() == "modified  = 'b.py worktree'"


### PR DESCRIPTION
This is done by using the new module-scoped Git repository fixture from Darkgraylib.

- [x] Merge akaihola/darkgraylib#84
- [x] Release Darkgraylib 2.1.0
- [x] Bump required minimum version of Darkgraylib to 2.1.0

To get aggregate timings for parameterized tests:
```bash
pip install pytest-reportlog
pytest --report-log=pytest.log.json
python analyze_pytest_log.py
```
<details>
<summary>analyze_pytest_log.py</summary>

```python
import json
from collections import defaultdict


def aggregate_test_durations(log_contents):
    """Aggregate durations of parameterized tests from pytest-reportlog output.

    Args:
        log_contents (str): The contents of the pytest-reportlog file

    Returns:
        dict: A dictionary mapping test names to their total duration

    """
    # Dictionary to store total durations for each base test name
    test_durations = defaultdict(float)

    # Process each line
    for line in log_contents.strip().split("\n"):
        try:
            report = json.loads(line)

            # Extract the base test name by removing the parameter portion
            full_nodeid = report["nodeid"]
            base_name = full_nodeid.split("[")[0]

            # Add the duration to the total for this test
            test_durations[base_name] += report["duration"]

        except (json.JSONDecodeError, KeyError, IndexError) as e:
            print(f"Error processing line: {e} in {line}")
            continue

    return dict(test_durations)

def main():
    # Sample usage
    log_contents = open("pytest.log.json").read()

    results = aggregate_test_durations(log_contents)

    # Print results in a formatted way
    print("\nAggregated test durations:")
    print("-" * 50)
    by_duration = sorted(results.items(), key=lambda x: x[1], reverse=True)
    for test_name, duration in by_duration:
        print(f"{test_name:<40} {duration:.6f} seconds")

if __name__ == "__main__":
    main()
```
</details>