### PR TITLE
Use `re.Pattern` for type checking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Internal
 - Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
 - Drop dependency on ``pip`` and ``distutils`` in the weekly CI "future" test. Use
   ``packaging`` instead.
+- No need to use `typing.Pattern` instead of `re.Pattern` in Python 3.9+.
 
 
 2.1.1_ - 2024-04-16

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """Setuptools entry point for Darker"""
 
 import re
-from typing import Pattern
 
 from setuptools import setup
 
@@ -9,7 +8,7 @@ SIDEBAR_RE = re.compile(r"\+---.*:alt: Support", re.DOTALL)
 CONTRIBUTORS_RE = re.compile(r"""\nThanks goes .*\nThis project follows """, re.DOTALL)
 
 
-def replace(name: str, regex: Pattern[str], replacement: str, content: str) -> str:
+def replace(name: str, regex: re.Pattern[str], replacement: str, content: str) -> str:
     """Replace/remove a section from the package description, based on a regex
 
     Raise an exception if the regular expression doesn't match anything.

--- a/src/darker/files.py
+++ b/src/darker/files.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Collection, Iterable, Iterator, Pattern
+from typing import TYPE_CHECKING, Collection, Iterable, Iterator
 
 from darkgraylib.files import find_project_root
 
@@ -74,7 +74,7 @@ def _resolves_outside_root_or_cannot_stat(path: Path, root: Path) -> bool:
 
 def _path_is_excluded(
     normalized_path: str,
-    pattern: Pattern[str] | None,
+    pattern: re.Pattern[str] | None,
 ) -> bool:
     """Return whether the path is excluded by the pattern.
 
@@ -88,9 +88,9 @@ def _path_is_excluded(
 def _gen_python_files(
     paths: Iterable[Path],
     root: Path,
-    exclude: Pattern[str],
-    extend_exclude: Pattern[str] | None,
-    force_exclude: Pattern[str] | None,
+    exclude: re.Pattern[str],
+    extend_exclude: re.Pattern[str] | None,
+    force_exclude: re.Pattern[str] | None,
 ) -> Iterator[Path]:
     """Generate all files under ``path`` whose paths are not excluded.
 

--- a/src/darker/formatters/base_formatter.py
+++ b/src/darker/formatters/base_formatter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Pattern, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from darker.files import find_pyproject_toml
 from darker.formatters.formatter_config import FormatterConfig
@@ -10,6 +10,7 @@ from darker.formatters.formatter_config import FormatterConfig
 if TYPE_CHECKING:
     from argparse import Namespace
     from pathlib import Path
+    from re import Pattern
 
     from darkgraylib.utils import TextDocument
 

--- a/src/darker/formatters/black_formatter.py
+++ b/src/darker/formatters/black_formatter.py
@@ -52,7 +52,7 @@ from darkgraylib.utils import TextDocument
 if TYPE_CHECKING:
     from argparse import Namespace
     from pathlib import Path
-    from typing import Pattern
+    from re import Pattern
 
     from black import FileMode as Mode
     from black import TargetVersion

--- a/src/darker/formatters/formatter_config.py
+++ b/src/darker/formatters/formatter_config.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Pattern, TypedDict
+from typing import TYPE_CHECKING, Iterable, TypedDict
 
 from darkgraylib.config import ConfigurationError
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from re import Pattern
 
 
 class FormatterConfig(TypedDict):

--- a/src/darker/formatters/none_formatter.py
+++ b/src/darker/formatters/none_formatter.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Pattern
+from typing import TYPE_CHECKING
 
 from darker.formatters.base_formatter import BaseFormatter
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from pathlib import Path
+    from re import Pattern
 
     from darkgraylib.utils import TextDocument
 

--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -64,7 +64,7 @@ else:
 
 if TYPE_CHECKING:
     from argparse import Namespace
-    from typing import Pattern
+    from re import Pattern
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Possible since Python 3.9. Pylint started to complain about `typing.Pattern`.

**Note:** The `working-directory` [test failure](https://github.com/akaihola/darker/actions/runs/13079611210/job/36499907495?pr=813) can be ignored, it will be fixed in #812.