### PR TITLE
Disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "black"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,6 @@ These features will be included in the next release:
 
 Added
 -----
-- Dependabot configuration for automatically opening prs for package version 
-  upgrades
 - New exit codes 2 for file not found, 3 for invalid command line arguments, 4 for
   missing dependencies and 123 for unknown failures.
 - Display exit code in parentheses after error message.


### PR DESCRIPTION
Fixes #788

Enforcing newest versions of Darker's dependencies may cause a problem for those users who like to install Darker in the same environment as the package they are reformatting. Their package may have an upper version limit for a dependency, e.g. to prevent an unintended update to an incompatible major version. If Darker then requires a minimum version newer than that limit, the installation of Darker will fail.

It's reasonable to keep Dependabot security updates (based on the [Github Advisory Database](https://github.com/advisories)) enabled, but for the above reasons, Dependabot version updates should in my opinion be disabled. We should support oldest possible non-vulnerable versions of our dependencies, and yet in a fresh environment users will still get the newest versions automatically installed.