### PR TITLE
Use Python to invoke ruff instead of binary

### DIFF
--- a/src/darker/formatters/ruff_formatter.py
+++ b/src/darker/formatters/ruff_formatter.py
@@ -228,6 +228,8 @@ def _ruff_format_stdin(
 
     """
     cmdline = [
+        sys.executable,
+        "-m",
         "ruff",
         "format",
         "--force-exclude",  # apply `exclude =` from conffile even with stdin


### PR DESCRIPTION
When user installs `ruff` via `pip install --user`, `ruff` binary is usually not on system path.

Directly invoke `ruff` will cause error `No such file or directory: 'ruff'`, ask Python to invoke the python one is an safer approach.