### PR TITLE
Use packaging.version.Version in test-future.yml

### DIFF
--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -40,9 +40,9 @@ jobs:
           import json
           import os
           import urllib.request
-          from distutils.version import LooseVersion
-          from importlib.metadata import version
           from textwrap import dedent
+
+          from packaging.version import Version
 
           for linenum, line in enumerate(open("setup.cfg"), 1):
               constraint = line.strip()
@@ -57,7 +57,7 @@ jobs:
               'https://pypi.org/pypi/black/json'
           ).read().decode()
           latest_version = max(
-              LooseVersion(s)
+              Version(s)
               for s in json.loads(response)['releases'].keys()
           )
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,11 @@ Fixed
 - Only split source code lines at Python's universal newlines (LF, CRLF, CR).
 - The Darker GitHub action now respects the ``working-directory`` input option.
 
+Internal
+--------
+- Drop dependency on ``pip`` and ``distutils`` in the weekly CI "future" test. Use
+  ``packaging`` instead.
+
 
 2.1.1_ - 2024-04-16
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ test =
     flynt>=0.76
     isort>=5.0.1
     mypy>=0.990
+    packaging
     pathspec  # to test `gen_python_files` in `test_black_diff.py`
     pydocstyle
     pygments


### PR DESCRIPTION
Dropping use of `distutils` which wasn't explicitly required anyway, but came in through `pip`.