### PR TITLE
Fix handling of files with exotic newlines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,8 +33,9 @@ Removed
 Fixed
 -----
 - Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
-- Update to Darkgraylib 2.0.1 to fix the configuration dump, the output of ``--version``
-  and the Git "dubious ownership" issue (see below).
+- Update to Darkgraylib 2.2.0 to fix the configuration dump, the output of
+  ``--version``, the Git "dubious ownership" issue, and source code line splitting
+  (see below).
 - In the configuration dump printed when ``-vv`` verbosity is used, the configuration
   section is now correctly named ``[tool.darker]`` instead of ``[tool.darkgraylib]``.
 - Pass Graylint version to `~darkgraylib.command_line.make_argument_parser` to make
@@ -43,6 +44,7 @@ Fixed
 - Work around a `pathlib.Path.resolve` bug in Python 3.8 and 3.9 on Windows.
   The work-around should be removed when Python 3.8 and 3.9 are no longer supported.
 - Add missing configuration flag for Flynt_.
+- Only split source code lines at Python's universal newlines (LF, CRLF, CR).
 
 
 2.1.1_ - 2024-04-16

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -4,7 +4,7 @@
 # interpreter and Python ependencies. Keep this up-to-date with minimum
 # versions in `setup.cfg`.
 black==22.3.0
-darkgraylib==2.1.0
+darkgraylib==2.2.0
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ package_dir =
 packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
-    darkgraylib~=2.1.0
+    darkgraylib~=2.2.0
     toml>=0.10.0
     typing_extensions>=4.0.1
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync

--- a/src/darker/tests/test_main_drop_changes_on_unedited_lines.py
+++ b/src/darker/tests/test_main_drop_changes_on_unedited_lines.py
@@ -1,0 +1,65 @@
+"""Tests for `__main__._drop_changes_on_unedited_lines`"""
+
+# pylint: disable=use-dict-literal
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from darker.__main__ import _drop_changes_on_unedited_lines
+from darkgraylib.utils import TextDocument
+
+
+@pytest.mark.kwparametrize(
+    dict(
+        content=TextDocument("s =  'reformat'\n"),
+        new_chunks=[(1, ("s =  'reformat'",), ('s = "reformat"',))],
+    ),
+    dict(
+        content=TextDocument('s = "keep"\n'),
+        new_chunks=[(1, ('s = "keep"',), ('s = "keep"',))],
+    ),
+    dict(
+        content=TextDocument("""l1 = "first line"\nl2 =  'second line'\n"""),
+        new_chunks=[
+            (
+                1,
+                ('l1 = "first line"', "l2 =  'second line'"),
+                ('l1 = "first line"', 'l2 = "second line"'),
+            )
+        ],
+    ),
+    dict(
+        content=TextDocument(
+            "# coding: iso-8859-5\n# б\x85б\x86\n", encoding="iso-8859-5"
+        ),
+        new_chunks=[
+            (
+                1,
+                ("# coding: iso-8859-5", "# б\x85б\x86"),
+                ("# coding: iso-8859-5", "# б\x85б\x86"),
+            )
+        ],
+    ),
+)
+def test_unchanged_content(tmp_path, content, new_chunks):
+    """Test that no reformats make it through for unmodified files."""
+    # A mock object that always returns an empty list of changed lines
+    edited_linenums_differ = Mock()
+    edited_linenums_differ.revision_vs_lines = Mock(return_value=[])
+    # The expected result is the same as the input content, unmodified
+    expect = content
+
+    result = _drop_changes_on_unedited_lines(
+        new_chunks,
+        abspath_in_rev2=tmp_path / "file.py",
+        relpath_in_repo=Path("file.py"),
+        edited_linenums_differ=edited_linenums_differ,
+        rev2_content=content,
+        rev2_isorted=content,
+        has_isort_changes=False,
+        has_fstring_changes=False,
+    )
+
+    assert result == expect


### PR DESCRIPTION
Fixes #768

- [x] Rebase akaihola/darkgraylib#87 on `main`
- [x] Solve failing unit tests
- [x] Merge akaihola/darkgraylib#87
- [x] Release Darkgraylib 2.1.1
- [x] Update Darkgraylib dependency (in `setup.cfg` and `constraints-oldest.txt`)