### PR TITLE
Fix python 3.12 deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ Internal
   ``packaging`` instead.
 - No need to use `typing.Pattern` instead of `re.Pattern` in Python 3.9+.
 - Always use newest artifact upload/download actions from the v4 series in the CI build.
+- Use `datetime.datetime.now()`, not ``.utcnow()`` to silence a deprecation warning.
 
 
 2.1.1_ - 2024-04-16

--- a/src/darker/__main__.py
+++ b/src/darker/__main__.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import warnings
 from argparse import Action, ArgumentError
-from datetime import datetime
+from datetime import datetime, timezone
 from difflib import unified_diff
 from pathlib import Path
 from typing import Collection, Generator, List, Optional, Tuple
@@ -363,7 +363,7 @@ def _drop_changes_on_unedited_lines(
             choose_lines(new_chunks, edited_linenums),
             encoding=rev2_content.encoding,
             newline=rev2_content.newline,
-            mtime=datetime.utcnow().strftime(GIT_DATEFORMAT),
+            mtime=datetime.now(timezone.utc).strftime(GIT_DATEFORMAT),
         )
 
         # 10. verify that the resulting reformatted source code parses to an identical


### PR DESCRIPTION
Python 3.12 emits deprecation warning when using darker

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
```